### PR TITLE
docs(barbell): promotion grid — 70/30 robust weight PASSES

### DIFF
--- a/dev/backtest/barbell-grid-2026-06-20/FINDINGS.md
+++ b/dev/backtest/barbell-grid-2026-06-20/FINDINGS.md
@@ -1,0 +1,115 @@
+# Barbell promotion grid — FINDINGS (2026-06-20 PM)
+
+**Verdict: PROMOTE the 70/30 (floor/engine) barbell weight** as the robust
+risk-adjusted blend — with a flagged breadth-confirmation follow-up before live
+capital. This is the **first lever to PASS a promotion grid** in the recent arc;
+contrast the 8 `edge_is_the_fat_tail` rejections (laggard, force-exit,
+stage2-ma-hold, late-flag, macro-trim, harvest-rotate, short-sleeve,
+vol-scaled-stop). The barbell passes precisely because it is a **structural
+diversification layer that does NOT touch the long tail** — a post-hoc capital
+allocation between two whole strategies, not a winner-/loser-touching knob.
+
+See `PLAN.md` for grid design + decision rule. Legs run by `scenario_runner`
+(CSV mode, current code), blended by `blend.awk`. Output:
+`dev/backtest/scenarios-2026-06-20-235722/`.
+
+## The grid (4 engine cells; SPY-only floor per matching window)
+
+| cell | window | universe | engine ret%/MaxDD% | floor ret%/MaxDD% |
+|------|--------|----------|--------------------|-------------------|
+| **A** | 2000-26 | SP500 PIT-2000 | 1570 / 36.8 | 387 / 18.8 |
+| **B** | 2010-26 | SP500 PIT-2000 | 173 / 20.3 | 239 / 18.8 |
+| **C** | 2010-26 | SP500 PIT-2010 | 245 / 18.9 | 239 / 18.8 |
+| **D** | 2000-10 | SP500 PIT-2000 | 364 / 36.8 | 40 / 18.3 |
+
+Period diversity: A(full) + B(bull) + D(bear). Macro-regime: A & D span
+dotcom+GFC. Universe diversity: B vs C (PIT-2000 vs PIT-2010 composition).
+Floor (SPY 30wk long/flat) does its job in the lost decade D: +40% at 18% MaxDD
+vs SPY buy-hold's ~−10%/55%DD — index-timing dodged both crashes.
+
+## Calmar (annualized return / MaxDD) — the risk-adjusted frontier metric
+
+| w_floor | A | B | C | D | min-cell |
+|---------|------|------|------|------|------|
+| 0.00 (pure engine) | 0.296 | 0.303 | 0.403 | **0.435** | 0.296 |
+| 0.50 | 0.369 | 0.451 | **0.462** | 0.417 | 0.369 |
+| 0.60 | 0.398 | **0.452** | 0.460 | 0.414 | 0.398 |
+| **0.70** | **0.437** | 0.451 | 0.457 | 0.413 | **0.413** |
+| 0.80 | 0.433 | 0.449 | 0.453 | 0.407 | 0.407 |
+| 1.00 (pure floor) | 0.319 | 0.400 | 0.400 | 0.183 | 0.183 |
+
+## Sharpe (annualized)
+
+| w_floor | A | B | C | D | min-cell |
+|---------|------|------|------|------|------|
+| 0.00 | 0.801 | 0.535 | 0.656 | **1.011** | 0.535 |
+| 0.50 | 0.801 | 0.683 | 0.750 | 0.877 | 0.683 |
+| 0.60 | 0.776 | 0.695 | 0.748 | 0.812 | 0.695 |
+| **0.70** | 0.739 | 0.699 | 0.738 | 0.729 | **0.699** |
+| 0.80 | 0.692 | 0.696 | 0.720 | 0.626 | 0.626 |
+| 1.00 | 0.575 | 0.669 | 0.669 | 0.379 | 0.379 |
+
+## Decision-rule application (`promotion-confirmation.md`)
+
+- **70/30 beats pure-engine Calmar in 3 of 4 cells** (A 0.437>0.296, B
+  0.451>0.303, C 0.457>0.403; D 0.413<0.435). 3/4 = "strong majority"
+  (all-but-one of 4). ✓
+- **Never badly dominated.** The one loss (D, isolated bear decade) is a ~5% gap,
+  not a collapse. ✓
+- **70/30 has the highest worst-cell Calmar (0.413) AND worst-cell Sharpe
+  (0.699)** of any weight — the most regime-robust point. The per-cell Calmar
+  winners disagree (A→0.70, B→0.60, C→0.50, D→0.00), so the single-window winner
+  is NOT the promotable value; 70/30 is the robust pick, exactly as the rule
+  prescribes.
+- Convergent evidence: matches the 06-02 finding (70/30 beat both legs in each
+  regime, `project_barbell_on_stocks`) and the ETF-lab barbell 70/30 (#1426).
+
+## WHY it works (the transferable mechanism)
+
+Genuine diversification, not less-risk-taking. Cell A: pure-engine annret ≈10.9%
+at 36.8% MaxDD; 70/30 annret ≈7.6% at 17.4% MaxDD. Return fell 30% but MaxDD fell
+53% — **DD falls faster than return because the two legs are imperfectly
+correlated** (the engine's deepest drawdowns are partly offset by the SPY-timing
+floor sitting in cash). That asymmetry is the free lunch; it raises Calmar. The
+barbell does not tax the fat tail — the engine's winners run fully inside the
+engine leg; the floor only reallocates *capital weight*, never trims a position.
+
+**Regime dependence (the nuance):** the benefit concentrates where the two legs
+have *comparable return* (bull cells B, C → blending is near-free DD reduction,
+Sharpe AND Calmar both up) and where the full-window engine DD is high relative
+to return (A). It vanishes in the **isolated bear decade D**, where the engine's
+own crash-dodging machinery (stage3-force-exit h=1 + laggard-rotation h=2)
+already delivers Sharpe 1.01 — the floor can only dilute an already-defended
+book. Reading: the barbell and the engine's internal crash defense are partial
+substitutes; you get the most marginal value from the floor in mixed/bull
+regimes, least in a pure grinding bear (where the engine alone already wins).
+
+## Caveats (honest, per `mechanism-validation-rigor.md`)
+
+1. **Universe-diversity leg is thin.** 3 of 4 cells share SP500 PIT-2000; only C
+   uses a different composition (PIT-2010) — and that is a *snapshot variant*,
+   not a breadth jump (top-1000/3000). The rule permits it, but the cross-
+   universe evidence rests largely on one cell. **Follow-up before live capital:**
+   one breadth-confirmation cell (top-1000 or top-3000 deep) via a rebuilt
+   snapshot warehouse (~26min; /tmp warehouses were cleared). The engine itself
+   is already known to generalize to breadth (`project_deep_1998_2026_contiguous`,
+   realized +1552%); this confirms the *weight* transfers to breadth.
+2. **Absolute engine returns drifted up vs 06-02** (cell A 1570% vs the doc's
+   918%) — current code carries 18 days of fixes (lazy market-state #1481,
+   cash-floor #1556, stale-exit #1487). MaxDD reproduced (36.8 vs 37.3). The grid
+   is **internally valid** (all legs current code); absolute numbers are not
+   comparable to the old writeup, only within-grid.
+3. **No `enable_barbell` config flag exists.** The barbell is a post-hoc
+   portfolio overlay across two strategy runs, not a single-strategy config axis.
+   "Promotion" here = a documented deployable recommendation (run capital as a
+   70/30 floor/engine blend), not a default flip in `Weinstein_strategy.config`.
+   Building the overlay as deployable, rebalanced code is the next engineering
+   step if live deployment is pursued.
+
+## Recommendation
+
+Adopt **70/30 (SPY-timing floor / Cell-E engine)** as the robust barbell weight
+for risk-adjusted deployment. It is the regime-robust Calmar/Sharpe maximizer and
+the first lever to clear a promotion grid. **Gate before live capital on** (a) a
+breadth-universe confirmation cell, and (b) building the rebalanced overlay as
+real code with a default-off enable flag per `experiment-flag-discipline.md`.

--- a/dev/backtest/barbell-grid-2026-06-20/PLAN.md
+++ b/dev/backtest/barbell-grid-2026-06-20/PLAN.md
@@ -1,0 +1,64 @@
+# Barbell promotion grid — 2026-06-20 PM
+
+**Lever:** barbell = post-hoc daily-return NAV blend of two legs —
+FLOOR = `Spy_only_weinstein` (SPY 30wk MA, long/flat, index-timing) +
+ENGINE = full Cell-E Weinstein on PIT S&P 500. The 2026-06-02 work
+(`project_barbell_on_stocks`, PRs #1434/#1435) showed the blend dominates
+**both** pure legs on Calmar in deep (2000-26) and bull (2010-26) regimes, but
+was **never taken to a promotion-confirmation grid**. Both 06-19 stop/short P0
+levers were NO-BUILD (winner/loser-touching, taxed the fat tail); barbell is the
+live lever because it is a **structural diversification layer** that does NOT
+touch the long tail (per `weinstein-faithful-core.md` + `edge_is_the_fat_tail`).
+
+**Why a grid (`.claude/rules/promotion-confirmation.md`):** a single-surface win
+is necessary-but-not-sufficient to flip a default. The 06-02 result was two
+overlapping windows on ONE universe (SP500 PIT-2000). Before recommending a
+blend weight for live deployment, the promotable *weight* must be robust across
+≥3 independent (period × universe) cells, including a genuinely different macro
+regime (a bear-dominated window).
+
+## Grid (4 engine cells × {pure floor, 50/60/70/80% floor, pure engine})
+
+| cell | window | universe | role |
+|------|--------|----------|------|
+| **A** | 2000-2026 | SP500 PIT-2000 | full history; spans dotcom+GFC = bear-macro ✓ (the "ACCEPT" cell) |
+| **B** | 2010-2026 | SP500 PIT-2000 | disjoint **bull** window (period diversity) |
+| **C** | 2010-2026 | SP500 PIT-**2010** | different index composition (universe diversity) |
+| **D** | 2000-2010 | SP500 PIT-2000 | disjoint **bear-dominated** window (dotcom+GFC, no recovery bull) |
+
+Period diversity: A(full) + B(bull) + D(bear). Macro-regime diversity: A & D
+span dotcom+GFC. Universe diversity: B vs C (PIT-2000 vs PIT-2010 composition).
+
+**Known caveat (recorded up front):** universe diversity here is "different PIT
+snapshot of the same index" — the *weaker* form the rule permits, not a breadth
+jump (top-1000/3000). The /tmp snapshot warehouses were cleared, and N≥1000 deep
+in CSV mode risks OOM, so a breadth cell needs a rebuilt snapshot warehouse
+(~26min) — deferred to a follow-up confirmation IF the cheap grid shows a robust
+weight. The deep top-3000 contiguous run (`project_deep_1998_2026_contiguous`,
+realized +1552%) already established the *engine* generalizes to breadth; this
+grid's question is narrower: **is the blend WEIGHT robust?**
+
+## Method
+
+- Each leg run by `scenario_runner` (CSV mode, parallel=1) → `equity_curve.csv`
+  (`date,portfolio_value` per step). Output root:
+  `dev/backtest/scenarios-2026-06-20-235722/`.
+- `blend.awk` inner-joins floor+engine on date, blends daily returns at weight w,
+  reconstructs NAV, emits total-return / annualized-Sharpe / MaxDD / Calmar /
+  Ulcer. Floor 2000-26 → A; floor 2010-26 → B,C; floor 2000-2010 → D.
+
+## Decision rule (`promotion-confirmation.md`)
+
+- **PROMOTE weight V** only if V beats baseline (pure engine) on the
+  risk-adjusted frontier in a strong-majority of cells (all-but-one of 4) AND is
+  never badly dominated in any cell.
+- The single-window Calmar winner is NOT automatically promotable — pick the
+  weight robust across the grid (often a neighbour of per-window winners).
+- If no single weight is robust → keep barbell as a documented option, promote
+  the most conservative robust weight with a regime-sensitivity caveat, or
+  promote nothing. Never promote the headline single-window winner on grid
+  disagreement.
+
+## Results
+
+_(filled when the run completes — see FINDINGS.md)_

--- a/dev/backtest/barbell-grid-2026-06-20/blend.awk
+++ b/dev/backtest/barbell-grid-2026-06-20/blend.awk
@@ -1,0 +1,37 @@
+# blend.awk — barbell NAV blend + risk metrics.
+# Usage: awk -v w=<floor_weight> -f blend.awk floor_equity.csv engine_equity.csv
+#   floor_weight in [0,1]; blended daily return = w*floor_ret + (1-w)*engine_ret.
+# Inputs: equity_curve.csv files (header "date,portfolio_value", date-ordered).
+# Output (tab-separated, one line): w total_return% sharpe maxdd% calmar ulcer% n
+#   sharpe = mean(ret)/popstd(ret)*sqrt(252); calmar = annret/maxdd;
+#   ulcer = sqrt(mean(drawdown%^2)) over the blended NAV path.
+BEGIN { FS=","; ann=252.0 }
+FNR==1 { next }                       # skip header in both files
+NR==FNR { f[$1]=$2+0; next }          # first file: floor[date]=value
+{                                     # second file (engine), date-ordered
+  d=$1; if (d in f) { date[++n]=d; fv[n]=f[d]; ev[n]=($2+0) }
+}
+END {
+  if (n<3) { printf "%.2f\tNA\tNA\tNA\tNA\tNA\t%d\n", w, n; exit }
+  nav=1.0; peak=1.0; maxdd=0.0; sum=0.0; sumsq=0.0; m=0; usum=0.0
+  for (i=2;i<=n;i++) {
+    fr=(fv[i]-fv[i-1])/fv[i-1]
+    er=(ev[i]-ev[i-1])/ev[i-1]
+    r=w*fr+(1-w)*er
+    nav*=(1+r)
+    sum+=r; sumsq+=r*r; m++
+    if (nav>peak) peak=nav
+    dd=(peak-nav)/peak                # fractional drawdown >=0
+    if (dd>maxdd) maxdd=dd
+    usum+=(dd*100)*(dd*100)
+  }
+  mean=sum/m
+  var=sumsq/m-mean*mean; if (var<0) var=0
+  sd=sqrt(var)
+  sharpe=(sd>0)? mean/sd*sqrt(ann) : 0
+  totret=(nav-1)*100
+  annret=(nav>0)? (exp(log(nav)*(ann/m))-1) : -1   # nav^(252/m)-1
+  calmar=(maxdd>0)? annret/maxdd : 0
+  ulcer=sqrt(usum/m)
+  printf "%.2f\t%.1f\t%.3f\t%.1f\t%.3f\t%.2f\t%d\n", w, totret, sharpe, maxdd*100, calmar, ulcer, n
+}

--- a/dev/backtest/barbell-grid-2026-06-20/engineA-sp500_2000-deep.sexp
+++ b/dev/backtest/barbell-grid-2026-06-20/engineA-sp500_2000-deep.sexp
@@ -1,0 +1,32 @@
+;; Barbell promotion grid (2026-06-20) — ENGINE leg, Cell A.
+;; Full-history cell (the "ACCEPT" cell): Cell-E production Weinstein on PIT
+;; S&P 500 as-of 2000-01-01, window 2000-2026 (spans dotcom bust + GFC =
+;; bear-dominated macro regime per promotion-confirmation.md). Config identical
+;; to the recovered p0-barbell-prod/production-deep.sexp.
+((name "engineA-sp500_2000-deep")
+ (description "Cell-E engine, SP500 PIT-2000, 2000-2026 — barbell grid cell A (full history, bear-macro).")
+ (period ((start_date 2000-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 100000.0)))
+   (total_trades      ((min   0.0)  (max 100000.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   1.0)  (max 360000.0))))))

--- a/dev/backtest/barbell-grid-2026-06-20/engineB-sp500_2000-bull.sexp
+++ b/dev/backtest/barbell-grid-2026-06-20/engineB-sp500_2000-bull.sexp
@@ -1,0 +1,32 @@
+;; Barbell promotion grid (2026-06-20) — ENGINE leg, Cell A.
+;; Full-history cell (the "ACCEPT" cell): Cell-E production Weinstein on PIT
+;; S&P 500 as-of 2000-01-01, window 2000-2026 (spans dotcom bust + GFC =
+;; bear-dominated macro regime per promotion-confirmation.md). Config identical
+;; to the recovered p0-barbell-prod/production-deep.sexp.
+((name "engineB-sp500_2000-bull")
+ (description "Cell-E engine, SP500 PIT-2000, 2000-2026 — barbell grid cell B (disjoint bull period 2010-2026).")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 100000.0)))
+   (total_trades      ((min   0.0)  (max 100000.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   1.0)  (max 360000.0))))))

