### PR TITLE
docs(agent-memory): refresh — overnight engine-edge/barbell/short findings

### DIFF
--- a/dev/agent-memory/project_barbell_on_stocks.md
+++ b/dev/agent-memory/project_barbell_on_stocks.md
@@ -103,3 +103,19 @@ Only gate #2 remains before live: build the deployable rebalanced overlay behind
 a default-off flag. Caveat: broad-cell absolute returns are MTM-inclusive +
 start-date/survivorship-confounded; the weight-SURFACE SHAPE (where Calmar/Sharpe
 peak) is the robust signal, each cell internally consistent (same floor/window).
+
+## 2026-06-21 — CORRECT-WINDOW (1998-26) frontier: light floor, NOT 70/30
+Redid the weight surface on the correct full-cycle window (engine beats S&P here,
+unlike the 2000-26 peak-start used earlier). Engine 1998-26 = +1100%/48.3%DD; SPY
+floor = +478%/24.3%DD. Frontier (floor w → return/Sharpe/MaxDD): 0→1100/.54/48.3 ·
+.30→965/.61/38.6 · .40→904/.63/35.0 · .50→838/.65/31.4 · .70→696/.66/23.6 ·
+1.0→478/.57/24.3. **Every w≤0.65 beats S&P (+599%).** Sharpe/Calmar peak at ~.70 BUT
+that's a **regime-averaging artifact**: sub-windows show crash-decade 1998-2008 →
+pure-ENGINE optimal (floor hurts, Sharpe .77→.62), bull 2009-26 → pure-FLOOR optimal
+(engine hurts, Sharpe .36→.73). No fixed weight optimal in both. **Recommend LIGHT
+floor w≈0.30-0.40** (keeps ~90% of return = 900-965%, cuts DD 48→35-39%, lifts
+Sharpe) over 70/30 (gives up too much return for a regime-artifact Sharpe gain).
+Regime-timing the weight = known-dead lever. The earlier "70/30 robust" (#1670/#1673)
+was on weak-engine windows (2000-26/top-1000); on the strong-engine window the
+return cost of 70/30 is the real consideration. Record:
+`dev/backtest/engine-edge-1998-2026/FINDINGS.md` (#1679).

--- a/dev/agent-memory/project_deep_1998_2026_contiguous.md
+++ b/dev/agent-memory/project_deep_1998_2026_contiguous.md
@@ -63,3 +63,14 @@ entries → 0 trades, flat NAV. Fix: build with an AUGMENTED universe (tradeable
 `universe_path` at the tradeable set only (context symbols not traded). Incremental
 rebuild adds just the 15 (~17s). The working `snap_top3000_2011` has 3015 files
 (3000+15); a naive top-3000 build has only 3000.
+
+## 2026-06-21 — RE-PIN on current code + edge is crash-protection only
+Re-ran long-only Cell-E top-3000 1998-26 on CURRENT code (per-share $0.01 cost):
+**total +1100% / MaxDD 48.3% / Sharpe 0.54** (realized ~+836%, 24% open MTM). The
+cached **+1552% / 35.9%** headline is OPTIMISTIC vs current code (18d of fixes
+#1481/#1556/#1487) — RETIRE it; honest number is +1100%/48% DD. vs S&P like-for-
+like (sim values on close_price, NO dividends; GSPC price +599%): engine beats S&P
++1100 vs +599. **But the edge is 100% crash-protection:** 1998-2008 engine +421% vs
+S&P −7% (+428pp alpha); 2009-2026 bull engine +130% vs S&P +631% (LAGS −501pp).
+Any window excluding a crash shows the strat LOSING to S&P. Record:
+`dev/backtest/engine-edge-1998-2026/FINDINGS.md` (#1679).

--- a/dev/agent-memory/project_edge_is_the_fat_tail.md
+++ b/dev/agent-memory/project_edge_is_the_fat_tail.md
@@ -52,3 +52,16 @@ lever whose action is "tax the source of the edge."
   prior is strongly negative and the burden is to show it does NOT tax the tail
   (the decomposition in `dev/plans/harvest-rotate-rigorous-test-2026-06-10.md`:
   timing vs picks vs structural-tax vs cost).
+
+## 2026-06-21 — MA-period dial (30→10wk) = MTM/capacity mirage, NOT an edge
+Probed Weinstein's faithful 10wk trader MA to fix the engine's 2009-26 bull-lag
+(+130% vs S&P +631%). 10wk FULL 1998-26 = +25,602% (vs 30wk +1100%), bull +4207%
+(vs +130%) — looks like it crushes the lag, BUT Sharpe COLLAPSED 0.54→0.21; ONE
+trade realized +$209M, open positions $195M of $257M NAV (76%). Pure
+fat-tail-compounding/capacity mirage (capacity-infeasible position sizes), amplified
+by faster MA catching more monsters. NO-BUILD. Lesson: MA period is the most
+impactful dial but faster≠better — any lever that works by catching MORE fat-tail
+names hits the capacity wall; the realistic edge is capacity-bounded, not MA-bounded.
+The 30wk bull-lag is partly the PRICE of a capacity-realistic book. Bull-lag is
+STRUCTURAL; address via barbell floor (capacity-safe), not faster MA. Record:
+`dev/backtest/engine-edge-1998-2026/PHASE-C-ma-period.md` (#TBD).

--- a/dev/agent-memory/project_short_funnel_crowded_out.md
+++ b/dev/agent-memory/project_short_funnel_crowded_out.md
@@ -61,3 +61,13 @@ lens-screen `short_sleeve_fraction` ∈ {0.1,0.2,0.3} via `decision_grading`: do
 now-numerous shorts add a real offsetting/DD-reducing leg, or churn at ~breakeven
 (the (c) symptom)? Real offset → WF-CV + grid; else record no-build-with-why
 (capital reserved for a non-paying leg = drag) and keep default-off.
+
+## 2026-06-21 — confirmed SUPPLY-gated, price-floor non-binding (line CLOSED)
+Loosened `short_min_price 17→5` on top-3000 1998-26 long-short deep: short count
+**36 vs baseline 37** — ~zero new shorts admitted → binding constraint is Stage-4
+signal supply (~1.3 shorts/yr), NOT the price filter. The 36 shorts net −$50k/28y,
+36% win, lottery-shaped (carried by 2009 +$206k); 2008 fired (7) but 2/7 win = not
+a reliable hedge. NO-BUILD: name-level Stage-4 shorts aren't a dependable bear
+defense — the barbell floor (index overlay) is. Record:
+`dev/backtest/short-supply-screen-2026-06-21/FINDINGS.md` (#1678). Route bear-
+defense to the regime/index overlay, not name-level shorts.


### PR DESCRIPTION
Refresh agent-memory snapshot with the overnight findings: deep-1998 re-pin (+1100%/48%, crash-protection edge), correct-window barbell weight (light floor), MA-period MTM mirage, short supply-gated. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)