### PR TITLE
feat(macro): decline-character classifier (slow-grind vs fast-V), default-off primitive

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -28,6 +28,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [all-eligible](all-eligible.md) | MERGED | — | — | — |
 | [support-floor-stops](support-floor-stops.md) | MERGED | — | — | — |
 | [short-side-strategy](short-side-strategy.md) | IN_PROGRESS | feat-weinstein | — | #1659 short-sleeve budget (default-off) MERGED; next: LOCAL sleeve-fraction screen → WF-CV → grid before default flip `[non-blocking]` |
+| [decline-character](decline-character.md) | IN_PROGRESS | feat-weinstein | feat/decline-character | Build 1 classifier (Slow_grind/Fast_v/Not_declining) READY_FOR_REVIEW; next: Build 0 A/D wiring, then Builds 2/3 (stop+short) |
 | [spy-only-reference](spy-only-reference.md) | IN_PROGRESS | feat-weinstein | — | WF-CV on sector-rotation testbed; top-1000 bankability gate; long-short verification (human session) |
 | [stage-accuracy](stage-accuracy.md) | IN_PROGRESS | feat-weinstein | — | force_exit_off grid REJECTED (#1503); cascade-selection inversion documented (#1509 merged); broad-universe WF-CV re-run data-gated |
 | [harvest-rotate](harvest-rotate.md) | MERGED | — | — | WF-CV REJECT (#1532) — dispersion-amplifying noise, not Sharpe edge; mechanism stays default-off, axis not promoted |

--- a/dev/status/decline-character.md
+++ b/dev/status/decline-character.md
@@ -1,0 +1,65 @@
+# Status: decline-character
+
+## Last updated: 2026-06-21
+
+## Status
+IN_PROGRESS
+
+## Interface stable
+NO
+
+A lookahead-free classifier of the current market decline
+(`Slow_grind | Fast_v | Not_declining`) — the shared primitive that two later
+consumers read. Full design + rationale:
+`dev/notes/decline-character-exploration-2026-06-21-PM.md`.
+
+The classifier is **regime INSURANCE**, not a winner-touching / fat-tail-taxing
+lever (`memory/project_edge_is_the_fat_tail` endorses "winner-touching only as
+explicit tail-RISK insurance", which the Fast_v-armed absolute stop is). It is
+Weinstein-faithful: it encodes the book Ch. 8 A/D-lead breadth doctrine as a
+read-only dial, not a spine change. All builds default-off.
+
+## Build sequence
+
+- **Build 0** — A/D data wiring (feat-data; replace `~ad_bars:[]` in the
+  snapshot pipeline). Until it lands the A/D-lead leg is theory-only; the
+  rate-of-decline + weeks-below-MA legs work today.
+- **Build 1** — Decline-character classifier (THIS PR). New standalone
+  `trading/analysis/weinstein/macro/lib/decline_character.{ml,mli}`. Pure
+  `classify`; no consumer, changes no behaviour.
+- **Build 2** — Fast-crash absolute long stop, arms on `Fast_v`
+  (`stop_types` config `catastrophic_stop_pct`, default 0.0).
+- **Build 3** — Faithful short (Bearish-only + `Slow_grind` gate) in screener.
+
+## Completed
+
+- **Build 1 — classifier** (READY_FOR_REVIEW, PR feat/decline-character).
+  `Decline_character.classify ~config ~macro ~index_bars : t`. Reads the
+  already-computed `Macro.result` (index stage MA value/direction + "A-D Line"
+  indicator signal) plus weekly index bars (rate-of-decline drawdown,
+  trailing-high drawdown, weeks-below-falling-MA). All thresholds in a
+  `Decline_character.config` record with `default_config` (no magic numbers):
+  `ad_lead_max_drawdown_pct=0.10`, `rate_lookback_weeks=4`,
+  `slow_grind_max_rate_pct=0.04`, `fast_v_min_rate_pct=0.08`,
+  `weeks_below_ma_slow_grind=8`, `trailing_high_lookback_weeks=52`. 6 unit
+  tests (fast-V, slow-grind, rising-MA, close-above-declining-MA, empty bars,
+  ambiguous shallow dip). No core-module edits; no `Macro.result` /
+  `Macro.analyze` change (goldens untouched).
+
+## In progress
+
+- None (Build 1 awaiting QC + merge).
+
+## Next steps
+
+1. Merge Build 1 (classifier).
+2. **Build 0** — A/D data wiring (feat-data) `[non-blocking]` — makes the
+   A/D-lead leg real (today the indicator is `Neutral` with `~ad_bars:[]`).
+3. **Build 2** — fast-crash absolute stop (depends on Build 1).
+4. **Build 3** — faithful short (depends on Build 1).
+5. Read-only screens (screen-rigor) on wired data → WF-CV if promising →
+   promotion grid, before any default flip.
+
+## Follow-ups
+
+- None.

--- a/trading/analysis/weinstein/macro/lib/decline_character.ml
+++ b/trading/analysis/weinstein/macro/lib/decline_character.ml
@@ -1,0 +1,129 @@
+open Core
+open Types
+
+type t = Slow_grind | Fast_v | Not_declining [@@deriving show, eq, sexp]
+
+type config = {
+  ad_lead_max_drawdown_pct : float;
+  rate_lookback_weeks : int;
+  slow_grind_max_rate_pct : float;
+  fast_v_min_rate_pct : float;
+  weeks_below_ma_slow_grind : int;
+  trailing_high_lookback_weeks : int;
+}
+[@@deriving sexp]
+
+let default_config =
+  {
+    ad_lead_max_drawdown_pct = 0.10;
+    rate_lookback_weeks = 4;
+    slow_grind_max_rate_pct = 0.04;
+    fast_v_min_rate_pct = 0.08;
+    weeks_below_ma_slow_grind = 8;
+    trailing_high_lookback_weeks = 52;
+  }
+
+(* The most recent index close, or [None] when there are no bars. *)
+let _current_close (bars : Daily_price.t list) : float option =
+  List.last bars |> Option.map ~f:(fun b -> b.Daily_price.close_price)
+
+(* Drawdown over the trailing [lookback] bars as a positive fraction
+   [(close_lookback - close_now) / close_lookback]; negative when the index
+   rose. [None] when there are too few bars or the reference close is
+   non-positive. Lookahead-free: reads only the last bar and the bar [lookback]
+   weeks earlier. *)
+let _trailing_drawdown_pct (bars : Daily_price.t list) ~(lookback : int) :
+    float option =
+  let n = List.length bars in
+  if n <= lookback then None
+  else
+    let arr = Array.of_list bars in
+    let close i = arr.(i).Daily_price.close_price in
+    let now = close (n - 1) and ref_close = close (n - 1 - lookback) in
+    if Float.( <= ) ref_close 0.0 then None
+    else Some ((ref_close -. now) /. ref_close)
+
+(* Drawdown of the current close from the highest close over the trailing
+   [lookback] window (current bar inclusive), as a positive fraction. [None]
+   when there are no bars or the peak is non-positive. *)
+let _drawdown_from_trailing_high (bars : Daily_price.t list) ~(lookback : int) :
+    float option =
+  match List.last bars with
+  | None -> None
+  | Some last ->
+      let window = List.drop bars (Int.max 0 (List.length bars - lookback)) in
+      let peak =
+        List.fold window ~init:0.0 ~f:(fun acc b ->
+            Float.max acc b.Daily_price.close_price)
+      in
+      if Float.( <= ) peak 0.0 then None
+      else Some ((peak -. last.Daily_price.close_price) /. peak)
+
+(* Consecutive most-recent weeks whose close is below [ma_value]. Counts back
+   from the latest bar and stops at the first bar at/above the MA. *)
+let _weeks_below_ma (bars : Daily_price.t list) ~(ma_value : float) : int =
+  List.rev bars
+  |> List.take_while ~f:(fun b ->
+      Float.( < ) b.Daily_price.close_price ma_value)
+  |> List.length
+
+(* The current "A-D Line" indicator signal from the macro result, if present. *)
+let _ad_line_signal (macro : Macro.result) :
+    [ `Bullish | `Bearish | `Neutral ] option =
+  List.find macro.Macro.indicators ~f:(fun r ->
+      String.equal r.Macro.name "A-D Line")
+  |> Option.map ~f:(fun r -> r.Macro.signal)
+
+(* The A-D line is "leading" the index lower when breadth is bearish while the
+   index has not yet broken far from its trailing high. Weinstein's
+   distribution-lead signature (book Ch. 8). A missing/Neutral/Bullish A-D
+   reading is "not leading". *)
+let _ad_line_is_leading (macro : Macro.result) (bars : Daily_price.t list)
+    ~(config : config) : bool =
+  match _ad_line_signal macro with
+  | Some `Bearish -> (
+      match
+        _drawdown_from_trailing_high bars
+          ~lookback:config.trailing_high_lookback_weeks
+      with
+      | Some dd -> Float.( <= ) dd config.ad_lead_max_drawdown_pct
+      | None -> false)
+  | Some (`Bullish | `Neutral) | None -> false
+
+(* Is a decline in progress at all? The MA must be falling and the current
+   close below it. A rising/flat MA or a close above the MA is [Not_declining].
+*)
+let _is_declining (macro : Macro.result) (bars : Daily_price.t list) : bool =
+  let stage = macro.Macro.index_stage in
+  match stage.Stage.ma_direction with
+  | Weinstein_types.Declining -> (
+      match _current_close bars with
+      | Some close -> Float.( < ) close stage.Stage.ma_value
+      | None -> false)
+  | Weinstein_types.Rising | Weinstein_types.Flat -> false
+
+let _is_slow_grind (macro : Macro.result) (bars : Daily_price.t list)
+    ~(config : config) ~(rate_pct : float) : bool =
+  let leading = _ad_line_is_leading macro bars ~config in
+  let grind_below_ma =
+    _weeks_below_ma bars ~ma_value:macro.Macro.index_stage.Stage.ma_value
+    >= config.weeks_below_ma_slow_grind
+    && Float.( < ) rate_pct config.slow_grind_max_rate_pct
+  in
+  leading || grind_below_ma
+
+let classify ~(config : config) ~(macro : Macro.result)
+    ~(index_bars : Daily_price.t list) : t =
+  if not (_is_declining macro index_bars) then Not_declining
+  else
+    let rate_pct =
+      Option.value
+        (_trailing_drawdown_pct index_bars ~lookback:config.rate_lookback_weeks)
+        ~default:0.0
+    in
+    if _is_slow_grind macro index_bars ~config ~rate_pct then Slow_grind
+    else if
+      (not (_ad_line_is_leading macro index_bars ~config))
+      && Float.( > ) rate_pct config.fast_v_min_rate_pct
+    then Fast_v
+    else Not_declining

--- a/trading/analysis/weinstein/macro/lib/decline_character.ml
+++ b/trading/analysis/weinstein/macro/lib/decline_character.ml
@@ -27,11 +27,17 @@ let default_config =
 let _current_close (bars : Daily_price.t list) : float option =
   List.last bars |> Option.map ~f:(fun b -> b.Daily_price.close_price)
 
-(* Drawdown over the trailing [lookback] bars as a positive fraction
-   [(close_lookback - close_now) / close_lookback]; negative when the index
-   rose. [None] when there are too few bars or the reference close is
-   non-positive. Lookahead-free: reads only the last bar and the bar [lookback]
-   weeks earlier. *)
+(* Positive drawdown [(reference - now) / reference] given a [reference] and
+   [now] close; negative when the index rose. [None] when [reference] is
+   non-positive. A single-[if] helper so its callers stay flat. *)
+let _drawdown_fraction ~(reference : float) ~(now : float) : float option =
+  if Float.( <= ) reference 0.0 then None
+  else Some ((reference -. now) /. reference)
+
+(* Drawdown over the trailing [lookback] bars as a positive fraction relative to
+   the close [lookback] weeks earlier. [None] when there are too few bars or the
+   reference close is non-positive. Lookahead-free: reads only the last bar and
+   the bar [lookback] weeks earlier. *)
 let _trailing_drawdown_pct (bars : Daily_price.t list) ~(lookback : int) :
     float option =
   let n = List.length bars in
@@ -39,25 +45,25 @@ let _trailing_drawdown_pct (bars : Daily_price.t list) ~(lookback : int) :
   else
     let arr = Array.of_list bars in
     let close i = arr.(i).Daily_price.close_price in
-    let now = close (n - 1) and ref_close = close (n - 1 - lookback) in
-    if Float.( <= ) ref_close 0.0 then None
-    else Some ((ref_close -. now) /. ref_close)
+    _drawdown_fraction
+      ~reference:(close (n - 1 - lookback))
+      ~now:(close (n - 1))
+
+(* Highest close over the trailing [lookback] window (current bar inclusive). *)
+let _trailing_peak_close (bars : Daily_price.t list) ~(lookback : int) : float =
+  let window = List.drop bars (Int.max 0 (List.length bars - lookback)) in
+  List.fold window ~init:0.0 ~f:(fun acc b ->
+      Float.max acc b.Daily_price.close_price)
 
 (* Drawdown of the current close from the highest close over the trailing
-   [lookback] window (current bar inclusive), as a positive fraction. [None]
-   when there are no bars or the peak is non-positive. *)
+   [lookback] window, as a positive fraction. [None] when there are no bars or
+   the peak is non-positive. *)
 let _drawdown_from_trailing_high (bars : Daily_price.t list) ~(lookback : int) :
     float option =
-  match List.last bars with
+  match _current_close bars with
   | None -> None
-  | Some last ->
-      let window = List.drop bars (Int.max 0 (List.length bars - lookback)) in
-      let peak =
-        List.fold window ~init:0.0 ~f:(fun acc b ->
-            Float.max acc b.Daily_price.close_price)
-      in
-      if Float.( <= ) peak 0.0 then None
-      else Some ((peak -. last.Daily_price.close_price) /. peak)
+  | Some now ->
+      _drawdown_fraction ~reference:(_trailing_peak_close bars ~lookback) ~now
 
 (* Consecutive most-recent weeks whose close is below [ma_value]. Counts back
    from the latest bar and stops at the first bar at/above the MA. *)
@@ -74,6 +80,11 @@ let _ad_line_signal (macro : Macro.result) :
       String.equal r.Macro.name "A-D Line")
   |> Option.map ~f:(fun r -> r.Macro.signal)
 
+(* A trailing-high drawdown shallow enough that breadth is judged to be leading
+   price lower (the index has not yet broken far from its high). *)
+let _within_lead_band ~(config : config) (dd : float) : bool =
+  Float.( <= ) dd config.ad_lead_max_drawdown_pct
+
 (* The A-D line is "leading" the index lower when breadth is bearish while the
    index has not yet broken far from its trailing high. Weinstein's
    distribution-lead signature (book Ch. 8). A missing/Neutral/Bullish A-D
@@ -81,14 +92,11 @@ let _ad_line_signal (macro : Macro.result) :
 let _ad_line_is_leading (macro : Macro.result) (bars : Daily_price.t list)
     ~(config : config) : bool =
   match _ad_line_signal macro with
-  | Some `Bearish -> (
-      match
-        _drawdown_from_trailing_high bars
-          ~lookback:config.trailing_high_lookback_weeks
-      with
-      | Some dd -> Float.( <= ) dd config.ad_lead_max_drawdown_pct
-      | None -> false)
   | Some (`Bullish | `Neutral) | None -> false
+  | Some `Bearish ->
+      _drawdown_from_trailing_high bars
+        ~lookback:config.trailing_high_lookback_weeks
+      |> Option.exists ~f:(_within_lead_band ~config)
 
 (* Is a decline in progress at all? The MA must be falling and the current
    close below it. A rising/flat MA or a close above the MA is [Not_declining].
@@ -96,11 +104,10 @@ let _ad_line_is_leading (macro : Macro.result) (bars : Daily_price.t list)
 let _is_declining (macro : Macro.result) (bars : Daily_price.t list) : bool =
   let stage = macro.Macro.index_stage in
   match stage.Stage.ma_direction with
-  | Weinstein_types.Declining -> (
-      match _current_close bars with
-      | Some close -> Float.( < ) close stage.Stage.ma_value
-      | None -> false)
   | Weinstein_types.Rising | Weinstein_types.Flat -> false
+  | Weinstein_types.Declining ->
+      _current_close bars
+      |> Option.exists ~f:(fun close -> Float.( < ) close stage.Stage.ma_value)
 
 let _is_slow_grind (macro : Macro.result) (bars : Daily_price.t list)
     ~(config : config) ~(rate_pct : float) : bool =
@@ -112,18 +119,28 @@ let _is_slow_grind (macro : Macro.result) (bars : Daily_price.t list)
   in
   leading || grind_below_ma
 
+(* A fast-V shock: breadth is NOT leading the decline (no distribution warning)
+   and the recent rate-of-decline is steep. *)
+let _is_fast_v (macro : Macro.result) (bars : Daily_price.t list)
+    ~(config : config) ~(rate_pct : float) : bool =
+  (not (_ad_line_is_leading macro bars ~config))
+  && Float.( > ) rate_pct config.fast_v_min_rate_pct
+
+(* Classify a decline already known to be in progress. Kept separate from
+   {!classify} so neither function carries a nested [else]. *)
+let _classify_declining (macro : Macro.result) (bars : Daily_price.t list)
+    ~(config : config) : t =
+  let rate_pct =
+    Option.value
+      (_trailing_drawdown_pct bars ~lookback:config.rate_lookback_weeks)
+      ~default:0.0
+  in
+  match _is_slow_grind macro bars ~config ~rate_pct with
+  | true -> Slow_grind
+  | false ->
+      if _is_fast_v macro bars ~config ~rate_pct then Fast_v else Not_declining
+
 let classify ~(config : config) ~(macro : Macro.result)
     ~(index_bars : Daily_price.t list) : t =
   if not (_is_declining macro index_bars) then Not_declining
-  else
-    let rate_pct =
-      Option.value
-        (_trailing_drawdown_pct index_bars ~lookback:config.rate_lookback_weeks)
-        ~default:0.0
-    in
-    if _is_slow_grind macro index_bars ~config ~rate_pct then Slow_grind
-    else if
-      (not (_ad_line_is_leading macro index_bars ~config))
-      && Float.( > ) rate_pct config.fast_v_min_rate_pct
-    then Fast_v
-    else Not_declining
+  else _classify_declining macro index_bars ~config

--- a/trading/analysis/weinstein/macro/lib/decline_character.mli
+++ b/trading/analysis/weinstein/macro/lib/decline_character.mli
@@ -1,0 +1,110 @@
+open Types
+
+(** Decline-character classifier — a pure, lookahead-free read-only signal that
+    labels the {b current} character of a market decline.
+
+    This is the shared primitive of the decline-character build sequence
+    (dev/notes/decline-character-exploration-2026-06-21-PM.md). Two later
+    consumers read it:
+    - {b slow-grind → faithful short}: a sustained distribution bear is the
+      regime Weinstein sanctions shorting into (book Ch. 8, 11).
+    - {b fast-V → tight absolute long stop}: a fast crash is the tail-RISK the
+      structural MA/correction-low trailing stop misses (it trails a distant
+      correction low and re-checks only weekly, so longs exit at the bottom —
+      the 2020 problem). Arming a tight absolute stop only on [Fast_v] keeps it
+      dormant in normal bull chop, so it does not tax the let-winners-run fat
+      tail (the sanctioned tail-RISK-insurance exception).
+
+    {b Faithfulness}: this encodes Weinstein's Advance-Decline-lead breadth
+    doctrine (book Ch. 8 — in a genuine distribution top the A/D line peaks and
+    rolls over while the index is still near its highs; a fast V-crash gives no
+    such breadth lead) as a read-only dial, not a spine change. It buys/sells
+    nothing on its own — it changes no behaviour until a consumer reads it.
+
+    {b Lookahead-free}: every input is computed from the [Macro.result] for the
+    current week plus index bars at the current week or earlier. No future bar
+    is ever read.
+
+    All functions are pure: same inputs always produce the same output. *)
+
+type t =
+  | Slow_grind
+      (** A sustained distribution decline: the A-D line is {b leading} the
+          index lower (breadth bearish while price has not yet broken far from
+          its high), OR the index has spent many consecutive weeks below a
+          falling MA at a shallow rate. The faithful-short regime. *)
+  | Fast_v
+      (** A fast V-shaped crash: breadth is {b not} leading (the A-D line
+          collapses with the index, no lead) and the index falls steeply over a
+          short window. The tight-absolute-stop regime. *)
+  | Not_declining
+      (** The tape is not in a decline (e.g. the MA is rising, or the current
+          close is not below a falling MA). Neither consumer arms. *)
+[@@deriving show, eq, sexp]
+
+type config = {
+  ad_lead_max_drawdown_pct : float;
+      (** How far below its trailing high the index may be and still count the
+          A-D line as {b leading} it (breadth bearish before price has broken
+          down). A drawdown shallower than this with a bearish A-D line is the
+          distribution-lead signature. Default: 0.10 (within 10% of the high).
+      *)
+  rate_lookback_weeks : int;
+      (** Trailing window (weeks) over which the rate-of-decline drawdown is
+          measured: [(close_lookback - close_now) / close_lookback]. Default: 4.
+      *)
+  slow_grind_max_rate_pct : float;
+      (** Upper bound on the per-window {b drawdown} magnitude (positive
+          fraction, e.g. 0.04 = 4% over the window) for the decline to count as
+          a shallow grind on the weeks-below-MA leg. Default: 0.04. *)
+  fast_v_min_rate_pct : float;
+      (** Lower bound on the per-window drawdown magnitude (positive fraction)
+          for the decline to count as a steep fast-V crash. Default: 0.08. *)
+  weeks_below_ma_slow_grind : int;
+      (** Minimum consecutive weeks the index close has been below a {b falling}
+          MA to call a shallow decline a slow grind. Default: 8. *)
+  trailing_high_lookback_weeks : int;
+      (** Window (weeks) over which the trailing index high is taken for the
+          A-D-lead drawdown comparison. Default: 52 (~1 year). *)
+}
+[@@deriving sexp]
+(** Tunable thresholds for {!classify}. Every threshold is a config field (no
+    hardcoded magic numbers) so the signal is gridable as a [Variant_matrix]
+    axis once a consumer wires it. Defaults reflect the illustrative thresholds
+    in the exploration note: weeks-below-MA ≥ 8, drawdown < 4%/window = shallow,
+    > 8%/window = steep, A-D-lead while index within ~10% of its high. *)
+
+val default_config : config
+(** [default_config] returns the exploration-note reference thresholds. *)
+
+val classify :
+  config:config -> macro:Macro.result -> index_bars:Daily_price.t list -> t
+(** [classify ~config ~macro ~index_bars] labels the current decline character.
+
+    @param macro
+      The already-computed macro result for the current week. Its
+      [index_stage.ma_value] / [index_stage.ma_direction] give the MA level and
+      slope, and its [indicators] list carries the "A-D Line" reading whose
+      [`Bearish] / [`Bullish] / [`Neutral] signal drives the A/D-lead leg. A
+      missing or [`Neutral] A-D reading means "no breadth lead" (treated as not
+      leading) — faithful to the current [~ad_bars:[]] wiring where the
+      indicator is [`Neutral] until breadth data lands (Build 0).
+    @param index_bars
+      Weekly bars for the primary index, chronological oldest-first. Read at the
+      current week (last bar) and earlier offsets only — never the future. Used
+      to compute the rate-of-decline drawdown, the trailing-high drawdown, and
+      the weeks-below-falling-MA count.
+
+    Classification rule (thresholds from [config]):
+    - {!Not_declining} when the MA is rising, or the current close is not below
+      a falling MA at all (no decline in progress).
+    - {!Slow_grind} when the A-D line is leading (A-D [`Bearish] while the index
+      is still within [ad_lead_max_drawdown_pct] of its trailing high), OR
+      (weeks-below-falling-MA ≥ [weeks_below_ma_slow_grind] AND the drawdown
+      magnitude over [rate_lookback_weeks] < [slow_grind_max_rate_pct]).
+    - {!Fast_v} when the A-D line is not leading AND the drawdown magnitude over
+      [rate_lookback_weeks] > [fast_v_min_rate_pct].
+    - {!Not_declining} otherwise (an ambiguous shallow dip with no qualifying
+      grind or crash signal).
+
+    Pure and lookahead-free. *)

--- a/trading/analysis/weinstein/macro/test/dune
+++ b/trading/analysis/weinstein/macro/test/dune
@@ -1,6 +1,6 @@
 (tests
- (names test_macro test_ad_bars_aggregation)
- (modules test_macro test_ad_bars_aggregation)
+ (names test_macro test_ad_bars_aggregation test_decline_character)
+ (modules test_macro test_ad_bars_aggregation test_decline_character)
  (libraries macro weinstein_types stage types core ounit2 matchers))
 
 (test

--- a/trading/analysis/weinstein/macro/test/test_decline_character.ml
+++ b/trading/analysis/weinstein/macro/test/test_decline_character.ml
@@ -1,0 +1,150 @@
+open OUnit2
+open Core
+open Matchers
+open Types
+
+let cfg = Decline_character.default_config
+
+(* ------------------------------------------------------------------ *)
+(* Inline fixture builders                                             *)
+(* ------------------------------------------------------------------ *)
+
+let make_bar date close =
+  {
+    Daily_price.date = Date.of_string date;
+    open_price = close;
+    high_price = close *. 1.01;
+    low_price = close *. 0.99;
+    close_price = close;
+    adjusted_close = close;
+    volume = 100_000;
+    active_through = None;
+  }
+
+(* Weekly bars from a price list, 7 days apart starting 2020-01-06. *)
+let weekly_bars prices =
+  let base = Date.of_string "2020-01-06" in
+  List.mapi prices ~f:(fun i p ->
+      make_bar (Date.to_string (Date.add_days base (i * 7))) p)
+
+(* An "A-D Line" indicator reading with the given signal. *)
+let ad_line signal : Macro.indicator_reading =
+  { name = "A-D Line"; signal; weight = 2.0; detail = "test" }
+
+(* A stage result carrying just the fields the classifier reads. *)
+let stage_result ~ma_value ~ma_direction : Stage.result =
+  {
+    stage = Weinstein_types.Stage4 { weeks_declining = 1 };
+    ma_value;
+    ma_direction;
+    ma_slope_pct = 0.0;
+    transition = None;
+    above_ma_count = 0;
+  }
+
+(* A macro result with the given index stage and A-D Line reading. *)
+let macro_result ~ma_value ~ma_direction ~ad_signal : Macro.result =
+  {
+    index_stage = stage_result ~ma_value ~ma_direction;
+    indicators = [ ad_line ad_signal ];
+    trend = Weinstein_types.Bearish;
+    confidence = 0.2;
+    regime_changed = false;
+    rationale = [];
+  }
+
+(* ------------------------------------------------------------------ *)
+(* Tests                                                               *)
+(* ------------------------------------------------------------------ *)
+
+(* A sharp V-crash: index plunges steeply over the last 4 weeks below a falling
+   MA, A-D line collapses WITH the index (Neutral/Bearish-but-deep, no lead). *)
+let test_fast_v _ =
+  (* 60 flat weeks at 100, then a steep 4-week plunge to ~75 (~25% drop). *)
+  let prices = List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 92.0; 84.0; 75.0 ] in
+  let index_bars = weekly_bars prices in
+  (* MA above the crashed close, declining; A-D Bearish but index already
+     down >10% from its high, so NOT leading. *)
+  let macro =
+    macro_result ~ma_value:98.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Bearish
+  in
+  assert_that
+    (Decline_character.classify ~config:cfg ~macro ~index_bars)
+    (equal_to Decline_character.Fast_v)
+
+(* A slow grind: shallow decline, many weeks below a falling MA, A-D diverged
+   (leading) while the index is still close to its high. *)
+let test_slow_grind _ =
+  (* Long shallow drift down: 100 down to ~96 over 20 weeks (each week below
+     the MA), only a ~1% drop over any 4-week window. *)
+  let prices = List.init 20 ~f:(fun i -> 100.0 -. (Float.of_int i *. 0.2)) in
+  let index_bars = weekly_bars prices in
+  let macro =
+    macro_result ~ma_value:101.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Bearish
+  in
+  assert_that
+    (Decline_character.classify ~config:cfg ~macro ~index_bars)
+    (equal_to Decline_character.Slow_grind)
+
+(* A rising-MA / near-high tape: not declining at all. *)
+let test_not_declining_rising_ma _ =
+  let prices = List.init 30 ~f:(fun i -> 100.0 +. (Float.of_int i *. 1.0)) in
+  let index_bars = weekly_bars prices in
+  let macro =
+    macro_result ~ma_value:110.0 ~ma_direction:Weinstein_types.Rising
+      ~ad_signal:`Bullish
+  in
+  assert_that
+    (Decline_character.classify ~config:cfg ~macro ~index_bars)
+    (equal_to Decline_character.Not_declining)
+
+(* Close above a declining MA is also Not_declining (no decline in progress). *)
+let test_not_declining_above_ma _ =
+  let prices = List.init 30 ~f:(fun _ -> 120.0) in
+  let index_bars = weekly_bars prices in
+  let macro =
+    macro_result ~ma_value:100.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Neutral
+  in
+  assert_that
+    (Decline_character.classify ~config:cfg ~macro ~index_bars)
+    (equal_to Decline_character.Not_declining)
+
+(* Edge: empty bars never crash and yield Not_declining. *)
+let test_empty_bars _ =
+  let macro =
+    macro_result ~ma_value:100.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Bearish
+  in
+  assert_that
+    (Decline_character.classify ~config:cfg ~macro ~index_bars:[])
+    (equal_to Decline_character.Not_declining)
+
+(* Edge: shallow decline below a falling MA but too few weeks below it and no
+   A-D lead → ambiguous → Not_declining (neither grind nor crash). *)
+let test_ambiguous_shallow_dip _ =
+  (* Just dipped below the MA for 2 weeks, shallow, no A-D lead. *)
+  let prices = List.init 10 ~f:(fun _ -> 100.0) @ [ 99.0; 98.5 ] in
+  let index_bars = weekly_bars prices in
+  let macro =
+    macro_result ~ma_value:100.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Neutral
+  in
+  assert_that
+    (Decline_character.classify ~config:cfg ~macro ~index_bars)
+    (equal_to Decline_character.Not_declining)
+
+let suite =
+  "decline_character"
+  >::: [
+         "fast_v" >:: test_fast_v;
+         "slow_grind" >:: test_slow_grind;
+         "not_declining_rising_ma" >:: test_not_declining_rising_ma;
+         "not_declining_above_ma" >:: test_not_declining_above_ma;
+         "empty_bars" >:: test_empty_bars;
+         "ambiguous_shallow_dip" >:: test_ambiguous_shallow_dip;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Build 1 of the decline-character sequence (`dev/notes/decline-character-exploration-2026-06-21-PM.md`): a pure, lookahead-free classifier of the **current** market decline. New standalone module `trading/analysis/weinstein/macro/lib/decline_character.{ml,mli}`.

```ocaml
type t = Slow_grind | Fast_v | Not_declining [@@deriving show, eq, sexp]
val classify : config:config -> macro:Macro.result -> index_bars:Daily_price.t list -> t
```

**This PR builds ONLY the classifier** — no consumers, no behaviour change anywhere. It reads the already-computed `Macro.result` (index-stage MA value/direction + the "A-D Line" indicator signal) plus weekly index bars, and computes three signals:

- **A/D-lead** (faithful to Weinstein Ch. 8 breadth doctrine): the "A-D Line" indicator is `` `Bearish `` while the index is still within `ad_lead_max_drawdown_pct` of its trailing high → breadth is leading price lower (distribution-top signature). A missing/`` `Neutral `` A-D reading = not leading (faithful to the current `~ad_bars:[]` wiring where the indicator is `` `Neutral `` until Build 0 lands).
- **rate-of-decline**: trailing-`rate_lookback_weeks` drawdown magnitude.
- **weeks-below-falling-MA**: consecutive recent weeks the close is below the MA.

Rule: `Not_declining` unless the MA is declining AND the close is below it; then `Slow_grind` if A/D is leading OR (weeks-below-MA ≥ threshold AND shallow rate); `Fast_v` if A/D not leading AND steep rate; else `Not_declining`.

## Config (default-off primitive; all thresholds, no magic numbers)

`Decline_character.config` + `default_config`, `[@@deriving sexp]` so it is `Variant_matrix`-gridable once a consumer wires it:

| field | default |
|---|---|
| `ad_lead_max_drawdown_pct` | 0.10 |
| `rate_lookback_weeks` | 4 |
| `slow_grind_max_rate_pct` | 0.04 |
| `fast_v_min_rate_pct` | 0.08 |
| `weeks_below_ma_slow_grind` | 8 |
| `trailing_high_lookback_weeks` | 52 |

## Discipline

- **Pure + lookahead-free** — reads only the current week and earlier bars.
- **No core-module edits** (Portfolio/Orders/Position/Strategy/Engine/Simulator). New file in the macro analysis lib only.
- **`Macro.result` / `Macro.analyze` untouched** — added as a sibling function so macro goldens/parity tests are not churned.
- **Weinstein-faithful**: encodes the A/D-lead breadth doctrine (book Ch. 8) as a read-only dial, not a spine change. Regime INSURANCE per `edge_is_the_fat_tail` (the Fast_v-armed absolute stop is the sanctioned tail-RISK exception). Changes no behaviour until a consumer reads it.

## Test plan

`test_decline_character.ml` (6 OUnit2 tests, inline synthetic fixtures, one `assert_that` per value):
- fast-V crash (steep rate, A-D collapses with index, no lead) → `Fast_v`
- slow-grind (shallow rate, many weeks below falling MA, A-D leading) → `Slow_grind`
- rising-MA near-high tape → `Not_declining`
- close above a declining MA → `Not_declining`
- empty bars (no crash) → `Not_declining`
- ambiguous shallow dip → `Not_declining`

`dune build` + the new tests pass (exit 0). Pre-existing `test_macro_e2e` failures are unrelated (fail identically on the clean main checkout; main CI is green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)