--- a/dev/backtest/barbell-grid-2026-06-20/engineC-sp500_2010-bull.sexp
+++ b/dev/backtest/barbell-grid-2026-06-20/engineC-sp500_2010-bull.sexp
@@ -1,0 +1,32 @@
+;; Barbell promotion grid (2026-06-20) — ENGINE leg, Cell A.
+;; Full-history cell (the "ACCEPT" cell): Cell-E production Weinstein on PIT
+;; S&P 500 as-of 2000-01-01, window 2000-2026 (spans dotcom bust + GFC =
+;; bear-dominated macro regime per promotion-confirmation.md). Config identical
+;; to the recovered p0-barbell-prod/production-deep.sexp.
+((name "engineC-sp500_2010-bull")
+ (description "Cell-E engine, SP500 PIT-2000, 2000-2026 — barbell grid cell C (universe diversity: SP500 PIT-2010 composition, 2010-2026).")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 100000.0)))
+   (total_trades      ((min   0.0)  (max 100000.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   1.0)  (max 360000.0))))))

--- a/dev/backtest/barbell-grid-2026-06-20/engineD-sp500_2000-bear.sexp
+++ b/dev/backtest/barbell-grid-2026-06-20/engineD-sp500_2000-bear.sexp
@@ -1,0 +1,32 @@
+;; Barbell promotion grid (2026-06-20) — ENGINE leg, Cell A.
+;; Full-history cell (the "ACCEPT" cell): Cell-E production Weinstein on PIT
+;; S&P 500 as-of 2000-01-01, window 2000-2026 (spans dotcom bust + GFC =
+;; bear-dominated macro regime per promotion-confirmation.md). Config identical
+;; to the recovered p0-barbell-prod/production-deep.sexp.
+((name "engineD-sp500_2000-bear")
+ (description "Cell-E engine, SP500 PIT-2000, 2000-2026 — barbell grid cell D (disjoint bear-dominated 2000-2010: dotcom+GFC, no recovery).")
+ (period ((start_date 2000-01-01) (end_date 2010-01-01)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 100000.0)))
+   (total_trades      ((min   0.0)  (max 100000.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   1.0)  (max 360000.0))))))

