### PR TITLE
docs(engine-edge): honest 1998-26 engine vs S&P + barbell frontier

### DIFF
--- a/dev/backtest/engine-edge-1998-2026/FINDINGS.md
+++ b/dev/backtest/engine-edge-1998-2026/FINDINGS.md
@@ -1,0 +1,106 @@
+# Engine edge + correct-window barbell — FINDINGS (2026-06-21, overnight)
+
+**Headline (honest, current code, the question "do we beat S&P?"):**
+Over the full cycle **1998-2026 the engine beats S&P-price (+1100% vs +599%)** —
+but the edge is **100% crash-protection, ~0% upside-capture.** It wins entirely by
+sidestepping 2000-02 + 2008; in the 2009-26 bull it **badly lags** plain buy-hold
+S&P (+130% vs +631%). The barbell is **regime-complementary insurance**, not a free
+return boost, and a fixed 70/30 weight is a compromise optimal in **neither**
+regime. Everything below is top-3000 PIT-1998, long-only Cell-E, current code,
+per-share \$0.01 cost, reusing `/tmp/snap_top3000_1998_ls`.
+
+## Phase A — engine vs S&P, like-for-like
+
+Engine NAV is valued on `close_price` (simulator.ml:150), **not** `adjusted_close`
+→ price-only, **no dividends** — so it is directly comparable to **SPX price
+return** (GSPC 975.04→6816.89 = **+599%**). The comparison is fair (both exclude
+dividends).
+
+| 1998-2026 | total return | realized* | MaxDD | Sharpe | Calmar |
+|---|---|---|---|---|---|
+| **engine** (Cell-E, top-3000) | **+1100%** | ~+836% | 48.3% | 0.54 | 0.19 |
+| SPX price (BAH) | +599% | — | ~57% (GFC) | — | — |
+| SPY-timing floor | +478% | — | 24.3% | 0.57 | 0.26 |
+
+*realized ≈ total − open MTM (unrealized \$2.64M of \$12M terminal NAV ≈ 24%). Even
+on a realized basis (+836%) the engine beats SPX-price (+599%).
+
+**Re-pin vs the cached headline:** `project_deep_1998_2026_contiguous` recorded
++1552% / MaxDD 35.9%. Current code (18 days of fixes: lazy market-state #1481,
+cash-floor #1556, stale-exit #1487, per-share cost) gives **+1100% / MaxDD 48.3%**
+— a **smaller edge and a materially WORSE drawdown**. The +1552%/35.9% headline was
+optimistic; the honest current-code number is +1100% with a scary ~48% drawdown.
+
+## Phase B — barbell weight surface (the user's #1 question)
+
+Blend (`blend.awk`) engine vs the 1998-26 SPY-timing floor, full floor-weight grid:
+
+| floor w | return | Sharpe | MaxDD | Calmar | Ulcer |
+|---|---|---|---|---|---|
+| 0.00 (pure engine) | 1100% | 0.537 | 48.3% | 0.183 | 16.2 |
+| 0.20 | 1019% | 0.583 | 41.9% | 0.205 | 12.6 |
+| 0.30 | 965% | 0.607 | 38.6% | 0.218 | 11.3 |
+| 0.40 | 904% | 0.630 | 35.0% | 0.234 | 10.3 |
+| 0.50 | 838% | 0.649 | 31.4% | 0.253 | 9.4 |
+| 0.70 | 696% | **0.660** | 23.6% | **0.311** | 7.9 |
+| 1.00 (pure floor) | 478% | 0.566 | 24.3% | 0.255 | 9.9 |
+
+**Every weight beats S&P-price (+599%) up to ~0.65 floor** — even the Sharpe/Calmar
+optimum (≈0.70) keeps +696%. So the barbell does NOT surrender the edge; it trades
+return for drawdown on a smooth frontier. There is **no sharp knee** — the choice is
+mandate-driven:
+- **Keep the edge, light insurance:** w=0.30-0.40 → 900-965% return (beats S&P by
+  +300-365pp), DD cut 48%→35-39%, Sharpe 0.61-0.63.
+- **Max risk-adjusted:** w=0.70 → Sharpe 0.66 / Calmar 0.31, DD 23.6%, still +696%.
+
+## The decomposition that reshapes the thesis (sub-window robustness)
+
+Same surface on disjoint regimes — **vs S&P-price in each** (GSPC: 1998-2008
+**−7.4%**, 2009-2026 **+631%**):
+
+| 1998-2008 (dotcom+GFC) | return | Sharpe | | 2009-2026 (bull) | return | Sharpe |
+|---|---|---|---|---|---|---|
+| engine (w=0) | **+421%** | **0.77** | | engine (w=0) | +130% | 0.36 |
+| floor (w=1) | +38% | 0.31 | | floor (w=1) | **+318%** | **0.73** |
+| **S&P price** | **−7%** | — | | **S&P price** | **+631%** | — |
+
+- **Crash decade:** engine **+421% vs S&P −7%** = +428pp alpha; adding floor *hurts*
+  (Sharpe 0.77→0.62). Pure engine is optimal.
+- **Bull decade:** engine **+130% vs S&P +631%** = **−501pp** (badly lags); even the
+  timing floor (+318%) lags S&P by −313pp. Adding floor *helps* monotonically; pure
+  floor is optimal.
+
+**So the full-window "70/30 optimal" is a regime-averaging artifact.** In the crash
+decade you want pure engine; in the bull you want pure floor (or just S&P BAH). 70/30
+is optimal in neither — it's the least-bad compromise across two opposite regimes.
+(This is the same bear→engine / bull→floor pattern the 06-20 grid showed in cells D
+vs B/C; the 1998-26 split makes it unambiguous.)
+
+## What this means (transferable why)
+
+1. **The strategy's edge is crash-protection, not stock-picking upside.** It beats
+   S&P over full cycles by losing far less in 2000-02 + 2008 (and catching the
+   recoveries), NOT by outperforming in bulls — where it lags buy-hold badly. Any
+   eval window that excludes a crash will show the strategy LOSING to S&P. This is
+   the precise, honest answer to "do we beat S&P": **yes over full cycles via
+   downside protection; no in sustained bulls.**
+2. **The barbell is regime-complementary insurance.** Engine = crash alpha, floor =
+   bull participation; they are anti-correlated by regime, which is *why* the
+   full-cycle blend cuts drawdown so well. But a *fixed* weight can't be optimal in
+   both regimes, and **regime-timing the weight is the known-dead lever**
+   (`project_next_lever_decision_grading`: regime-gating = SPY-timing, worse). So the
+   deployable recommendation is a *fixed* light-to-medium floor (0.30-0.50) chosen by
+   drawdown tolerance, accepting it's a compromise — not a regime-switched weight.
+3. **The cached +1552%/35.9% headline must be retired.** Honest current-code number:
+   **+1100% / 48.3% DD**, edge concentrated in the crash decade.
+
+## Recommendation
+- For "beat S&P with a smoother ride over full cycles": **light-to-medium floor
+  (w≈0.30-0.40)** keeps ~90% of the engine's S&P-beating return while cutting the
+  48% drawdown to ~35-39% and lifting Sharpe. NOT 70/30 (gives up too much return
+  for a marginal Sharpe gain that's itself a regime artifact).
+- **Set expectations honestly:** this strategy will *underperform* S&P in sustained
+  bull markets. Its mandate is full-cycle outperformance via crash avoidance.
+- Open lever (Phase C): does a faithful *trader* preset (10wk MA / continuation /
+  full sizing) reduce the 2009-26 bull-lag while keeping crash alpha? Motivated by
+  the −501pp bull gap. Tested next if config-ready.

--- a/dev/backtest/engine-edge-1998-2026/flr/floor-1998-deep.sexp
+++ b/dev/backtest/engine-edge-1998-2026/flr/floor-1998-deep.sexp
@@ -1,0 +1,18 @@
+;; Barbell promotion grid (2026-06-20) — FLOOR leg, window 1998-2026.
+;; SPY-only Weinstein investor preset (30wk MA, long/flat). The drawdown-defense
+;; floor leg; blended against each engine cell over the matching window.
+((name "floor-1998-deep")
+ (description "SPY-only Weinstein (30wk MA, long/flat) 1998-2026 — barbell grid FLOOR (1998-26 engine-edge window).")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/spy-only.sexp")
+ (universe_size 1)
+ (config_overrides ())
+ (strategy (Spy_only_weinstein (symbol SPY) (ma_period_weeks 30)))
+ (expected
+  ((total_return_pct  ((min -90.0)  (max 5000.0)))
+   (total_trades      ((min   0.0)  (max  200.0)))
+   (win_rate          ((min   0.0)  (max  100.0)))
+   (sharpe_ratio      ((min  -2.0)  (max    5.0)))
+   (max_drawdown_pct  ((min   0.0)  (max   95.0)))
+   (avg_holding_days  ((min   0.0)  (max 5000.0)))
+   (wall_seconds      ((min   0.1)  (max 3600.0))))))

--- a/dev/backtest/engine-edge-1998-2026/flr/run.log
+++ b/dev/backtest/engine-edge-1998-2026/flr/run.log
@@ -1,0 +1,41 @@
+File ".", line 1, characters 0-0:
+Warning: No dune-project file has been found in directory ".". A default one
+is assumed but the project might break when dune is upgraded. Please create a
+dune-project file.
+Hint: generate the project file with: $ dune init project <name>
+Loading 1 scenarios from /workspaces/trading-1/dev/backtest/engine-edge-1998-2026/flr (parallel=1)
+Fixtures root: /workspaces/trading-1/trading/test_data/backtest_scenarios
+Bar data source: CSV mode
+Progress emission: every 4 Friday cycle(s) per scenario
+All-eligible diagnostic: disabled
+Output root: /workspaces/trading-1/dev/backtest/scenarios-2026-06-21-074236
+
+>>> Running floor-1998-deep: SPY-only Weinstein (30wk MA, long/flat) 1998-2026 — barbell grid FLOOR (1998-26 engine-edge window). (1998-01-01 to 2026-04-30)
+Using scenario-provided sector map (1 symbols)...
+Universe: 1 stocks
+Loading AD breadth bars...
+Total symbols (universe + index + sector ETFs): 16
+Running backtest (1998-01-01 to 2026-04-30, warmup from 1997-06-05)...
+Panel_runner: simulator window 1997-06-05..2026-04-30 (warmup 210 days, strategy Spy_only_weinstein(SPY,ma=30wk))
+Panel_runner: in-process snapshot built (16 symbols, /tmp/panel_runner_csv_snapshot_261c91)
+Panel_runner: snapshot cache cap = 4096 MB (env SNAPSHOT_CACHE_MB)
+Panel_runner: snapshot bar reader wired (calendar 7541 days) for strategy
+WARN: portfolio rejected fill for SPY (side=Types.Buy qty=7102.0000 price=147.0000): { Status.code = Status.Invalid_argument;
+  message =
+  "Insufficient cash for trade. Required: 1044065.02, Available: 1040905.9571999997, Unrealized loss drag: 0."
+  }. Stranded position will be reverted for retry (see Cancel_handler).
+WARN: portfolio rejected fill for SPY (side=Types.Buy qty=10598.0000 price=314.1700): { Status.code = Status.Invalid_argument;
+  message =
+  "Insufficient cash for trade. Required: 3329679.64, Available: 3303694.9697000002, Unrealized loss drag: 0."
+  }. Stranded position will be reverted for retry (see Cancel_handler).
+WARN: portfolio rejected fill for SPY (side=Types.Buy qty=10901.0000 price=306.1600): { Status.code = Status.Invalid_argument;
+  message =
+  "Insufficient cash for trade. Required: 3337559.17, Available: 3303694.9697000002, Unrealized loss drag: 0."
+  }. Stranded position will be reverted for retry (see Cancel_handler).
+Panel_runner: snapshot cache hits=229803 misses=16 evictions=0 n_symbols=16 misses_per_symbol=1.00
+Scenario                       Return  Trades  WinRate    MaxDD   Result
+------------------------------------------------------------------------------
+floor-1998-deep                478.4%      22    54.5%    24.3%   PASS
+
+1/1 scenarios passed.
+RUN_EXIT=0 DONE

--- a/dev/backtest/engine-edge-1998-2026/ma10/engine-top3000-1998-ma10.sexp
+++ b/dev/backtest/engine-edge-1998-2026/ma10/engine-top3000-1998-ma10.sexp
@@ -1,0 +1,36 @@
+;; Engine-edge + barbell engine leg — canonical LONG-ONLY Cell-E, 1998-2026.
+;; The S&P-beating baseline (cf. project_deep_1998_2026_contiguous: realized
+;; +1552% vs SPX +599%). Re-confirmed on CURRENT code over the correct full-cycle
+;; window (1998-26, captures the dot-com run-up + bust + GFC), top-3000 PIT-1998.
+;; Cost model = the established deep baseline (per-share $0.01). This run's equity
+;; curve is BOTH the engine-edge baseline (Phase A) and the barbell engine leg
+;; (Phase B). Snapshot mode (reuse /tmp/snap_top3000_1998_ls). See
+;; dev/notes/overnight-plan-2026-06-21.md.
+((name "engine-top3000-1998-ma10")
+ (description "Cell-E LONG-ONLY 10wk-MA trader dial, top-3000 1998-2026 — bull-lag probe vs 30wk baseline.")
+ (period ((start_date 1998-01-01) (end_date 2026-04-30)))
+ (universe_path "workspaces/trading-1/trading/test_data/goldens-custom-universe/composition/top-3000-1998.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))
+   ((stage_config ((ma_period 10))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.01)
+   (bid_ask_spread_bps 0.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct  ((min -100.0) (max 1000000.0)))
+   (total_trades      ((min    0.0) (max 1000000.0)))
+   (win_rate          ((min    0.0) (max     100.0)))
+   (sharpe_ratio      ((min  -100.0) (max     100.0)))
+   (max_drawdown_pct  ((min    0.0) (max     100.0)))
+   (avg_holding_days  ((min    0.0) (max  100000.0)))
+   (wall_seconds      ((min    1.0) (max  360000.0))))))

--- a/dev/backtest/engine-edge-1998-2026/ma10/run.log
+++ b/dev/backtest/engine-edge-1998-2026/ma10/run.log
@@ -4,14 +4,14 @@ is assumed but the project might break when dune is upgraded. Please create a
 dune-project file.
 Hint: generate the project file with: $ dune init project <name>
 [snapshot-mode] loaded manifest at /tmp/snap_top3000_1998_ls/manifest.sexp (schema_hash=060588c0224b7d7e73f367fbd1801084, 3015 entries)
-Loading 1 scenarios from /workspaces/trading-1/dev/backtest/engine-edge-1998-2026/eng (parallel=1)
+Loading 1 scenarios from /workspaces/trading-1/dev/backtest/engine-edge-1998-2026/ma10 (parallel=1)
 Fixtures root: /
 Bar data source: snapshot mode (/tmp/snap_top3000_1998_ls)
 Progress emission: every 4 Friday cycle(s) per scenario
 All-eligible diagnostic: disabled
-Output root: /workspaces/trading-1/dev/backtest/scenarios-2026-06-21-062834
+Output root: /workspaces/trading-1/dev/backtest/scenarios-2026-06-21-075019
 
->>> Running engine-top3000-1998-deep: Cell-E LONG-ONLY, top-3000 PIT-1998, 1998-2026 — engine-edge baseline + barbell engine leg. (1998-01-01 to 2026-04-30)
+>>> Running engine-top3000-1998-ma10: Cell-E LONG-ONLY 10wk-MA trader dial, top-3000 1998-2026 — bull-lag probe vs 30wk baseline. (1998-01-01 to 2026-04-30)
 Using scenario-provided sector map (3000 symbols)...
 Universe: 3000 stocks
 Loading AD breadth bars...
@@ -20,4 +20,3 @@ Running backtest (1998-01-01 to 2026-04-30, warmup from 1997-06-05)...
 Panel_runner: simulator window 1997-06-05..2026-04-30 (warmup 210 days, strategy Weinstein)
 Panel_runner: snapshot cache cap = 1024 MB (env SNAPSHOT_CACHE_MB)
 Panel_runner: snapshot bar reader wired (calendar 7541 days) for strategy
-RUN_EXIT=0 DONE


### PR DESCRIPTION
**Phase A+B of the overnight plan.** Honest current-code engine vs S&P on the CORRECT full-cycle window, + the barbell weight surface, + a regime decomposition that reshapes the thesis.

**Headline:** engine 1998-26 beats S&P-price (+1100% vs +599%, like-for-like — sim uses close_price, no dividends either side) — BUT the edge is 100% crash-protection: it wins entirely by sidestepping 2000-02 + 2008 (1998-2008: engine +421% vs S&P −7%); in the 2009-26 bull it badly LAGS buy-hold (+130% vs +631%).

**Barbell frontier (1998-26):** every floor weight ≤0.65 beats S&P; Sharpe/Calmar peak at ~0.70 but that's a regime-averaging artifact (crash decade → pure engine optimal; bull → pure floor optimal). Recommend a LIGHT floor (w≈0.30-0.40): keeps ~90% of return (900-965%), cuts DD 48%→35-39%, lifts Sharpe — NOT 70/30.

**Re-pin:** cached +1552%/35.9% headline → honest current-code +1100%/48.3% DD. Retire the old number.

Full record: `dev/backtest/engine-edge-1998-2026/FINDINGS.md`. Docs/research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)