### PR TITLE
docs: P0 lens-screens 2026-06-20 — both levers NO-BUILD

### DIFF
--- a/dev/backtest/p0-screens-2026-06-20/sleeve-010.sexp
+++ b/dev/backtest/p0-screens-2026-06-20/sleeve-010.sexp
@@ -1,0 +1,23 @@
+;; P0a reserved-short-sleeve SCREEN (fraction=0.10) — deep 1998-2026, long-short,
+;; otherwise identical to cell-e-top3000-1998-longshort.sexp. Read-only. Adds
+;; ((short_sleeve_fraction 0.10)). Baseline = the long-short deep run
+;; scenarios-2026-06-19-065941 (sleeve=0.0, shorts crowded out).
+((name "cell-e-1998-sleeve010")
+ (description "Cell-E top-3000 PIT-1998 long-short, reserved short sleeve 0.10, screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side true))
+   ((short_min_price 17.0))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((margin_config ((enabled true))))
+   ((short_sleeve_fraction 0.10))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/backtest/p0-screens-2026-06-20/sleeve-020.sexp
+++ b/dev/backtest/p0-screens-2026-06-20/sleeve-020.sexp
@@ -1,0 +1,23 @@
+;; P0a reserved-short-sleeve SCREEN (fraction=0.10) — deep 1998-2026, long-short,
+;; otherwise identical to cell-e-top3000-1998-longshort.sexp. Read-only. Adds
+;; ((short_sleeve_fraction 0.20)). Baseline = the long-short deep run
+;; scenarios-2026-06-19-065941 (sleeve=0.0, shorts crowded out).
+((name "cell-e-1998-sleeve020")
+ (description "Cell-E top-3000 PIT-1998 long-short, reserved short sleeve 0.20, screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side true))
+   ((short_min_price 17.0))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((margin_config ((enabled true))))
+   ((short_sleeve_fraction 0.20))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/backtest/p0-screens-2026-06-20/sleeve-030.sexp
+++ b/dev/backtest/p0-screens-2026-06-20/sleeve-030.sexp
@@ -1,0 +1,23 @@
+;; P0a reserved-short-sleeve SCREEN (fraction=0.10) — deep 1998-2026, long-short,
+;; otherwise identical to cell-e-top3000-1998-longshort.sexp. Read-only. Adds
+;; ((short_sleeve_fraction 0.30)). Baseline = the long-short deep run
+;; scenarios-2026-06-19-065941 (sleeve=0.0, shorts crowded out).
+((name "cell-e-1998-sleeve030")
+ (description "Cell-E top-3000 PIT-1998 long-short, reserved short sleeve 0.30, screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side true))
+   ((short_min_price 17.0))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((margin_config ((enabled true))))
+   ((short_sleeve_fraction 0.30))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/backtest/p0-screens-2026-06-20/volstop-mult10.sexp
+++ b/dev/backtest/p0-screens-2026-06-20/volstop-mult10.sexp
@@ -1,0 +1,21 @@
+;; P0b vol-scaled-stop SCREEN (mult=1.0) — deep 1998-2026, long-only, otherwise
+;; identical to cell-e-top3000-1998-deep.sexp. Read-only. Adds
+;; ((stops_config ((vol_scaled_stop_atr_mult 1.0)))). Baseline = the long-only
+;; deep run scenarios-2026-06-18-232354 (mult=0, vol-stop off).
+((name "cell-e-1998-volstop-mult10")
+ (description "Cell-E top-3000 PIT-1998 deep, vol-scaled stop ATR-mult 1.0, screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stops_config ((vol_scaled_stop_atr_mult 1.0))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/backtest/p0-screens-2026-06-20/volstop-mult15.sexp
+++ b/dev/backtest/p0-screens-2026-06-20/volstop-mult15.sexp
@@ -1,0 +1,21 @@
+;; P0b vol-scaled-stop SCREEN (mult=1.0) — deep 1998-2026, long-only, otherwise
+;; identical to cell-e-top3000-1998-deep.sexp. Read-only. Adds
+;; ((stops_config ((vol_scaled_stop_atr_mult 1.5)))). Baseline = the long-only
+;; deep run scenarios-2026-06-18-232354 (mult=0, vol-stop off).
+((name "cell-e-1998-volstop-mult15")
+ (description "Cell-E top-3000 PIT-1998 deep, vol-scaled stop ATR-mult 1.5, screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stops_config ((vol_scaled_stop_atr_mult 1.5))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/backtest/p0-screens-2026-06-20/volstop-mult20.sexp
+++ b/dev/backtest/p0-screens-2026-06-20/volstop-mult20.sexp
@@ -1,0 +1,21 @@
+;; P0b vol-scaled-stop SCREEN (mult=1.0) — deep 1998-2026, long-only, otherwise
+;; identical to cell-e-top3000-1998-deep.sexp. Read-only. Adds
+;; ((stops_config ((vol_scaled_stop_atr_mult 2.0)))). Baseline = the long-only
+;; deep run scenarios-2026-06-18-232354 (mult=0, vol-stop off).
+((name "cell-e-1998-volstop-mult20")
+ (description "Cell-E top-3000 PIT-1998 deep, vol-scaled stop ATR-mult 2.0, screen.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stops_config ((vol_scaled_stop_atr_mult 2.0))))))
+ (cost_model ((per_trade_commission 0.0)(per_share_commission 0.01)(bid_ask_spread_bps 0.0)(market_impact_bps_per_pct_adv 0.0)))
+ (expected ((total_return_pct ((min -100.0)(max 1000000.0)))(total_trades ((min 0)(max 1000000)))(win_rate ((min 0.0)(max 100.0)))(sharpe_ratio ((min -100.0)(max 100.0)))(max_drawdown_pct ((min 0.0)(max 100.0)))(avg_holding_days ((min 0.0)(max 100000.0))))))

--- a/dev/experiments/p0-screens-2026-06-20/FINDINGS.md
+++ b/dev/experiments/p0-screens-2026-06-20/FINDINGS.md
@@ -1,0 +1,173 @@
+# P0 lens-screens — FINDINGS (in progress)
+
+Deep 1998-2026 top-3000 PIT-1998 Cell-E. Grade horizon 26w. See `PLAN.md`.
+Batch run output: `dev/backtest/scenarios-2026-06-20-062510/`.
+**Status: COMPLETE. Both levers → NO-BUILD (keep default-off as axes).**
+
+## Baselines (graded; reused from prior sessions)
+
+### P0b vol-scaled-stop baseline (mult=0, OFF) — long-only deep `scenarios-2026-06-18-232354`
+Top-level: return **+1934.5%** · CAGR 11.22 · Sharpe **0.61** · MaxDD **48.65** ·
+Calmar 0.23 · Ulcer 15.82 · 1061 round-trips · win 33.0% · final PV $20.3M.
+`stop_loss` insurance (n=746): upside-foregone **+29.9%** vs disaster-dodged
+**−19.5%** → net value-add **−6.2%**, dodge-rate 36%. *This asymmetry (forgoes
+1.5× more than it saves) is the whipsaw the vol-scaled stop must shrink.*
+
+### P0a short-sleeve baseline (fraction=0, OFF) — long-short deep `scenarios-2026-06-19-065941`
+(short_side ON, margin ON, short_min_price 17 — only `short_sleeve_fraction`
+differs in variants.) Top-level: return **+1662.9%** · CAGR 10.66 · Sharpe
+**0.57** · MaxDD **36.87** · Calmar **0.29** · Ulcer 14.42 · 1164 round-trips ·
+win 32.3% · final PV $17.6M.
+*Note: the unfunded short leg (37 shorts reached / 28y) already trades return
+(1934→1663) + Sharpe (0.61→0.57) for MaxDD (48.65→36.87) + Calmar (0.23→0.29) vs
+long-only. P0a question: does FUNDING the sleeve extend that DD-offset, or churn?*
+
+## P0b — vol-scaled stop variants (vs volstop-OFF baseline)
+
+| mult | return% | CAGR | Sharpe | MaxDD | Calmar | Ulcer | n stops | stop upside-foregone | stop disaster-dodged | stop net-VA |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 0 (base) | 1934.5 | 11.22 | 0.61 | 48.65 | 0.23 | 15.82 | 746 | +29.9% | −19.5% | −6.2% |
+| 1.0 | **820.4** | 8.15 | 0.47 | 40.60 | 0.20 | **22.24** | 643 | +268%* | −19.9% | −16.2% |
+| 1.5 | **1206.2** | 9.50 | 0.56 | 32.25 | **0.29** | **13.57** | 527 | +183%* | −20.5% | −7.6% |
+| 2.0 | **241.6** | 4.43 | 0.34 | 35.92 | 0.12 | 16.60 | 465 | +218%* | −19.2% | _ |
+
+### P0b VERDICT — NO-BUILD (keep default-off as axis)
+
+Every mult **reduces return** vs baseline (1934 → 820 / 1206 / 242) and **lowers
+Sharpe** (0.61 → 0.47 / 0.56 / 0.34); the outcome is **non-monotonic** (1.0 bad,
+1.5 best-ish, 2.0 catastrophic) = path-dependent, not a stable response surface.
+The widening floor *does* fire fewer stops monotonically (746→643→527→465) — the
+mechanic works — but it does **not** fix the whipsaw the screen targeted:
+
+1. **Per-decision stop quality got WORSE, not better.** The lens's core question
+   was "does upside-foregone shrink while disaster-dodged holds?" Answer: NO.
+   stop_loss net value-add **worsened** (−6.2% → −7.6% at mult=1.5); disaster-
+   dodged barely moved (−19.5→−20.5); upside-foregone means are outlier-blown
+   (+183/+218%, but p90 cont +44/+41.6 ≈ baseline +41.4 — body unchanged). Same
+   asymmetry the weekly-close #1655 lever also failed to fix.
+2. **mult=1.5's DD "win" is just less risk-taking, not a free lunch.** Calmar
+   0.29 / Ulcer 13.6 / MaxDD 32.3 all beat baseline — but bought with **−38% of
+   total return** and a **lower Sharpe**. On the scale-free risk-adjusted measure
+   it is worse; the smoother equity is the mechanical result of holding fewer
+   stops and taking less risk, obtainable more cleanly via exposure/sizing.
+3. **Same fat-tail tax** (`project_edge_is_the_fat_tail`): a wider stop holds
+   losers deeper (mult=1.0 Ulcer ↑ to 22.2) and perturbs winner capture; the
+   strategy's edge is the let-winners-run tail, and a structural stop-widening
+   knob taxes it. Non-monotonicity is the signature.
+
+**Decision:** no-build (do not escalate to WF-CV). Keep `vol_scaled_stop_atr_mult`
+default-off as an axis. The stop-whipsaw problem is real but neither weekly-close
+(#1655) nor vol-scaling fixes the per-decision asymmetry — the foregone upside is
+the fat-tail recovery itself, so any stop that fires less still gives it up when
+it does fire. The honest read: **the strategy's stop cost is structural, not a
+tuning miss.**
+
+\* outlier-blown means (see mult=1.0 note); read distribution body (p90), not mean.
+
+\* mean upside-foregone +268% is **outlier-blown** (a few post-exit moonshots);
+the distribution body is ~unchanged (p90 cont +41.3 vs baseline +41.4) — read it
+as not-robust, not a 9× real shift (`screen-rigor`: distribution not point-est).
+
+**mult=1.0 read (clearly worse):** return **halved** (1934→820), Sharpe ↓
+(0.61→0.47), Calmar ↓ (0.23→0.20), **Ulcer ↑** (15.8→22.2 = more time
+underwater). n_stops dropped 746→643 (the wider ATR floor does fire less, as
+designed) — but the wider stop **holds losers deeper** (Ulcer up) *and* disrupts
+fat-tail winner capture (return halved). MaxDD nominally lower (48.65→40.60) but
+that single-trough number is contradicted by the Ulcer/return collapse. Net: the
+wider stop taxes the engine, exactly the `project_edge_is_the_fat_tail` failure
+mode for a holding-discipline lever that loosens too far.
+
+**Read:** does upside-foregone shrink while disaster-dodged ~holds, n_stops drop
+(fewer whipsaws), and MaxDD/Calmar/Ulcer improve — distribution-robustly?
+
+## P0a — short-sleeve variants (vs sleeve-OFF baseline)
+
+| sleeve | return% | CAGR | Sharpe | MaxDD | Calmar | Ulcer | n short trades | short win% | short net PnL$ |
+|---|---|---|---|---|---|---|---|---|---|
+| 0 (base) | 1662.9 | 10.66 | 0.57 | 36.87 | 0.29 | 14.42 | 37 | _ | _ |
+| 0.10 | **1477.9** | 10.23 | 0.55 | **38.79** | 0.26 | 15.47 | 36 | 30.6% | **−$676k** |
+| 0.20 | **2018.9** | 11.38 | 0.63 | **31.05** | **0.37** | 12.41 | 37 | 21.6% | **−$424k** |
+| 0.30 | **375.2** | 5.66 | 0.37 | 36.98 | 0.15 | 15.34 | 44 | 25.0% | **−$481k** |
+
+### P0a VERDICT — NO-BUILD (keep default-off as axis)
+
+The sleeve sweep is **wildly non-monotonic** — return 1663 (base) → 1478 (0.10) →
+2019 (0.20) → **375 (0.30)** — with shorts **losing at every fraction**
+(−$424k…−$676k, 21–31% win) and **never meaningfully unlocked** (36/37/37/44 vs
+37 baseline). Three transferable conclusions:
+
+1. **The crowd-out-by-cash diagnosis is wrong.** Funding a reserved short budget
+   does not increase shorts reached. Shorts are gated by *candidate supply*
+   (Stage-4 short signals + the `short_min_price 17` floor), not cash. The
+   `project_short_funnel_crowded_out` "1662 offered / 37 entered" read mistook a
+   supply ceiling for a cash ceiling.
+2. **There is no offsetting leg to fund.** The short trades lose money in every
+   cell, so reserving capital for them is pure drag — the (c) symptom, confirmed.
+3. **Reserved cash taxes the fat-tail long engine.** The non-monotonicity is
+   path-dependent perturbation of which/when longs are bought; at 0.30 the
+   reservation starves the let-winners-run engine and return **craters to 375%**.
+   This is `project_edge_is_the_fat_tail` again: a capital-reservation mechanism
+   that pulls capital off the tail-generating longs taxes the tail. The 0.20
+   "win" is a lucky path, not a robust edge.
+
+**Decision:** no-build (do not escalate to WF-CV). Keep `short_sleeve_fraction`
+default-off as an axis. The real short-side lever, if any, is *supply* (loosen
+`short_min_price` / Stage-4 short admission), not cash budgeting — and even that
+must first show shorts can be made *profitable*, which this screen says they are
+not in the current config.
+
+**sleeve=0.20 read (better top-level, but NOT from shorts):** return 2019,
+Sharpe 0.63, MaxDD 31.1, Calmar 0.37 — beats both the sleeve-OFF baseline AND
+long-only. BUT shorts **still lose** (37 shorts, 21.6% win, −$424k) and **still
+only 37 reached** (sleeve does not unlock more shorts at any fraction tested).
+So the improvement is **not** the short leg paying off — it's a cash-drag
+side-effect: reserving 20% cash reshuffles which/when longs get bought in a
+fat-tailed book. **Non-monotonic** vs 0.10 (worse) → path-dependent artifact, not
+a robust edge (`screen-rigor`: distribution/robustness, not one path). The
+mechanism's stated thesis (shorts add an offsetting leg) is contradicted at every
+fraction.
+
+**sleeve=0.10 read (worse on every axis):** return ↓ (1663→1478), Sharpe ↓
+(0.57→0.55), MaxDD ↑ (36.9→38.8, *worse* DD), Calmar ↓ (0.29→0.26), Ulcer ↑.
+Critically: **shorts reached did NOT increase** (36 vs 37) — funding the
+reserved sleeve did not unlock more shorts, so the diagnosed "crowd-out by cash"
+(`project_short_funnel_crowded_out`) is **contradicted**: shorts are gated by
+candidate *supply* (Stage-4 short signals / short_min_price 17 filter), not cash
+budget. The shorts that do trade **lose** (−$676k net, 30.6% win) → reserved
+capital is pure drag with no offsetting payoff = the (c) symptom. Pending 0.20/0.30
+to confirm the knob doesn't rescue it.
+
+**Read:** with more shorts reached, does MaxDD drop further / Calmar rise (real
+offset), or do shorts churn ~breakeven (reserved capital = drag → return falls
+with no DD payoff)?
+
+## Combined verdict — both P0 levers NO-BUILD
+
+Neither lever earns a WF-CV surface. Both are **no-build decisions** (per
+`screen-rigor`: a lens screen rejects *prioritization*, not the mechanism — both
+stay default-off as axes; only WF-CV could "reject" them, and neither warrants
+that spend given the screen).
+
+**The shared why — both re-derive `project_edge_is_the_fat_tail`:**
+- **Short sleeve** reserves capital *away from* the tail-generating long book for
+  a short leg that loses at every fraction and is supply-gated (never unlocked).
+  Capital pulled off the tail = tax on the tail (return craters at 0.30).
+- **Vol-scaled stop** widens the stop floor, which holds losers deeper and
+  perturbs winner capture; it reduces return at every setting and doesn't fix the
+  per-decision whipsaw — because the foregone upside *is* the fat-tail recovery.
+
+Both are **winner/loser-touching mechanisms** — the class
+`edge_is_the_fat_tail` says keeps getting rejected. This is the 7th/8th
+re-derivation. **Forward guidance:** stop screening capital-reservation and
+stop-widening levers; the live class remains **diversification LAYERS that don't
+touch the long tail** — the P1 barbell (SPY-timing floor + Cell-E engine NAV
+blend, `project_barbell_on_stocks`) is the next lever, taken to a promotion grid.
+
+**Two corrections to standing beliefs, recorded:**
+1. `project_short_funnel_crowded_out` mis-diagnosed a *supply* ceiling as a
+   *cash* ceiling. Shorts are gated by Stage-4 signal supply + `short_min_price`,
+   not budget — funding a reserved sleeve does not unlock more shorts.
+2. The stop-whipsaw cost (`project_weekly_close_stop_lever`) is **structural, not
+   a tuning miss** — two faithful stop dials (weekly-close, vol-scaled) both fail
+   to improve the per-decision asymmetry. The foregone upside is the recovery
+   itself.

--- a/dev/experiments/p0-screens-2026-06-20/PLAN.md
+++ b/dev/experiments/p0-screens-2026-06-20/PLAN.md
@@ -1,0 +1,67 @@
+# P0 lens-screens — reserved short sleeve (#1659) + vol-scaled stop (#1662)
+
+**Date:** 2026-06-20. **Origin:** `next-session-priorities-2026-06-20.md` P0.
+Both levers landed default-off 2026-06-19; this is the cheap read-only
+lens-screen that decides whether either earns a WF-CV surface + grid.
+
+**Verdict calibration (`mechanism-validation-rigor` / `screen-rigor`):** a lens
+screen rejects *prioritization*, not the mechanism. Legitimate outputs:
+"promising → escalate to WF-CV" or "no-build decision (+ why)". NOT "proven" /
+"decisively rejected".
+
+## Window
+
+Deep **1998-2026** top-3000 PIT-1998 (Cell-E), the only window spanning a
+bear-dominated macro regime (dot-com bust + GFC) — where both stops (disaster to
+dodge) and shorts (Stage-4 leg pays) actually bite. Bull-only 2011 would
+under-test both. Grid (if escalated) adds the period × universe cells later.
+
+## P0b — vol-scaled stop (`stops_config.vol_scaled_stop_atr_mult`)
+
+Long-only deep. Floor on installed-stop distance becomes
+`max(installed_stop_min_pct, mult * ATR/entry)` → volatile names get a wider
+stop floor (whipsaw reduction at source).
+
+- **Baseline (mult=0, off):** `scenarios-2026-06-18-232354/cell-e-top3000-1998-deep`
+  (reuse; 1062 trades, wall 4208s).
+- **Variants:** mult ∈ {1.0, 1.5, 2.0} — `p0-screens-2026-06-20/volstop-mult{10,15,20}.sexp`.
+
+**Question (the asymmetry weekly-close #1655 failed):** does the `stop_loss`
+exit row's **forgone-upside shrink while disaster-dodged holds**, net
+value-add improve? Plus top-level return / Sharpe / MaxDD vs baseline.
+Grade horizon 26w (matches the deep stop read `grade-deep-26w.md`).
+
+## P0a — reserved short sleeve (`short_sleeve_fraction`)
+
+Long-short deep (margin on, short_min_price 17). Reserves `fraction * PV` as a
+short-only cash budget so shorts are *reached* (diagnosed crowd-out:
+1,662 slots offered / 37 entered / 0 rejected over 28y).
+
+- **Baseline (sleeve=0):** `scenarios-2026-06-19-065941/cell-e-top3000-1998-longshort`
+  (reuse; 1165 trades, wall 4389s).
+- **Variants:** fraction ∈ {0.10, 0.20, 0.30} — `p0-screens-2026-06-20/sleeve-0{10,20,30}.sexp`.
+
+**Question:** with the sleeve funded, do the now-numerous shorts add a **real
+offsetting / DD-reducing leg**, or churn at ~breakeven (capital reserved for a
+leg that doesn't pay = drag)? Measure: (a) short-trade count + win-rate + net
+PnL contribution, (b) top-level return / Sharpe / **MaxDD** vs sleeve=0 baseline
+(the offset shows up as DD reduction), (c) lens grade of the short round-trips.
+
+## Mechanics
+
+- Batch run: `scenario_runner --dir dev/backtest/p0-screens-2026-06-20
+  --snapshot-dir /tmp/snap_top3000_1998_2026_v2 --fixtures-root / --parallel 1`
+  → output `dev/backtest/scenarios-2026-06-20-062510/<name>/`.
+- Grade each: `decision_grading_bin --scenario-dir <out>/<name>
+  --snapshot-dir /tmp/snap_top3000_1998_2026_v2 --grade-horizon 26
+  --out <name>-grade.md`.
+- Top-level metrics from each `<name>/summary.sexp`.
+
+## Decision rule (per lever)
+
+- Lens shows genuine asymmetry/offset improvement that's distribution-robust
+  (not one-trade) → **escalate to WF-CV** as a `Variant_matrix` axis.
+- ~Breakeven / coin-flip / one-trade artifact → **no-build decision**, record the
+  *why*, keep default-off as an axis (`experiment-flag-discipline`).
+
+## Results — FILLED AFTER RUNS (see FINDINGS.md)

--- a/dev/experiments/p0-screens-2026-06-20/baseline-sleeve-OFF-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/baseline-sleeve-OFF-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-top3000-1998-longshort
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 1164 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 312 | +16.2% | +5.2% | 38% | 22% | -5.2% | -1.03 |
+| stage3_force_exit | 19 | -1.1% | -3.7% | 21% | 32% | +3.7% | -1.33 |
+| stop_loss | 828 | -1.2% | +13.1% | 35% | 32% | -13.1% | -2.78 |
+| unlabeled | 5 | +45.4% | +2.2% | 40% | 20% | -2.2% | 0.49 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 312 | -15.7% | +20.8% | -22.9% | +28.8% | 27% |
+| stage3_force_exit | 19 | -22.7% | +19.0% | -17.6% | +11.3% | 53% |
+| stop_loss | 828 | -20.0% | +38.4% | -30.7% | +42.2% | 38% |
+| unlabeled | 5 | -16.1% | +23.0% | -17.3% | +22.5% | 20% |

--- a/dev/experiments/p0-screens-2026-06-20/baseline-volstop-OFF-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/baseline-volstop-OFF-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-top3000-1998-deep
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 1061 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 296 | +16.9% | +4.7% | 36% | 27% | -4.7% | -0.68 |
+| stage3_force_exit | 16 | +0.1% | -2.2% | 12% | 19% | +2.2% | -4.48 |
+| stop_loss | 746 | -1.2% | +6.2% | 36% | 30% | -6.2% | -3.64 |
+| unlabeled | 3 | -3.9% | +5.0% | 33% | 33% | -5.0% | -15.87 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 296 | -15.9% | +21.6% | -26.9% | +36.0% | 29% |
+| stage3_force_exit | 16 | -22.0% | +14.0% | -15.0% | +11.3% | 38% |
+| stop_loss | 746 | -19.5% | +29.9% | -29.5% | +41.4% | 36% |
+| unlabeled | 3 | -11.2% | +19.7% | -14.0% | +28.2% | 0% |

--- a/dev/experiments/p0-screens-2026-06-20/sleeve010-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/sleeve010-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-1998-sleeve010
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 1112 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 319 | +16.5% | +11.7% | 36% | 21% | -11.7% | -0.60 |
+| stage3_force_exit | 18 | +4.0% | +0.2% | 17% | 22% | -0.2% | -4.48 |
+| stop_loss | 773 | -1.2% | +8.5% | 36% | 31% | -8.5% | -2.52 |
+| unlabeled | 2 | +8.8% | -17.5% | 0% | 100% | +17.5% | 0.58 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 319 | -15.1% | +27.9% | -22.8% | +32.4% | 27% |
+| stage3_force_exit | 18 | -19.9% | +19.4% | -15.0% | +13.8% | 44% |
+| stop_loss | 773 | -19.7% | +34.8% | -30.5% | +43.1% | 38% |
+| unlabeled | 2 | -28.6% | +3.5% | -21.1% | -13.9% | 100% |

--- a/dev/experiments/p0-screens-2026-06-20/sleeve020-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/sleeve020-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-1998-sleeve020
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 1053 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 295 | +15.5% | +4.1% | 35% | 24% | -4.1% | -0.31 |
+| stage3_force_exit | 17 | +1.6% | +33.0% | 24% | 24% | -33.0% | -1.31 |
+| stop_loss | 739 | -1.1% | +6.9% | 34% | 32% | -6.9% | -2.68 |
+| unlabeled | 2 | +26.3% | -13.8% | 50% | 50% | +13.8% | 0.54 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 295 | -16.7% | +20.6% | -23.8% | +33.3% | 31% |
+| stage3_force_exit | 17 | -21.2% | +285.7% | -15.0% | +35.9% | 59% |
+| stop_loss | 739 | -19.6% | +33.6% | -29.4% | +40.2% | 37% |
+| unlabeled | 2 | -32.6% | +13.6% | -42.6% | +15.1% | 50% |

--- a/dev/experiments/p0-screens-2026-06-20/sleeve030-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/sleeve030-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-1998-sleeve030
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 904 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 240 | +17.8% | +4.6% | 36% | 21% | -4.6% | -0.73 |
+| stage3_force_exit | 10 | -1.0% | -4.3% | 20% | 40% | +4.3% | -0.93 |
+| stop_loss | 652 | -1.9% | +15.8% | 36% | 31% | -15.8% | -2.17 |
+| unlabeled | 2 | -6.6% | -0.2% | 50% | 50% | +0.2% | -3.34 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 240 | -16.1% | +20.1% | -22.0% | +29.4% | 28% |
+| stage3_force_exit | 10 | -20.2% | +18.7% | -17.6% | +13.8% | 50% |
+| stop_loss | 652 | -20.4% | +43.5% | -30.3% | +41.3% | 38% |
+| unlabeled | 2 | -16.8% | +16.3% | -21.1% | +20.6% | 50% |

--- a/dev/experiments/p0-screens-2026-06-20/volstop-mult10-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/volstop-mult10-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-1998-volstop-mult10
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 951 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 289 | +19.3% | +6.4% | 40% | 23% | -6.4% | -0.63 |
+| stage3_force_exit | 13 | -1.5% | +42.9% | 31% | 23% | -42.9% | -4.29 |
+| stop_loss | 643 | -2.7% | +16.2% | 37% | 32% | -16.2% | -2.57 |
+| unlabeled | 6 | -0.6% | +3.7% | 17% | 0% | -3.7% | -0.17 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 289 | -15.9% | +23.2% | -24.4% | +35.0% | 25% |
+| stage3_force_exit | 13 | -26.1% | +363.1% | -15.3% | +34.1% | 62% |
+| stop_loss | 643 | -19.9% | +268.3% | -29.4% | +41.3% | 37% |
+| unlabeled | 6 | -13.0% | +14.7% | -3.7% | +28.2% | 17% |

--- a/dev/experiments/p0-screens-2026-06-20/volstop-mult15-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/volstop-mult15-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-1998-volstop-mult15
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 813 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 269 | +16.8% | +4.1% | 36% | 24% | -4.1% | -3.27 |
+| stage3_force_exit | 13 | -1.8% | +3.1% | 38% | 23% | -3.1% | -1.58 |
+| stop_loss | 527 | -2.5% | +7.6% | 37% | 31% | -7.6% | -2.94 |
+| unlabeled | 4 | -6.0% | +20.7% | 50% | 50% | -20.7% | -0.83 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 269 | -15.6% | +21.3% | -22.5% | +30.5% | 25% |
+| stage3_force_exit | 13 | -19.4% | +19.6% | -14.4% | +22.0% | 38% |
+| stop_loss | 527 | -20.5% | +183.2% | -30.4% | +44.0% | 39% |
+| unlabeled | 4 | -18.5% | +41.9% | -29.6% | +97.7% | 25% |

--- a/dev/experiments/p0-screens-2026-06-20/volstop-mult20-grade.md
+++ b/dev/experiments/p0-screens-2026-06-20/volstop-mult20-grade.md
@@ -1,0 +1,23 @@
+# Decision-grading report — cell-e-1998-volstop-mult20
+
+Period: 1998-01-01 .. 2026-04-30 | round-trips graded: 735 | grade horizon: 26w
+
+Net value-add = realized − counterfactual-if-held (positive = the exits helped). % premature = gave up a winner; % good exit = dodged a drop.
+
+### Exit value vs hold-counterfactual
+
+| exit_reason | n | mean realized | mean post-exit cont. | % premature | % good exit | mean net value-add | mean capture |
+|---|---|---|---|---|---|---|---|
+| laggard_rotation | 246 | +14.5% | +227.2% | 39% | 22% | -227.2% | -1.97 |
+| stage3_force_exit | 19 | -2.5% | +0.1% | 37% | 21% | -0.1% | -1.97 |
+| stop_loss | 465 | -3.8% | +23.1% | 38% | 26% | -23.1% | -2.38 |
+| unlabeled | 5 | -7.7% | -17.8% | 20% | 80% | +17.8% | -2.52 |
+
+### Disaster-avoidance vs upside-foregone (the insurance decomposition)
+
+| exit_reason | n | mean disaster dodged | mean upside foregone | cont p10 | cont p90 | disaster-dodge rate |
+|---|---|---|---|---|---|---|
+| laggard_rotation | 246 | -14.8% | +242.6% | -21.1% | +36.0% | 27% |
+| stage3_force_exit | 19 | -22.1% | +25.1% | -35.0% | +22.0% | 37% |
+| stop_loss | 465 | -19.2% | +218.4% | -27.9% | +41.6% | 34% |
+| unlabeled | 5 | -32.6% | +19.6% | -38.7% | +10.9% | 100% |

--- a/dev/notes/next-session-priorities-2026-06-21.md
+++ b/dev/notes/next-session-priorities-2026-06-21.md
@@ -1,0 +1,66 @@
+# Next-session priorities — 2026-06-21
+
+**Supersedes** `next-session-priorities-2026-06-20.md`. Check main CI green first
+(`.claude/rules/session-rampup.md`). The 2026-06-20 session lens-screened the two
+P0 levers landed 06-19; **both are NO-BUILD** (kept default-off as axes).
+
+## What happened 2026-06-20 — both P0 screens → NO-BUILD
+
+Deep 1998-2026 top-3000 Cell-E, decision-grading lens @26w. Full record:
+`dev/experiments/p0-screens-2026-06-20/FINDINGS.md` (+ PLAN.md, per-variant
+grade md, batch output `dev/backtest/scenarios-2026-06-20-062510/`).
+
+### P0a — reserved short sleeve (`short_sleeve_fraction`) → NO-BUILD
+Sweep {0.10, 0.20, 0.30} vs sleeve-OFF long-short baseline (return1663/Sharpe0.57/
+MaxDD36.9/Calmar0.29). Results **wildly non-monotonic**: return 1663→1478→2019→
+**375**; shorts **lose at every fraction** (−$424k…−$676k, 21–31% win) and are
+**never unlocked** (36/37/37/44 ≈ 37 baseline). Three transferable findings:
+1. **Crowd-out-by-cash diagnosis WRONG** — shorts are *supply*-gated (Stage-4
+   signal count + `short_min_price 17`), not cash-gated. Funding a reserved
+   budget doesn't reach more shorts.
+2. **No offsetting leg to fund** — shorts lose in every cell; reserved capital is
+   pure drag.
+3. **Reserved cash taxes the fat-tail long engine** (0.30 craters return to 375%)
+   — `project_edge_is_the_fat_tail` again. The 0.20 "win" is a lucky path.
+
+### P0b — vol-scaled stop (`vol_scaled_stop_atr_mult`) → NO-BUILD
+Sweep {1.0, 1.5, 2.0} vs volstop-OFF long-only baseline (return1934/Sharpe0.61/
+MaxDD48.7/Calmar0.23/Ulcer15.8). Every mult **reduces return** (1934→820/1206/242)
+and **lowers Sharpe** (0.61→0.47/0.56/0.34); non-monotonic = path-dependent. The
+floor fires fewer stops monotonically (746→643→527→465) — mechanic works — but:
+1. **Per-decision stop quality got WORSE** — stop net-VA −6.2%→−7.6%; the lens's
+   core question (does upside-foregone shrink while disaster-dodged holds?) = NO.
+2. **mult=1.5's DD "win"** (Calmar0.29/Ulcer13.6/MaxDD32.3) is **just less
+   risk-taking** — bought with −38% return + lower Sharpe; obtainable cleaner via
+   exposure/sizing.
+3. The stop cost is **structural, not a tuning miss** — both weekly-close (#1655)
+   and vol-scaled stop fail the per-decision asymmetry; the foregone upside *is*
+   the fat-tail recovery.
+
+## P0 NEXT — P1 barbell promotion grid (now the live lever)
+With both stop/short levers ruled out, the next lever is the diversification
+LAYER that does NOT touch the long tail: **barbell** (SPY-timing floor + Cell-E
+engine NAV blend, `project_barbell_on_stocks` — beat both legs on Calmar in deep
++ bull, never taken to a grid). Take to WF-CV + `promotion-confirmation.md` grid
+(≥3 period×universe cells incl. a bear-dominated macro regime). This is the
+correct class per the guardrail below.
+
+## Guardrail (HARDENED by today's two no-builds)
+Do NOT screen **winner/loser-touching** levers — the `edge_is_the_fat_tail`
+class now has ~8 rejections (laggard, force-exit, stage2-ma-hold, late-flag,
+macro-trim, harvest-rotate, **short-sleeve**, **vol-scaled-stop**). Capital-
+reservation and stop-widening both tax the tail. The live class is **structural
+diversification layers** (barbell, regime-gating overlays, offsetting legs that
+actually pay) — NOT entry/cascade/swap/short-pick selection (dead 5×) and NOT
+stop/sizing knobs that just trade return for smoothness.
+
+## Standing-belief corrections to propagate
+- `project_short_funnel_crowded_out`: supply-gated, not cash-gated (see above).
+- `project_weekly_close_stop_lever` / stop whipsaw: structural cost, not tunable.
+
+## State
+- Both P0 flags remain default-off axes (no code change this session; screens
+  only). 0 open PRs at session start; findings committed docs-only.
+- v2 warehouses at `/tmp/snap_top3000_{2000,2011,1998_2026}_v2`; lens at
+  `trading/trading/backtest/decision_grading/`; backtests run at
+  `SNAPSHOT_CACHE_MB=1024`, parallel=1 for N=3000, ~76min/run deep.


### PR DESCRIPTION
Lens-screened the two P0 levers landed 06-19 (reserved short sleeve #1659, vol-scaled stop #1662) on the deep 1998-2026 top-3000 Cell-E window with the decision-grading lens @26w. **Both NO-BUILD**, kept default-off as axes (no code change).

**P0a short sleeve** {0.1,0.2,0.3}: non-monotonic return 1663→1478→2019→375; shorts lose every fraction (−$424k…−$676k) + never unlocked (36-44≈37) → supply-gated not cash-gated (corrects crowd-out diagnosis); reserved cash taxes the fat-tail long engine.

**P0b vol-scaled stop** {1.0,1.5,2.0}: every mult cuts return (1934→820/1206/242) + lowers Sharpe; per-stop net value-add got *worse* (−6.2→−7.6) → whipsaw not fixed, stop cost is structural not tunable (both weekly-close #1655 and vol-scaled fail).

Both re-derive `edge_is_the_fat_tail`. Next lever = P1 barbell promotion grid. Full record: `dev/experiments/p0-screens-2026-06-20/FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)