--- a/dev/backtest/barbell-grid-2026-06-20/floor-2000-bear.sexp
+++ b/dev/backtest/barbell-grid-2026-06-20/floor-2000-bear.sexp
@@ -1,0 +1,18 @@
+;; Barbell promotion grid (2026-06-20) — FLOOR leg, window 2000-2010.
+;; SPY-only Weinstein investor preset (30wk MA, long/flat). The drawdown-defense
+;; floor leg; blended against each engine cell over the matching window.
+((name "floor-2000-bear")
+ (description "SPY-only Weinstein (30wk MA, long/flat) 2000-2010 — barbell grid FLOOR (cell D window).")
+ (period ((start_date 2000-01-01) (end_date 2010-01-01)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Spy_only_weinstein (symbol SPY) (ma_period_weeks 30)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 5000.0)))
+   (total_trades      ((min   0.0)  (max  200.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   0.1)  (max 3600.0))))))

--- a/dev/backtest/barbell-grid-2026-06-20/floor-2000-deep.sexp
+++ b/dev/backtest/barbell-grid-2026-06-20/floor-2000-deep.sexp
@@ -1,0 +1,18 @@
+;; Barbell promotion grid (2026-06-20) — FLOOR leg, window 2000-2026.
+;; SPY-only Weinstein investor preset (30wk MA, long/flat). The drawdown-defense
+;; floor leg; blended against each engine cell over the matching window.
+((name "floor-2000-deep")
+ (description "SPY-only Weinstein (30wk MA, long/flat) 2000-2026 — barbell grid FLOOR (cell A window).")
+ (period ((start_date 2000-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Spy_only_weinstein (symbol SPY) (ma_period_weeks 30)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 5000.0)))
+   (total_trades      ((min   0.0)  (max  200.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   0.1)  (max 3600.0))))))

--- a/dev/backtest/barbell-grid-2026-06-20/floor-2010-bull.sexp
+++ b/dev/backtest/barbell-grid-2026-06-20/floor-2010-bull.sexp
@@ -1,0 +1,18 @@
+;; Barbell promotion grid (2026-06-20) — FLOOR leg, window 2010-2026.
+;; SPY-only Weinstein investor preset (30wk MA, long/flat). The drawdown-defense
+;; floor leg; blended against each engine cell over the matching window.
+((name "floor-2010-bull")
+ (description "SPY-only Weinstein (30wk MA, long/flat) 2010-2026 — barbell grid FLOOR (cells B,C window).")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Spy_only_weinstein (symbol SPY) (ma_period_weeks 30)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 5000.0)))
+   (total_trades      ((min   0.0)  (max  200.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   0.1)  (max 3600.0))))))

--- a/dev/notes/next-session-priorities-2026-06-21.md
+++ b/dev/notes/next-session-priorities-2026-06-21.md
@@ -1,0 +1,74 @@
+# Next-session priorities — 2026-06-21
+
+**Supersedes** `next-session-priorities-2026-06-20-PM.md`. Check main CI green
+first (`.claude/rules/session-rampup.md`). The 2026-06-20 PM session ran the
+**barbell promotion grid** — the lever the 06-20-PM doc named as P0 NEXT after
+both stop/short levers were NO-BUILD.
+
+## What happened 2026-06-20 PM — barbell grid PASSES (first lever to clear a grid)
+
+Full record: `dev/backtest/barbell-grid-2026-06-20/FINDINGS.md` (+ PLAN.md,
+specs, `blend.awk`). Legs run by `scenario_runner` (CSV mode, current code);
+outputs `dev/backtest/scenarios-2026-06-20-235722/` (gitignored).
+
+**Verdict: PROMOTE 70/30 (SPY-timing floor / Cell-E engine) as the robust
+risk-adjusted barbell weight.** 4-cell grid (A=2000-26 full/bear-macro,
+B=2010-26 bull, C=2010-26 diff-index-composition, D=2000-2010 bear decade):
+
+- 70/30 **beats pure-engine Calmar in 3/4 cells** (A 0.437>0.296, B 0.451>0.303,
+  C 0.457>0.403), loses only narrowly in D (0.413<0.435), and has the **highest
+  worst-cell Calmar (0.413) AND Sharpe (0.699)** of any weight → the regime-robust
+  pick. Per-cell winners disagree (0.70/0.60/0.50/0.00) so the single-window
+  winner is NOT promotable; 70/30 is. Matches 06-02 + ETF-lab 70/30.
+- **Why real:** genuine diversification, not less-risk-taking. Cell A: annret
+  −30% but MaxDD −53% (legs imperfectly correlated) → Calmar UP. Does NOT tax the
+  fat tail (engine winners run fully inside the engine leg; floor only reweights
+  capital). This is why it passes where 8 tail-touching levers were rejected.
+- **Regime nuance:** benefit concentrates in bull/mixed (B,C: Sharpe+Calmar both
+  up) and high-DD full window (A); **vanishes in the isolated bear decade D**,
+  where the engine's own stage3-exit+laggard machinery already gives Sharpe 1.01
+  — the barbell and the engine's internal crash defense are partial substitutes.
+
+## P0 NEXT — two gates before the 70/30 barbell can take live capital
+
+1. **Breadth-universe confirmation cell.** The grid's universe-diversity leg is
+   thin: 3/4 cells share SP500 PIT-2000; only C differs (PIT-2010 *snapshot*, not
+   a breadth jump). Run ONE breadth cell — top-1000 or top-3000 deep — and re-blend
+   at 70/30 to confirm the weight transfers to breadth. Needs a rebuilt snapshot
+   warehouse (~26min; /tmp warehouses were cleared — see recipe in
+   `dev/backtest/barbell-grid-2026-06-20/PLAN.md`). The *engine* already
+   generalizes to breadth (`project_deep_1998_2026_contiguous` realized +1552%);
+   this confirms the *weight* does. `[blocking: confirm before live deploy]`
+2. **Build the barbell overlay as deployable code.** Today's blend is post-hoc
+   (`blend.awk` over two equity curves). There is no `enable_barbell` config.
+   To deploy live, build a rebalanced 70/30 floor/engine capital overlay behind a
+   default-off flag per `experiment-flag-discipline.md` (R1 default-off, R2
+   searchable axis, R3 no default-on without the ACCEPT this grid provides).
+   This is real engineering (two-strategy capital allocation), not a screen.
+
+## Secondary (unchanged from 06-20-PM, lower priority than the barbell gates)
+
+- **Short-supply screen** [~76min deep run]: loosen `short_min_price 17→5` (and a
+  1.0 variant), re-run the long-short deep cell, decompose shorts by exit-year +
+  win/loss distribution. Question: does a bigger short book stay per-trade-favorable
+  AND finally fire in 2008? Yellow flag: 2008 whipsaw loss suggests name-level
+  Stage-4 short timing is the real failure — loosening supply may just lose more.
+  If it still loses in 2008 → "name-level shorts aren't a dependable bear hedge;
+  use the regime/index overlay (= the barbell) instead" and this line closes.
+  Recipe in `next-session-priorities-2026-06-20-PM.md` §Queued.
+
+## Guardrail (unchanged)
+Live class = **structural diversification layers** (barbell ← now PASSED;
+regime-gating overlays; offsetting legs that actually pay). NOT winner/loser-
+touching levers (`edge_is_the_fat_tail`, 8 rejections) and NOT entry/cascade/
+short-pick selection (dead 5×). The barbell passing CONFIRMS the guardrail's
+prediction: the diversification-layer class is where the gains are.
+
+## State
+- 1 commit this session (docs/research): barbell grid artifacts +
+  `blend.awk` + FINDINGS/PLAN + this doc. No code change (post-hoc blend; the
+  deployable overlay is P0 NEXT #2 above).
+- Barbell ACCEPT now exists for the 70/30 weight (this grid) — satisfies
+  `experiment-flag-discipline.md` R3's ACCEPT prerequisite for a future
+  default-on, pending the breadth-confirmation cell.
+- v2 /tmp snapshot warehouses were CLEARED; rebuild for any breadth/top-N run.


### PR DESCRIPTION
## Barbell promotion grid — first lever to clear a promotion grid

Took the barbell (SPY-timing floor + Cell-E engine NAV blend, `project_barbell_on_stocks`) to a `promotion-confirmation.md` grid — the P0 NEXT named by `next-session-priorities-2026-06-20-PM.md` after both 06-19 stop/short levers were NO-BUILD.

**Verdict: PROMOTE 70/30 (floor/engine)** as the robust risk-adjusted weight.

4 engine cells (SPY-only floor per window), all current-code CSV mode:
| cell | window | universe | role |
|---|---|---|---|
| A | 2000-26 | SP500 PIT-2000 | full / bear-macro (dotcom+GFC) |
| B | 2010-26 | SP500 PIT-2000 | disjoint bull |
| C | 2010-26 | SP500 PIT-2010 | universe diversity |
| D | 2000-10 | SP500 PIT-2000 | disjoint bear decade |

**Calmar by floor-weight (min-cell):** .50→.369 · .60→.398 · **.70→.413** · .80→.407. 70/30 beats pure-engine Calmar in 3/4 cells (A .437>.296, B .451>.303, C .457>.403), loses narrowly only in D, and has the highest worst-cell Calmar AND Sharpe — the regime-robust pick (per-cell winners disagree, so the single-window winner is not promotable).

**Why it passes where 8 `edge_is_the_fat_tail` levers were rejected:** the barbell is a structural diversification layer that does NOT touch the long tail — engine winners run fully inside the engine leg; the floor only reweights capital. Genuine diversification (cell A: annret −30% but MaxDD −53% → Calmar up).

**Gates before live capital (P0 next):** (1) one breadth-universe confirmation cell (universe-diversity leg is thin); (2) build the barbell as a deployable rebalanced overlay behind a default-off flag.

Docs/research only — no code change (post-hoc `blend.awk` over equity curves). Full record in `dev/backtest/barbell-grid-2026-06-20/FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)