### PR TITLE
feat(stops): fast-crash absolute stop, armed on Fast_v decline (default-off)

### DIFF
--- a/dev/status/decline-character.md
+++ b/dev/status/decline-character.md
@@ -1,6 +1,6 @@
 # Status: decline-character
 
-## Last updated: 2026-06-21
+## Last updated: 2026-06-22
 
 ## Status
 IN_PROGRESS
@@ -33,7 +33,7 @@ read-only dial, not a spine change. All builds default-off.
 
 ## Completed
 
-- **Build 1 — classifier** (READY_FOR_REVIEW, PR feat/decline-character).
+- **Build 1 — classifier** (MERGED, PR #1692).
   `Decline_character.classify ~config ~macro ~index_bars : t`. Reads the
   already-computed `Macro.result` (index stage MA value/direction + "A-D Line"
   indicator signal) plus weekly index bars (rate-of-decline drawdown,
@@ -42,9 +42,36 @@ read-only dial, not a spine change. All builds default-off.
   `ad_lead_max_drawdown_pct=0.10`, `rate_lookback_weeks=4`,
   `slow_grind_max_rate_pct=0.04`, `fast_v_min_rate_pct=0.08`,
   `weeks_below_ma_slow_grind=8`, `trailing_high_lookback_weeks=52`. 6 unit
-  tests (fast-V, slow-grind, rising-MA, close-above-declining-MA, empty bars,
-  ambiguous shallow dip). No core-module edits; no `Macro.result` /
-  `Macro.analyze` change (goldens untouched).
+  tests. No core-module edits; no `Macro.result` / `Macro.analyze` change.
+
+- **Build 2 — fast-crash absolute stop** (READY_FOR_REVIEW, PR
+  feat/fast-crash-stop). Default-off `stops_config.catastrophic_stop_pct`
+  (`[@sexp.default 0.0]`, exact no-op) in `stop_types.{ml,mli}`. New
+  macro-AGNOSTIC `Catastrophic_stop.{ml,mli}` in the stops lib (re-exported as
+  `Weinstein_stops.Catastrophic_stop`): `trailing_high_of_state` (reads the stop
+  state's `last_trend_extreme`) + `check_hit ~armed ~pct ~trailing_high ~bar
+  ~side`. OR'd into the trigger decision in `stops_runner.ml` via a new optional
+  `?catastrophic_armed:bool` (default false → no-op) on `Stops_runner.update`.
+  The `Fast_v → armed` decision is made in the strategy lib: a new
+  `prior_decline_character` ref is classified at the macro step (via
+  `Decline_character_wiring.{classify,update_ref}`, converting the weekly index
+  view to bars) and read STRICTLY PRIOR by the next tick's stops pass —
+  lookahead-free, mirroring the `prior_macro_result` pattern. Stops lib stays
+  macro-agnostic (no `macro` dep added — A2). No core-module edits. To keep
+  `weinstein_stops.ml` / `weinstein_strategy.ml` under the 500-line @large cap
+  and `_process_market_day` under the 50-line fn cap (both were pre-maxed), the
+  PR carries proportionate code-health extractions: the trigger lives in its own
+  `Catastrophic_stop` module; the exit-audit-list helper moved to its natural
+  home `Exit_audit_capture.emit_for_list`; the transition-assembly + exited-id
+  helpers moved to a new pure `Transition_assembly` module; and the dials+entries
+  tail of `_process_market_day` became `_run_dials_and_entries`.
+  Tests: 8 in `test_weinstein_stops.ml` (helper both sides + no-op at
+  armed=false / pct=0 + `trailing_high_of_state`), 3 in `test_stops_runner.ml`
+  (armed+pct>0 → TriggerExit; armed=false → no exit; pct=0 → no exit). Threshold
+  config for the classifier is `Decline_character.default_config` for now; the
+  searchable mechanism axis is `catastrophic_stop_pct` (a real
+  `Weinstein_strategy.config` `stops_config.*` float field →
+  Variant_matrix-searchable per R2, same as `vol_scaled_stop_atr_mult`).
 
 ## In progress
 
@@ -52,12 +79,13 @@ read-only dial, not a spine change. All builds default-off.
 
 ## Next steps
 
-1. Merge Build 1 (classifier).
+1. Merge Build 2 (fast-crash absolute stop, PR feat/fast-crash-stop).
 2. **Build 0** — A/D data wiring (feat-data) `[non-blocking]` — makes the
    A/D-lead leg real (today the indicator is `Neutral` with `~ad_bars:[]`).
-3. **Build 2** — fast-crash absolute stop (depends on Build 1).
-4. **Build 3** — faithful short (depends on Build 1).
-5. Read-only screens (screen-rigor) on wired data → WF-CV if promising →
+3. **Build 3** — faithful short (Bearish-only + `Slow_grind` gate in screener;
+   depends on Build 1, on main).
+4. Read-only screens (screen-rigor) on the `catastrophic_stop_pct` surface
+   (and the 2020 fast-crash scenario specifically) → WF-CV if promising →
    promotion grid, before any default flip.
 
 ## Follow-ups

--- a/trading/trading/weinstein/stops/lib/catastrophic_stop.ml
+++ b/trading/trading/weinstein/stops/lib/catastrophic_stop.ml
@@ -1,0 +1,18 @@
+open Core
+open Trading_base.Types
+open Stop_types
+
+let trailing_high_of_state = function
+  | Trailing { last_trend_extreme; _ } -> Some last_trend_extreme
+  | Initial _ | Tightened _ -> None
+
+let check_hit ~armed ~pct ~trailing_high ~bar ~side =
+  if (not armed) || Float.( <= ) pct 0.0 then false
+  else
+    match side with
+    | Long ->
+        Float.( <= ) bar.Types.Daily_price.low_price
+          (trailing_high *. (1.0 -. pct))
+    | Short ->
+        Float.( >= ) bar.Types.Daily_price.high_price
+          (trailing_high *. (1.0 +. pct))

--- a/trading/trading/weinstein/stops/lib/catastrophic_stop.mli
+++ b/trading/trading/weinstein/stops/lib/catastrophic_stop.mli
@@ -1,0 +1,47 @@
+(** Fast-crash absolute stop (Build 2,
+    dev/notes/decline-character-exploration-2026-06-21-PM.md).
+
+    An {b absolute} drop from the position's trailing high that fires faster
+    than the structural MA/correction-low trailing stop in a fast crash. It is
+    explicit tail-RISK insurance, dormant ([~armed = false]) in normal times, so
+    it does not tax the let-winners-run fat tail
+    ([.claude/rules/weinstein-faithful-core.md]). Gated on the
+    [Stop_types.config.catastrophic_stop_pct] knob; default [0.0] is an exact
+    no-op.
+
+    This lib stays macro-AGNOSTIC: the [Slow_grind | Fast_v] decision is made
+    one level up in the strategy lib and passed in as a plain [~armed:bool]. *)
+
+open Trading_base.Types
+
+val trailing_high_of_state : Stop_types.stop_state -> float option
+(** [Some] the stop state's trailing high — the rally peak for a long, the
+    decline trough for a short ([last_trend_extreme]). Only
+    {!Stop_types.Trailing} carries one; {!Stop_types.Initial} and
+    {!Stop_types.Tightened} return [None] (no trend leg has been tracked yet).
+    This is the [trailing_high] input to {!check_hit}: when it is [None] the
+    fast-crash absolute stop is dormant for that position. *)
+
+val check_hit :
+  armed:bool ->
+  pct:float ->
+  trailing_high:float ->
+  bar:Types.Daily_price.t ->
+  side:position_side ->
+  bool
+(** [true] when the fast-crash absolute stop fires for this bar.
+
+    Returns [false] (no-op) unless {b both}:
+    - [armed] is [true] — the position's market is in a fast-V decline. The
+      arming decision is made in the strategy lib (from
+      {!Decline_character.Fast_v}) so this lib stays macro-agnostic. [armed]
+      defaults to [false] at every existing call site, so the mechanism is
+      dormant by default.
+    - [pct > 0.0] — the [Stop_types.config.catastrophic_stop_pct] knob is
+      enabled. At the default [0.0] the stop never fires.
+
+    When both hold, fires when a long's [bar.low ≤ trailing_high *. (1. -. pct)]
+    or a short's [bar.high ≥ trailing_high *. (1. +. pct)] — the intra-bar
+    extreme in the against-position direction, mirroring the GTC structural
+    stop's intra-bar trigger. Pure: same inputs always produce the same result.
+*)

--- a/trading/trading/weinstein/stops/lib/stop_types.ml
+++ b/trading/trading/weinstein/stops/lib/stop_types.ml
@@ -46,6 +46,7 @@ type config = {
   vol_scaled_stop_atr_mult : float; [@sexp.default 0.0]
   vol_scaled_stop_atr_period : int;
       [@sexp.default default_vol_scaled_stop_atr_period]
+  catastrophic_stop_pct : float; [@sexp.default 0.0]
 }
 [@@deriving show, eq, sexp]
 
@@ -62,4 +63,5 @@ let default_config =
     trigger_on_weekly_close = false;
     vol_scaled_stop_atr_mult = 0.0;
     vol_scaled_stop_atr_period = default_vol_scaled_stop_atr_period;
+    catastrophic_stop_pct = 0.0;
   }

--- a/trading/trading/weinstein/stops/lib/stop_types.mli
+++ b/trading/trading/weinstein/stops/lib/stop_types.mli
@@ -151,6 +151,36 @@ type config = {
       (** ATR lookback period (in daily bars) for [vol_scaled_stop_atr_mult].
           Consulted only when [vol_scaled_stop_atr_mult > 0.0]; the standard
           Wilder 14-day period (see {!Atr.atr}). *)
+  catastrophic_stop_pct : float; [@sexp.default 0.0]
+      (** Fast-crash {b absolute} stop distance from the position's trailing
+          high, as a positive fraction (default-off). When [> 0.0] {b and} the
+          position's market is in a fast-V decline (the [~armed] flag, decided
+          one level up in the strategy lib from {!Decline_character.Fast_v}), a
+          long's stop fires when
+          [bar.low ≤ trailing_high *. (1. -. catastrophic_stop_pct)] and a
+          short's when
+          [bar.high ≥ trailing_high *. (1. +. catastrophic_stop_pct)], where
+          [trailing_high] is the stop state's [last_trend_extreme] (the rally
+          peak for a long, the decline trough for a short). The check ORs into
+          the existing structural trigger — whichever fires first exits.
+
+          Why: the structural MA/correction-low trailing stop trails a distant
+          prior correction and re-checks only weekly, so in a fast crash (2020)
+          longs exit 3-4 weeks late, at the bottom, eating the full drawdown. An
+          absolute drop-% stop from the trailing high caps that fast-crash loss
+          the structural stop misses (design
+          [dev/notes/decline-character-exploration-2026-06-21-PM.md] §Build 2).
+
+          Faithful-core: this is explicit {b tail-RISK insurance}, not an
+          always-on tight stop. It is {e dormant} ([~armed = false]) in normal
+          bull chop, so it does not tax the let-winners-run fat tail (the
+          sanctioned exception in [.claude/rules/weinstein-faithful-core.md] —
+          winner-touching only as explicit tail-RISK insurance). It arms only
+          when the macro tape is a fast-V crash. Default [0.0] is an exact no-op
+          (the trigger is gated on [pct > 0.0]) so every existing golden replays
+          unchanged. Default-off experiment axis per
+          [.claude/rules/experiment-flag-discipline.md]; promoted only on a
+          ledger ACCEPT. *)
 }
 [@@deriving show, eq, sexp]
 (** Configuration for stop management behavior. All thresholds are configurable

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.ml
@@ -7,6 +7,7 @@ module Support_floor = Support_floor
 module Stop_split_adjust = Stop_split_adjust
 module Stop_widen = Stop_widen
 module Vol_scaled_stop = Vol_scaled_stop
+module Catastrophic_stop = Catastrophic_stop
 
 (* Round-number nudging lives in {!Stop_nudge} (extracted to keep this
    coordinator under the file-length cap). This adapts it to the stops config's

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.mli
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.mli
@@ -35,6 +35,11 @@ module Vol_scaled_stop = Vol_scaled_stop
     in proportion to the candidate's ATR. See the module doc for the contract.
 *)
 
+module Catastrophic_stop = Catastrophic_stop
+(** Fast-crash absolute stop (default-off, [config.catastrophic_stop_pct]).
+    Macro-agnostic trigger armed only in a fast-V decline. See the module doc
+    for the contract. *)
+
 (** {1 Core Functions} *)
 
 val compute_initial_stop :

--- a/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/test/test_weinstein_stops.ml
@@ -598,9 +598,110 @@ let test_no_phantom_cycle_on_continuous_advance _ =
          | Trailing { correction_count; _ } -> Some correction_count | _ -> None)
        (equal_to 1))
 
+(* ---- Catastrophic_stop.check_hit tests ----
+   Fast-crash absolute stop (Build 2). With trailing_high=100.0 and pct=0.10:
+   - Long fires when bar.low <= 90.0; Short fires when bar.high >= 110.0.
+   The predicate is a no-op (false) when armed=false or pct<=0.0. *)
+
+let test_catastrophic_hit_long_fires_when_armed _ =
+  (* low 89 breaches 100*(1-0.10)=90 → fires when armed. *)
+  let bar = make_bar ~low_price:89.0 ~high_price:95.0 () in
+  assert_that
+    (Catastrophic_stop.check_hit ~armed:true ~pct:0.10 ~trailing_high:100.0 ~bar
+       ~side:Long)
+    (equal_to true)
+
+let test_catastrophic_hit_long_no_fire_above_threshold _ =
+  (* low 91 is above 90 → no fire even when armed. *)
+  let bar = make_bar ~low_price:91.0 ~high_price:95.0 () in
+  assert_that
+    (Catastrophic_stop.check_hit ~armed:true ~pct:0.10 ~trailing_high:100.0 ~bar
+       ~side:Long)
+    (equal_to false)
+
+let test_catastrophic_hit_long_noop_when_not_armed _ =
+  (* low 80 deeply breaches 90, but armed=false → dormant (no fire). *)
+  let bar = make_bar ~low_price:80.0 ~high_price:95.0 () in
+  assert_that
+    (Catastrophic_stop.check_hit ~armed:false ~pct:0.10 ~trailing_high:100.0
+       ~bar ~side:Long)
+    (equal_to false)
+
+let test_catastrophic_hit_long_noop_when_pct_zero _ =
+  (* pct=0.0 is the default no-op: never fires even armed + breaching. *)
+  let bar = make_bar ~low_price:50.0 ~high_price:95.0 () in
+  assert_that
+    (Catastrophic_stop.check_hit ~armed:true ~pct:0.0 ~trailing_high:100.0 ~bar
+       ~side:Long)
+    (equal_to false)
+
+let test_catastrophic_hit_short_fires_when_armed _ =
+  (* high 111 breaches 100*(1+0.10)=110 → fires when armed. *)
+  let bar = make_bar ~low_price:105.0 ~high_price:111.0 () in
+  assert_that
+    (Catastrophic_stop.check_hit ~armed:true ~pct:0.10 ~trailing_high:100.0 ~bar
+       ~side:Short)
+    (equal_to true)
+
+let test_catastrophic_hit_short_no_fire_below_threshold _ =
+  (* high 109 is below 110 → no fire even when armed. *)
+  let bar = make_bar ~low_price:105.0 ~high_price:109.0 () in
+  assert_that
+    (Catastrophic_stop.check_hit ~armed:true ~pct:0.10 ~trailing_high:100.0 ~bar
+       ~side:Short)
+    (equal_to false)
+
+let test_catastrophic_hit_short_noop_when_not_armed _ =
+  let bar = make_bar ~low_price:105.0 ~high_price:130.0 () in
+  assert_that
+    (Catastrophic_stop.check_hit ~armed:false ~pct:0.10 ~trailing_high:100.0
+       ~bar ~side:Short)
+    (equal_to false)
+
+let test_trailing_high_of_state _ =
+  (* Only Trailing carries last_trend_extreme; Initial / Tightened return None. *)
+  let trailing =
+    Trailing
+      {
+        stop_level = 90.0;
+        last_correction_extreme = 95.0;
+        last_trend_extreme = 120.0;
+        ma_at_last_adjustment = 100.0;
+        correction_count = 1;
+        correction_observed_since_reset = true;
+      }
+  in
+  assert_that
+    (Catastrophic_stop.trailing_high_of_state trailing)
+    (is_some_and (float_equal 120.0));
+  assert_that
+    (Catastrophic_stop.trailing_high_of_state
+       (Initial { stop_level = 90.0; reference_level = 95.0 }))
+    is_none;
+  assert_that
+    (Catastrophic_stop.trailing_high_of_state
+       (Tightened
+          { stop_level = 90.0; last_correction_extreme = 95.0; reason = "t" }))
+    is_none
+
 let suite =
   "weinstein_stops"
   >::: [
+         "catastrophic_hit_long_fires_when_armed"
+         >:: test_catastrophic_hit_long_fires_when_armed;
+         "catastrophic_hit_long_no_fire_above_threshold"
+         >:: test_catastrophic_hit_long_no_fire_above_threshold;
+         "catastrophic_hit_long_noop_when_not_armed"
+         >:: test_catastrophic_hit_long_noop_when_not_armed;
+         "catastrophic_hit_long_noop_when_pct_zero"
+         >:: test_catastrophic_hit_long_noop_when_pct_zero;
+         "catastrophic_hit_short_fires_when_armed"
+         >:: test_catastrophic_hit_short_fires_when_armed;
+         "catastrophic_hit_short_no_fire_below_threshold"
+         >:: test_catastrophic_hit_short_no_fire_below_threshold;
+         "catastrophic_hit_short_noop_when_not_armed"
+         >:: test_catastrophic_hit_short_noop_when_not_armed;
+         "trailing_high_of_state" >:: test_trailing_high_of_state;
          "initial_stop_long" >:: test_compute_initial_stop_long;
          "initial_stop_nudge_whole"
          >:: test_compute_initial_stop_nudge_at_whole_number;

--- a/trading/trading/weinstein/strategy/lib/decline_character_wiring.ml
+++ b/trading/trading/weinstein/strategy/lib/decline_character_wiring.ml
@@ -1,0 +1,26 @@
+open Core
+
+(* Convert the snapshot weekly index view into the [Daily_price.t list] shape
+   {!Decline_character.classify} consumes (chronological, oldest first). The
+   weekly_view arrays are already oldest-at-index-0, so a straight fold over the
+   index range preserves that order. [Decline_character] reads per-bar closes;
+   we still populate high/low/open/adjusted_close from the weekly aggregates so
+   the bars are well-formed for any future field the classifier might read. *)
+let _index_bars_of_weekly_view
+    (v : Snapshot_runtime.Snapshot_bar_views.weekly_view) =
+  List.init v.n ~f:(fun i ->
+      Types.Daily_price.make ~date:v.dates.(i) ~open_price:v.closes.(i)
+        ~high_price:v.highs.(i) ~low_price:v.lows.(i) ~close_price:v.closes.(i)
+        ~volume:(Float.to_int v.volumes.(i))
+        ~adjusted_close:v.closes.(i) ())
+
+let classify ~config ~macro ~index_view =
+  let index_bars = _index_bars_of_weekly_view index_view in
+  Decline_character.classify ~config ~macro ~index_bars
+
+let update_ref ~prior_decline_character ~macro_result_opt ~index_view =
+  match macro_result_opt with
+  | None -> ()
+  | Some macro ->
+      prior_decline_character :=
+        classify ~config:Decline_character.default_config ~macro ~index_view

--- a/trading/trading/weinstein/strategy/lib/decline_character_wiring.mli
+++ b/trading/trading/weinstein/strategy/lib/decline_character_wiring.mli
@@ -1,0 +1,40 @@
+(** Strategy-side adapter for {!Decline_character.classify}.
+
+    Build 2 (dev/notes/decline-character-exploration-2026-06-21-PM.md): the
+    fast-crash absolute stop ([stops_config.catastrophic_stop_pct]) is armed
+    only when the primary index is in a fast-V decline. This module bridges the
+    snapshot-shaped weekly index view the strategy carries to the
+    [index_bars : Daily_price.t list] input {!Decline_character.classify}
+    expects.
+
+    The conversion lives here, in the strategy lib (which already depends on
+    [weinstein.macro]), so the stops lib and stops runner stay macro-agnostic
+    (A2): they receive a plain [~armed:bool], not a {!Decline_character.t}. *)
+
+val classify :
+  config:Decline_character.config ->
+  macro:Macro.result ->
+  index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
+  Decline_character.t
+(** [classify ~config ~macro ~index_view] labels the current decline character
+    of the primary index.
+
+    Builds the [index_bars] list {!Decline_character.classify} reads (it
+    consults only per-bar closes) from [index_view]'s weekly closes —
+    chronological, oldest first, matching the [classify] contract. [macro] is
+    the already-computed macro result for the current week. Pure and
+    lookahead-free: every input is at the current week or earlier. *)
+
+val update_ref :
+  prior_decline_character:Decline_character.t ref ->
+  macro_result_opt:Macro.result option ->
+  index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
+  unit
+(** [update_ref ~prior_decline_character ~macro_result_opt ~index_view] stores a
+    fresh {!classify} of the index into [prior_decline_character] when
+    [macro_result_opt] is [Some] (a screening day) — using
+    {!Decline_character.default_config}. On a non-screening day ([None]) it is a
+    no-op, so the ref retains the last classification: the strategy's stops pass
+    reads it on the NEXT tick (strictly prior, no lookahead — the Build 2
+    fast-crash absolute-stop arming seam). The searchable mechanism flag is
+    [stops_config.catastrophic_stop_pct]. *)

--- a/trading/trading/weinstein/strategy/lib/exit_audit_capture.ml
+++ b/trading/trading/weinstein/strategy/lib/exit_audit_capture.ml
@@ -175,3 +175,11 @@ let emit_exit_audit ~(audit_recorder : Audit_recorder.t) ~prior_macro_result
         ~lookback_bars ~bar_reader ~prior_stages ~positions ~trans ~exit_reason
         ~exit_price
   | _ -> ()
+
+let emit_for_list ~(config : Weinstein_strategy_config.config) ~audit_recorder
+    ~prior_macro_result ~bar_reader ~prior_stages ~positions ts =
+  List.iter ts
+    ~f:
+      (emit_exit_audit ~audit_recorder ~prior_macro_result
+         ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
+         ~bar_reader ~prior_stages ~positions)

--- a/trading/trading/weinstein/strategy/lib/exit_audit_capture.mli
+++ b/trading/trading/weinstein/strategy/lib/exit_audit_capture.mli
@@ -35,3 +35,20 @@ val emit_exit_audit :
     last set inside [Weinstein_strategy._run_screen]. When it's still [None]
     (exit fired before the first Friday) the snapshot defaults to [Neutral] /
     [0.0]. *)
+
+val emit_for_list :
+  config:Weinstein_strategy_config.config ->
+  audit_recorder:Audit_recorder.t ->
+  prior_macro_result:Macro.result option ref ->
+  bar_reader:Bar_reader.t ->
+  prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->
+  positions:Trading_strategy.Position.t Map.M(String).t ->
+  Trading_strategy.Position.transition list ->
+  unit
+(** [emit_for_list ~config ~audit_recorder ~prior_macro_result ~bar_reader
+     ~prior_stages ~positions ts] pipes every transition in [ts] through
+    {!emit_exit_audit} (reading [stage_config] / [lookback_bars] off [config]).
+    A convenience over a bare [List.iter] for the force-exit / stage3 / laggard
+    exit lists, which (unlike the stops pass) have no built-in audit emission.
+    Must run while [positions] still holds the position (before the exit
+    transition applies). No-op on non-[TriggerExit] transitions. *)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.ml
@@ -185,37 +185,83 @@ let _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
     ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos
     ~risk_params ~state ~bar ~current_date ~event
 
+(** Fast-crash absolute-stop exit, OR'd alongside the structural trigger.
+
+    Build 2 (dev/notes/decline-character-exploration-2026-06-21-PM.md): when the
+    position's market is in a fast-V decline ([catastrophic_armed]) and the
+    [stops_config.catastrophic_stop_pct] knob is enabled, a long's bar low
+    breaching [trailing_high *. (1 - pct)] (mirror for shorts) fires an exit
+    even when the slower structural stop has not. The trail is read from [state]
+    via {!Weinstein_stops.trailing_high_of_state} — only a [Trailing] state
+    carries one, so the catastrophic stop is dormant until a trend leg exists.
+    No exit when [catastrophic_armed = false] or [pct = 0.0] (the default), so
+    existing callers / goldens are bit-identical. The exit fill price reuses the
+    structural [_make_exit_transition] (bar low for longs / high for shorts). *)
+let _catastrophic_hit ~catastrophic_armed ~stops_config ~(pos : Position.t)
+    ~state ~bar =
+  match Weinstein_stops.Catastrophic_stop.trailing_high_of_state state with
+  | None -> false
+  | Some trailing_high ->
+      Weinstein_stops.Catastrophic_stop.check_hit ~armed:catastrophic_armed
+        ~pct:stops_config.Weinstein_stops.catastrophic_stop_pct ~trailing_high
+        ~bar ~side:pos.Position.side
+
+let _catastrophic_exit ~catastrophic_armed ~stops_config ~(pos : Position.t)
+    ~state ~bar ~current_date =
+  if _catastrophic_hit ~catastrophic_armed ~stops_config ~pos ~state ~bar then
+    Some
+      (_make_exit_transition
+         ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos
+         ~current_date ~state ~bar ())
+  else None
+
 (** Process stop logic for one held position. Returns (exit_transition option,
     adjust_transition option).
 
     Under [Weekly] cadence with [as_of] not on a Friday, only the trigger check
     runs (see [_handle_stop_trigger_only]); the state machine is not advanced
     and [stop_states] is unchanged. Under [Daily] (or [Weekly] on Friday), the
-    state machine runs as before via [_handle_stop_full]. *)
+    state machine runs as before via [_handle_stop_full].
+
+    The fast-crash absolute stop ([_catastrophic_exit]) is OR'd alongside both
+    branches: if the structural path produced no exit but the catastrophic stop
+    fires, its exit is emitted instead. The structural exit takes precedence
+    when both fire (same [TriggerExit] kind). *)
 let _handle_stop ?ma_cache ?prior_stage_ma_values ?(stop_update_cadence = Daily)
-    ~stops_config ~stage_config ~lookback_bars ~(pos : Position.t)
-    ~(risk_params : Position.risk_params) ~state ~bar ~stop_states ~ticker
-    ~bar_reader ~as_of ~prior_stages () =
+    ?(catastrophic_armed = false) ~stops_config ~stage_config ~lookback_bars
+    ~(pos : Position.t) ~(risk_params : Position.risk_params) ~state ~bar
+    ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages () =
   let current_date = bar.Types.Daily_price.date in
   let advance_state_machine =
     match stop_update_cadence with
     | Daily -> true
     | Weekly -> _is_weekly_close ~as_of
   in
-  if not advance_state_machine then
-    _handle_stop_trigger_only
-      ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos ~state
-      ~bar ~current_date
-  else
-    _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
-      ~stage_config ~lookback_bars ~pos ~risk_params ~state ~bar ~stop_states
-      ~ticker ~bar_reader ~as_of ~prior_stages ~current_date ()
+  let exit_tr, adjust_tr =
+    if not advance_state_machine then
+      _handle_stop_trigger_only
+        ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos
+        ~state ~bar ~current_date
+    else
+      _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
+        ~stage_config ~lookback_bars ~pos ~risk_params ~state ~bar ~stop_states
+        ~ticker ~bar_reader ~as_of ~prior_stages ~current_date ()
+  in
+  match exit_tr with
+  | Some _ -> (exit_tr, adjust_tr)
+  | None ->
+      let catastrophic_tr =
+        _catastrophic_exit ~catastrophic_armed ~stops_config ~pos ~state ~bar
+          ~current_date
+      in
+      (catastrophic_tr, adjust_tr)
 
 (** Process stop for one position; returns updated (exits, adjusts) accumulator.
 *)
 let _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
-    ~stops_config ~stage_config ~lookback_bars ~stop_states ~get_price
-    ~bar_reader ~as_of ~prior_stages (pos : Position.t) (exits, adjusts) =
+    ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars ~stop_states
+    ~get_price ~bar_reader ~as_of ~prior_stages (pos : Position.t)
+    (exits, adjusts) =
   let ticker = pos.symbol in
   match
     (Position.get_state pos, Map.find !stop_states ticker, get_price ticker)
@@ -223,7 +269,7 @@ let _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
   | Position.Holding h, Some state, Some bar -> (
       match
         _handle_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
-          ~stops_config ~stage_config ~lookback_bars ~pos
+          ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars ~pos
           ~risk_params:h.risk_params ~state ~bar ~stop_states ~ticker
           ~bar_reader ~as_of ~prior_stages ()
       with
@@ -232,10 +278,10 @@ let _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
       | None, None -> (exits, adjusts))
   | _ -> (exits, adjusts)
 
-let update ?ma_cache ?stop_update_cadence ?prior_stage_ma_values ~stops_config
-    ~stage_config ~lookback_bars ~positions ~get_price ~stop_states ~bar_reader
-    ~as_of ~prior_stages () =
+let update ?ma_cache ?stop_update_cadence ?prior_stage_ma_values
+    ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars ~positions
+    ~get_price ~stop_states ~bar_reader ~as_of ~prior_stages () =
   Map.fold positions ~init:([], []) ~f:(fun ~key:_ ~data:pos acc ->
       _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
-        ~stops_config ~stage_config ~lookback_bars ~stop_states ~get_price
-        ~bar_reader ~as_of ~prior_stages pos acc)
+        ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars
+        ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages pos acc)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.mli
@@ -28,6 +28,7 @@ val update :
   ?ma_cache:Weekly_ma_cache.t ->
   ?stop_update_cadence:stop_update_cadence ->
   ?prior_stage_ma_values:float Hashtbl.M(String).t ->
+  ?catastrophic_armed:bool ->
   stops_config:Weinstein_stops.config ->
   stage_config:Stage.config ->
   lookback_bars:int ->
@@ -69,4 +70,14 @@ val update :
     {!Stage3_force_exit_runner} reads the same table to apply its
     [stage3_exit_margin_pct] filter (price-below-MA margin gate). When omitted,
     no MA values are recorded — the stage3 force-exit margin filter then
-    short-circuits as "margin met" and behaviour matches pre-fix runs. *)
+    short-circuits as "margin met" and behaviour matches pre-fix runs.
+
+    [catastrophic_armed] (optional, default [false]) arms the fast-crash
+    absolute stop ([stops_config.catastrophic_stop_pct]). When [true] {b and}
+    that knob is [> 0.0], a position whose bar low (long) / high (short)
+    breaches [trailing_high *. (1 ∓ pct)] gets a [TriggerExit] alongside the
+    structural stop — see {!Weinstein_stops.check_catastrophic_hit}. The arming
+    decision is made one level up in the strategy lib from the prior cycle's
+    {!Decline_character.t} (a fast-V decline), keeping this runner and the stops
+    lib macro-agnostic. The default [false] (and the knob's default [0.0]) is an
+    exact no-op, so every existing caller and golden replays bit-identically. *)

--- a/trading/trading/weinstein/strategy/lib/transition_assembly.ml
+++ b/trading/trading/weinstein/strategy/lib/transition_assembly.ml
@@ -1,0 +1,51 @@
+open Core
+open Trading_strategy
+
+let trigger_exit_ids_of (ts : Position.transition list) : String.Set.t =
+  List.filter_map ts ~f:(fun (t : Position.transition) ->
+      match t.kind with
+      | Position.TriggerExit _ -> Some t.position_id
+      | _ -> None)
+  |> String.Set.of_list
+
+let filter_out_exited_ids exited_ids (ts : Position.transition list) :
+    Position.transition list =
+  if Set.is_empty exited_ids then ts
+  else
+    List.filter ts ~f:(fun (t : Position.transition) ->
+        not (Set.mem exited_ids t.position_id))
+
+let assemble_output ~exit_transitions ~stage3_force_exit_transitions
+    ~laggard_rotation_transitions ~force_exit_transitions
+    ~macro_trim_transitions ~harvest_rotate_transitions ~adjust_transitions
+    ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids =
+  let force_liq_exited_ids = trigger_exit_ids_of force_exit_transitions in
+  let macro_trim_exited_ids = trigger_exit_ids_of macro_trim_transitions in
+  let all_exited_ids =
+    Set.union_list
+      (module String)
+      [
+        stop_exited_ids;
+        stage3_exited_ids;
+        laggard_exited_ids;
+        force_liq_exited_ids;
+        macro_trim_exited_ids;
+      ]
+  in
+  let adjust_transitions =
+    filter_out_exited_ids all_exited_ids adjust_transitions
+  in
+  (* Drop a harvest-trim for any position already fully exited this tick (a stop
+     hit / Stage-3 / laggard / force-liq / macro-bearish exit) — that position is
+     closing, so there is nothing left to trim. *)
+  let harvest_rotate_transitions =
+    filter_out_exited_ids all_exited_ids harvest_rotate_transitions
+  in
+  Ok
+    {
+      Strategy_interface.transitions =
+        exit_transitions @ stage3_force_exit_transitions
+        @ laggard_rotation_transitions @ force_exit_transitions
+        @ macro_trim_transitions @ harvest_rotate_transitions
+        @ adjust_transitions @ entry_transitions;
+    }

--- a/trading/trading/weinstein/strategy/lib/transition_assembly.mli
+++ b/trading/trading/weinstein/strategy/lib/transition_assembly.mli
@@ -1,0 +1,39 @@
+(** Exited-position set helpers + final transition-list assembly for the
+    Weinstein strategy's per-tick output.
+
+    Extracted from [weinstein_strategy.ml] to keep that coordinator under the
+    file-length cap: these are the pure list/set utilities that combine the
+    several exit / adjust / entry transition streams a market day produces into
+    the single ordered output, dropping adjust/harvest transitions for positions
+    already fully exited this tick. *)
+
+open Core
+open Trading_strategy
+
+val trigger_exit_ids_of : Position.transition list -> String.Set.t
+(** The set of [position_id]s carried by [TriggerExit] transitions in the list
+    (non-exit transitions contribute nothing). *)
+
+val filter_out_exited_ids :
+  String.Set.t -> Position.transition list -> Position.transition list
+(** Drop every transition whose [position_id] is in the exited set. Identity
+    when the set is empty. *)
+
+val assemble_output :
+  exit_transitions:Position.transition list ->
+  stage3_force_exit_transitions:Position.transition list ->
+  laggard_rotation_transitions:Position.transition list ->
+  force_exit_transitions:Position.transition list ->
+  macro_trim_transitions:Position.transition list ->
+  harvest_rotate_transitions:Position.transition list ->
+  adjust_transitions:Position.transition list ->
+  entry_transitions:Position.transition list ->
+  stop_exited_ids:String.Set.t ->
+  stage3_exited_ids:String.Set.t ->
+  laggard_exited_ids:String.Set.t ->
+  Strategy_interface.output Status.status_or
+(** Combine the per-tick transition streams into the single ordered
+    {!Strategy_interface.output}. Adjust and harvest-rotate transitions are
+    dropped for any position already fully exited this tick (a stop / Stage-3 /
+    laggard / force-liq / macro-bearish exit), since a closing position has
+    nothing left to adjust or trim. Always returns [Ok]. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -36,24 +36,12 @@ let entries_from_candidates = S.entries_from_candidates
 let survivors_for_screening = S.survivors_for_screening
 let prune_universe_by_active_through = S.prune_universe_by_active_through
 
-let _trigger_exit_ids_of (ts : Position.transition list) : String.Set.t =
-  List.filter_map ts ~f:(fun (t : Position.transition) ->
-      match t.kind with
-      | Position.TriggerExit _ -> Some t.position_id
-      | _ -> None)
-  |> String.Set.of_list
-
-let _filter_out_exited_ids exited_ids (ts : Position.transition list) :
-    Position.transition list =
-  if Set.is_empty exited_ids then ts
-  else
-    List.filter ts ~f:(fun (t : Position.transition) ->
-        not (Set.mem exited_ids t.position_id))
-
 let _positions_minus_exited ~(positions : Position.t Map.M(String).t)
     ~(stop_exit_transitions : Position.transition list) :
     Position.t Map.M(String).t =
-  let exited_ids = _trigger_exit_ids_of stop_exit_transitions in
+  let exited_ids =
+    Transition_assembly.trigger_exit_ids_of stop_exit_transitions
+  in
   if Set.is_empty exited_ids then positions
   else
     Map.filter positions ~f:(fun (p : Position.t) ->
@@ -116,25 +104,29 @@ let _record_force_exit ~last_stop_out_dates ~positions ~current_date
 
 let _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
     ~prior_stage_ma_values ~get_price ~last_stop_out_dates ~audit_recorder
-    ~prior_macro_result ~current_date =
+    ~prior_macro_result ~prior_decline_character ~current_date =
   Stops_split_runner.adjust ~positions ~stop_states ~bar_reader
     ~as_of:current_date;
+  (* Arm the fast-crash absolute stop from the PRIOR cycle's decline-character
+     (strictly past — this cycle's classify runs later, at the macro step; a
+     plain bool keeps the stops lib macro-agnostic). *)
+  let catastrophic_armed =
+    phys_equal !prior_decline_character Decline_character.Fast_v
+  in
   let exit_transitions, adjust_transitions =
     Stops_runner.update
       ?ma_cache:(Bar_reader.ma_cache bar_reader)
       ~stop_update_cadence:config.stop_update_cadence ~prior_stage_ma_values
-      ~stops_config:config.stops_config ~stage_config:config.stage_config
-      ~lookback_bars:config.lookback_bars ~positions ~get_price ~stop_states
-      ~bar_reader ~as_of:current_date ~prior_stages ()
+      ~catastrophic_armed ~stops_config:config.stops_config
+      ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
+      ~positions ~get_price ~stop_states ~bar_reader ~as_of:current_date
+      ~prior_stages ()
   in
   List.iter exit_transitions
     ~f:
       (_handle_stop_out_transition ~last_stop_out_dates ~positions ~current_date);
-  List.iter exit_transitions
-    ~f:
-      (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
-         ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
-         ~bar_reader ~prior_stages ~positions);
+  Exit_audit_capture.emit_for_list ~config ~audit_recorder ~prior_macro_result
+    ~bar_reader ~prior_stages ~positions exit_transitions;
   (exit_transitions, adjust_transitions)
 
 let _run_laggard_rotation ~config ~positions ~last_stop_out_dates ~bar_reader
@@ -173,36 +165,24 @@ let _run_stage3_force_exit ~config ~positions ~last_stop_out_dates
          ~label:"stage3_force_exit");
   stage3_ts
 
-(* Emit the exit-side audit (incl. MFE/MAE) for a list of [TriggerExit]
-   transitions, mirroring the stops pass. Without this, stage3-force-exit,
-   laggard-rotation, and force-liquidation exits carry no [exit_decision] and
-   their excursion metrics default to 0.0 (a no-op on non-[TriggerExit]
-   transitions, so it is safe to pipe any list through). Must run while
-   [positions] still holds the position (before the exit transition applies). *)
-let _emit_exit_audit_for ~config ~audit_recorder ~prior_macro_result ~bar_reader
-    ~prior_stages ~positions ts =
-  List.iter ts
-    ~f:
-      (Exit_audit_capture.emit_exit_audit ~audit_recorder ~prior_macro_result
-         ~stage_config:config.stage_config ~lookback_bars:config.lookback_bars
-         ~bar_reader ~prior_stages ~positions)
-
 let _run_special_exits ~config ~positions ~last_stop_out_dates
     ~(portfolio : Portfolio_view.t) ~get_price ~peak_tracker ~audit_recorder
     ~prior_macro_result ~prior_stages ~prior_stage_ma_values ~stage3_streaks
     ~laggard_streaks ~bar_reader ~index_view ~exit_transitions ~current_date =
   let emit_audit =
-    _emit_exit_audit_for ~config ~audit_recorder ~prior_macro_result ~bar_reader
-      ~prior_stages ~positions
+    Exit_audit_capture.emit_for_list ~config ~audit_recorder ~prior_macro_result
+      ~bar_reader ~prior_stages ~positions
   in
   let raw_force_exit_ts =
     Force_liquidation_runner.update
       ~config:config.portfolio_config.force_liquidation ~positions ~get_price
       ~cash:portfolio.cash ~current_date ~peak_tracker ~audit_recorder
   in
-  let stop_exited_ids = _trigger_exit_ids_of exit_transitions in
+  let stop_exited_ids =
+    Transition_assembly.trigger_exit_ids_of exit_transitions
+  in
   let force_exit_ts =
-    _filter_out_exited_ids stop_exited_ids raw_force_exit_ts
+    Transition_assembly.filter_out_exited_ids stop_exited_ids raw_force_exit_ts
   in
   let is_friday =
     Weinstein_strategy_screening.is_screening_day_view index_view
@@ -213,8 +193,10 @@ let _run_special_exits ~config ~positions ~last_stop_out_dates
       ~stop_exited_ids ~current_date
   in
   emit_audit stage3_ts;
-  let stage3_exited_ids = _trigger_exit_ids_of stage3_ts in
-  let force_exit_ts = _filter_out_exited_ids stage3_exited_ids force_exit_ts in
+  let stage3_exited_ids = Transition_assembly.trigger_exit_ids_of stage3_ts in
+  let force_exit_ts =
+    Transition_assembly.filter_out_exited_ids stage3_exited_ids force_exit_ts
+  in
   let laggard_ts =
     _run_laggard_rotation ~config ~positions ~last_stop_out_dates ~bar_reader
       ~get_price ~laggard_streaks ~is_friday
@@ -222,8 +204,10 @@ let _run_special_exits ~config ~positions ~last_stop_out_dates
       ~current_date
   in
   emit_audit laggard_ts;
-  let laggard_exited_ids = _trigger_exit_ids_of laggard_ts in
-  let force_exit_ts = _filter_out_exited_ids laggard_exited_ids force_exit_ts in
+  let laggard_exited_ids = Transition_assembly.trigger_exit_ids_of laggard_ts in
+  let force_exit_ts =
+    Transition_assembly.filter_out_exited_ids laggard_exited_ids force_exit_ts
+  in
   emit_audit force_exit_ts;
   ( force_exit_ts,
     stage3_ts,
@@ -303,13 +287,18 @@ let _run_entries ~fold_start_date ~config ~stop_states ~last_stop_out_dates
     limits; the skip-id union (stop / Stage-3 / laggard / force-liq exits) is
     assembled here. *)
 let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
-    ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages ~get_price
-    ~current_date ~index_view ~is_screening_day ~stop_exited_ids
-    ~stage3_exited_ids ~laggard_exited_ids ~force_exit_transitions =
+    ~prior_macro_result ~prior_decline_character ~peak_tracker ~bar_reader
+    ~prior_stages ~get_price ~current_date ~index_view ~is_screening_day
+    ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
+    ~force_exit_transitions =
   let macro_result_opt =
     _run_macro ~config ~ad_bars ~prior_macro ~prior_macro_result ~peak_tracker
       ~bar_reader ~prior_stages ~current_date ~index_view ~is_screening_day
   in
+  (* Re-classify the index's decline character (strictly-past read by the next
+     tick's stops pass to arm the fast-crash absolute stop — Build 2). *)
+  Decline_character_wiring.update_ref ~prior_decline_character ~macro_result_opt
+    ~index_view;
   let skip_ids =
     Set.union_list
       (module String)
@@ -317,7 +306,7 @@ let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
         stop_exited_ids;
         stage3_exited_ids;
         laggard_exited_ids;
-        _trigger_exit_ids_of force_exit_transitions;
+        Transition_assembly.trigger_exit_ids_of force_exit_transitions;
       ]
   in
   let macro_trim_transitions =
@@ -326,51 +315,38 @@ let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
   in
   (macro_result_opt, macro_trim_transitions)
 
-let _assemble_output ~exit_transitions ~stage3_force_exit_transitions
-    ~laggard_rotation_transitions ~force_exit_transitions
-    ~macro_trim_transitions ~harvest_rotate_transitions ~adjust_transitions
-    ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids =
-  let force_liq_exited_ids = _trigger_exit_ids_of force_exit_transitions in
-  let macro_trim_exited_ids = _trigger_exit_ids_of macro_trim_transitions in
-  let all_exited_ids =
-    Set.union_list
-      (module String)
-      [
-        stop_exited_ids;
-        stage3_exited_ids;
-        laggard_exited_ids;
-        force_liq_exited_ids;
-        macro_trim_exited_ids;
-      ]
+(** Run the held-position dials (late-Stage-2 tighten + harvest-rotate) and the
+    entry walk. Returns [(late_tighten, harvest_rotate, entries)]. Extracted
+    from {!_process_market_day} so that coordinator stays within the
+    function-length limit. *)
+let _run_dials_and_entries ~fold_start_date ~config ~stop_states
+    ~last_stop_out_dates ~peak_tracker ~bar_reader ~prior_stages
+    ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
+    ~index_view ~audit_recorder ~prior_macro_result ~is_screening_day
+    ~macro_result_opt ~positions =
+  let late_tighten_transitions, harvest_rotate_transitions =
+    _run_held_position_dials ~config ~positions ~get_price ~prior_stages
+      ~index_view ~audit_recorder ~prior_macro_result ~bar_reader ~current_date
   in
-  let adjust_transitions =
-    _filter_out_exited_ids all_exited_ids adjust_transitions
+  let entry_transitions =
+    _run_entries ~fold_start_date ~config ~stop_states ~last_stop_out_dates
+      ~peak_tracker ~bar_reader ~prior_stages ~sector_prior_stages
+      ~ticker_sectors ~get_price ~portfolio ~current_date ~index_view
+      ~audit_recorder ~is_screening_day ~macro_result_opt
   in
-  (* Drop a harvest-trim for any position already fully exited this tick (a stop
-     hit / Stage-3 / laggard / force-liq / macro-bearish exit) — that position is
-     closing, so there is nothing left to trim. *)
-  let harvest_rotate_transitions =
-    _filter_out_exited_ids all_exited_ids harvest_rotate_transitions
-  in
-  Ok
-    {
-      Strategy_interface.transitions =
-        exit_transitions @ stage3_force_exit_transitions
-        @ laggard_rotation_transitions @ force_exit_transitions
-        @ macro_trim_transitions @ harvest_rotate_transitions
-        @ adjust_transitions @ entry_transitions;
-    }
+  (late_tighten_transitions, harvest_rotate_transitions, entry_transitions)
 
 let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
-    ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
-    ~bar_reader ~prior_stages ~prior_stage_ma_values ~sector_prior_stages
-    ~ticker_sectors ~stage3_streaks ~laggard_streaks ~audit_recorder ~get_price
-    ~(portfolio : Portfolio_view.t) ~current_date =
+    ~last_stop_out_dates ~prior_macro ~prior_macro_result
+    ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
+    ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors ~stage3_streaks
+    ~laggard_streaks ~audit_recorder ~get_price ~(portfolio : Portfolio_view.t)
+    ~current_date =
   let positions = portfolio.positions in
   let exit_transitions, adjust_transitions =
     _run_stops_pass ~config ~positions ~stop_states ~bar_reader ~prior_stages
       ~prior_stage_ma_values ~get_price ~last_stop_out_dates ~audit_recorder
-      ~prior_macro_result ~current_date
+      ~prior_macro_result ~prior_decline_character ~current_date
   in
   let index_view =
     Bar_reader.weekly_view_for bar_reader ~symbol:config.indices.primary
@@ -392,40 +368,40 @@ let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
   in
   let macro_result_opt, macro_trim_transitions =
     _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
-      ~prior_macro_result ~peak_tracker ~bar_reader ~prior_stages ~get_price
-      ~current_date ~index_view ~is_screening_day ~stop_exited_ids
-      ~stage3_exited_ids ~laggard_exited_ids ~force_exit_transitions
+      ~prior_macro_result ~prior_decline_character ~peak_tracker ~bar_reader
+      ~prior_stages ~get_price ~current_date ~index_view ~is_screening_day
+      ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
+      ~force_exit_transitions
   in
-  let late_tighten_transitions, harvest_rotate_transitions =
-    _run_held_position_dials ~config ~positions ~get_price ~prior_stages
-      ~index_view ~audit_recorder ~prior_macro_result ~bar_reader ~current_date
+  let late_tighten_transitions, harvest_rotate_transitions, entry_transitions =
+    _run_dials_and_entries ~fold_start_date ~config ~stop_states
+      ~last_stop_out_dates ~peak_tracker ~bar_reader ~prior_stages
+      ~sector_prior_stages ~ticker_sectors ~get_price ~portfolio ~current_date
+      ~index_view ~audit_recorder ~prior_macro_result ~is_screening_day
+      ~macro_result_opt ~positions
   in
-  let entry_transitions =
-    _run_entries ~fold_start_date ~config ~stop_states ~last_stop_out_dates
-      ~peak_tracker ~bar_reader ~prior_stages ~sector_prior_stages
-      ~ticker_sectors ~get_price ~portfolio ~current_date ~index_view
-      ~audit_recorder ~is_screening_day ~macro_result_opt
-  in
-  _assemble_output ~exit_transitions ~stage3_force_exit_transitions
-    ~laggard_rotation_transitions ~force_exit_transitions
-    ~macro_trim_transitions ~harvest_rotate_transitions
+  Transition_assembly.assemble_output ~exit_transitions
+    ~stage3_force_exit_transitions ~laggard_rotation_transitions
+    ~force_exit_transitions ~macro_trim_transitions ~harvest_rotate_transitions
     ~adjust_transitions:(adjust_transitions @ late_tighten_transitions)
     ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
 
 let _on_market_close ~fold_start_date ~config ~ad_bars ~stop_states
-    ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
-    ~bar_reader ~prior_stages ~prior_stage_ma_values ~sector_prior_stages
-    ~ticker_sectors ~stage3_streaks ~laggard_streaks ~audit_recorder ~get_price
-    ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
+    ~last_stop_out_dates ~prior_macro ~prior_macro_result
+    ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
+    ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors ~stage3_streaks
+    ~laggard_streaks ~audit_recorder ~get_price ~get_indicator:_
+    ~(portfolio : Portfolio_view.t) =
   match get_price config.indices.primary with
   | None -> Ok { Strategy_interface.transitions = [] }
   | Some primary_bar ->
       let current_date = primary_bar.Types.Daily_price.date in
       _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
-        ~last_stop_out_dates ~prior_macro ~prior_macro_result ~peak_tracker
-        ~bar_reader ~prior_stages ~prior_stage_ma_values ~sector_prior_stages
-        ~ticker_sectors ~stage3_streaks ~laggard_streaks ~audit_recorder
-        ~get_price ~portfolio ~current_date
+        ~last_stop_out_dates ~prior_macro ~prior_macro_result
+        ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
+        ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors
+        ~stage3_streaks ~laggard_streaks ~audit_recorder ~get_price ~portfolio
+        ~current_date
 
 let _init_strategy_state ~initial_stop_states ~ad_bars =
   let stop_states = ref initial_stop_states in
@@ -435,6 +411,9 @@ let _init_strategy_state ~initial_stop_states ~ad_bars =
   let prior_macro = ref Weinstein_types.Neutral in
   let peak_tracker = Portfolio_risk.Force_liquidation.Peak_tracker.create () in
   let prior_macro_result : Macro.result option ref = ref None in
+  (* Most recent index decline-character; updated at the macro step, read
+     strictly-prior by the next tick's stops pass to arm the fast-crash stop. *)
+  let prior_decline_character = ref Decline_character.Not_declining in
   let prior_stages = Hashtbl.create (module String) in
   let prior_stage_ma_values : float Hashtbl.M(String).t =
     Hashtbl.create (module String)
@@ -454,6 +433,7 @@ let _init_strategy_state ~initial_stop_states ~ad_bars =
     prior_macro,
     peak_tracker,
     prior_macro_result,
+    prior_decline_character,
     prior_stages,
     prior_stage_ma_values,
     sector_prior_stages,
@@ -472,6 +452,7 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
         prior_macro,
         peak_tracker,
         prior_macro_result,
+        prior_decline_character,
         prior_stages,
         prior_stage_ma_values,
         sector_prior_stages,
@@ -486,9 +467,9 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
     let on_market_close =
       _on_market_close ~fold_start_date ~config ~ad_bars:weekly_ad_bars
         ~stop_states ~last_stop_out_dates ~prior_macro ~prior_macro_result
-        ~peak_tracker ~bar_reader ~prior_stages ~prior_stage_ma_values
-        ~sector_prior_stages ~ticker_sectors ~stage3_streaks ~laggard_streaks
-        ~audit_recorder
+        ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
+        ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors
+        ~stage3_streaks ~laggard_streaks ~audit_recorder
   end in
   (module M : Strategy_interface.STRATEGY)
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -688,6 +688,7 @@ module Internal_for_test : sig
     last_stop_out_dates:Date.t Hashtbl.M(String).t ->
     prior_macro:Weinstein_types.market_trend ref ->
     prior_macro_result:Macro.result option ref ->
+    prior_decline_character:Decline_character.t ref ->
     peak_tracker:Portfolio_risk.Force_liquidation.Peak_tracker.t ->
     bar_reader:Bar_reader.t ->
     prior_stages:Weinstein_types.stage Hashtbl.M(String).t ->

--- a/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_force_liquidation_strategy.ml
@@ -63,6 +63,7 @@ type _strategy_state = {
   last_stop_out_dates : Date.t Hashtbl.M(String).t;
   prior_macro : market_trend ref;
   prior_macro_result : Macro.result option ref;
+  prior_decline_character : Decline_character.t ref;
   peak_tracker : FL.Peak_tracker.t;
   prior_stages : stage Hashtbl.M(String).t;
   prior_stage_ma_values : float Hashtbl.M(String).t;
@@ -82,6 +83,7 @@ let _fresh_state ~bar_reader =
     last_stop_out_dates = Hashtbl.create (module String);
     prior_macro = ref Neutral;
     prior_macro_result = ref None;
+    prior_decline_character = ref Decline_character.Not_declining;
     peak_tracker = FL.Peak_tracker.create ();
     prior_stages = Hashtbl.create (module String);
     prior_stage_ma_values = Hashtbl.create (module String);
@@ -106,6 +108,7 @@ let _drive_tick state ~config ~current_date ~portfolio =
     ~stop_states:state.stop_states
     ~last_stop_out_dates:state.last_stop_out_dates
     ~prior_macro:state.prior_macro ~prior_macro_result:state.prior_macro_result
+    ~prior_decline_character:state.prior_decline_character
     ~peak_tracker:state.peak_tracker ~bar_reader:state.bar_reader
     ~prior_stages:state.prior_stages
     ~prior_stage_ma_values:state.prior_stage_ma_values

--- a/trading/trading/weinstein/strategy/test/test_stops_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_runner.ml
@@ -541,6 +541,95 @@ let test_weekly_cadence_trigger_fires_on_midweek_bar _ =
        ])
 
 (* ------------------------------------------------------------------ *)
+(* Build 2: fast-crash absolute stop (catastrophic_stop_pct)            *)
+(*                                                                      *)
+(* When the index is in a fast-V decline (catastrophic_armed=true) and  *)
+(* the catastrophic_stop_pct knob is enabled, a long whose bar low      *)
+(* breaches trailing_high*(1-pct) gets a TriggerExit even when the      *)
+(* slower structural stop has not fired. Default-off: armed=false OR    *)
+(* pct=0.0 reproduces the structural-only behaviour bit-for-bit.        *)
+(* ------------------------------------------------------------------ *)
+
+(** A Trailing stop state seeded with [last_trend_extreme] = the rally peak the
+    catastrophic stop measures its absolute drop from, and a structural
+    [stop_level] far below the bar so the structural trigger never fires — the
+    catastrophic stop is isolated as the only possible exit. *)
+let _trailing_state ~stop_level ~trend_extreme =
+  Weinstein_stops.Trailing
+    {
+      stop_level;
+      last_correction_extreme = trend_extreme *. 0.95;
+      last_trend_extreme = trend_extreme;
+      ma_at_last_adjustment = trend_extreme *. 0.9;
+      correction_count = 1;
+      correction_observed_since_reset = true;
+    }
+
+(** Drive a single [Stops_runner.update] over one long position in a Trailing
+    state, with [catastrophic_stop_pct] = [pct] and [~catastrophic_armed]. The
+    bar low ($88) breaches trailing_high($100)*(1-0.10)=$90 but stays above the
+    structural stop ($80), so the only possible exit is the catastrophic stop.
+    Returns the exit transitions. *)
+let _run_catastrophic ~armed ~pct =
+  let ticker = "AAPL" in
+  let entry_date = Date.of_string "2024-01-05" in
+  let pos = make_holding_pos ticker 100.0 entry_date in
+  let positions = String.Map.singleton ticker pos in
+  let stop_states =
+    ref
+      (String.Map.singleton ticker
+         (_trailing_state ~stop_level:80.0 ~trend_extreme:100.0))
+  in
+  let stops_config =
+    { default_cfg with Weinstein_stops.catastrophic_stop_pct = pct }
+  in
+  (* Bar low 88 < trailing_high 100 * (1 - 0.10) = 90, but > structural stop 80. *)
+  let bar = make_bar "2024-01-12" ~close:89.0 ~low:88.0 ~high:90.0 () in
+  let exits, _adjusts =
+    Stops_runner.update ~catastrophic_armed:armed ~stops_config
+      ~stage_config:default_stage_cfg ~lookback_bars:52 ~positions
+      ~get_price:(get_price_of [ (ticker, bar) ])
+      ~stop_states ~bar_reader:(Bar_reader.empty ())
+      ~as_of:(Date.of_string "2024-01-12")
+      ~prior_stages:(Hashtbl.create (module String))
+      ()
+  in
+  exits
+
+(** Armed + pct>0 + breaching bar → a single TriggerExit is emitted. *)
+let test_catastrophic_armed_fires_trigger_exit _ =
+  let exits = _run_catastrophic ~armed:true ~pct:0.10 in
+  assert_that exits
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (tr : Trading_strategy.Position.transition) ->
+                 tr.position_id)
+               (equal_to "AAPL");
+             field
+               (fun (tr : Trading_strategy.Position.transition) -> tr.kind)
+               (matching ~msg:"Expected TriggerExit"
+                  (function
+                    | Trading_strategy.Position.TriggerExit _ -> Some ()
+                    | _ -> None)
+                  (equal_to ()));
+           ];
+       ])
+
+(** Not armed → the catastrophic stop is dormant; no exit (structural
+    unchanged). *)
+let test_catastrophic_not_armed_no_exit _ =
+  let exits = _run_catastrophic ~armed:false ~pct:0.10 in
+  assert_that exits is_empty
+
+(** pct=0.0 (default no-op) → no catastrophic exit even when armed. *)
+let test_catastrophic_pct_zero_no_exit _ =
+  let exits = _run_catastrophic ~armed:true ~pct:0.0 in
+  assert_that exits is_empty
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -548,6 +637,12 @@ let () =
   run_test_tt_main
     ("stops_runner"
     >::: [
+           "Build2: catastrophic stop fires TriggerExit when armed"
+           >:: test_catastrophic_armed_fires_trigger_exit;
+           "Build2: catastrophic stop dormant when not armed"
+           >:: test_catastrophic_not_armed_no_exit;
+           "Build2: catastrophic stop no-op at pct=0.0"
+           >:: test_catastrophic_pct_zero_no_exit;
            "update with no positions returns empty"
            >:: test_update_no_positions_returns_empty;
            "update with position but no stop state returns empty"


### PR DESCRIPTION
## What it does

Build 2 of the decline-character sequence (`dev/notes/decline-character-exploration-2026-06-21-PM.md` §Build 2). Adds an **absolute** drop-% stop from the position's trailing high that fires faster than the structural MA/correction-low trailing stop in a fast crash. Motivation: in 2020 the structural stop trailed a distant 2019 correction low and re-checked only weekly, so longs exited 3-4 weeks late, at the bottom, eating the full ~38% DD.

## Mechanism (default-off, exact no-op at the default)

- **Config:** `stops_config.catastrophic_stop_pct : float [@sexp.default 0.0]` in `stop_types.{ml,mli}`. `0.0` = no-op (trigger gated on `pct > 0.0`), so every existing golden replays bit-identically — **experiment-flag-discipline R1**. Cited.
- **Trigger:** new macro-AGNOSTIC `Catastrophic_stop` module in the stops lib (re-exported as `Weinstein_stops.Catastrophic_stop`): `check_hit ~armed ~pct ~trailing_high ~bar ~side` (long fires on `bar.low ≤ trailing_high*(1-pct)`, short on `bar.high ≥ trailing_high*(1+pct)`) + `trailing_high_of_state` (reads the stop state's `last_trend_extreme`; `None` for Initial/Tightened → dormant). OR'd into the trigger decision in `stops_runner.ml` via a new optional `?catastrophic_armed:bool` (default `false` → no-op) on `Stops_runner.update`.
- **Threading (lookahead-free):** the `Fast_v → armed` decision is made in the strategy lib (keeping the stops lib macro-agnostic — **A2**, no `macro` dep added). A new `prior_decline_character` ref is classified at the macro step (`Decline_character_wiring`, converting the weekly index view to bars + `Decline_character.default_config`) and read **strictly prior** by the next tick's stops pass — mirrors the existing `prior_macro_result` pattern. The stops pass runs before the macro step each tick, so it reads the previous cycle's label: no future bar is consulted.

## Weinstein-faithful (W2)

This is explicit **tail-RISK insurance** gated to fast-V regimes, *not* an always-on tight stop. It is dormant (`armed=false`) in normal bull chop, so it does not tax the let-winners-run fat tail — the sanctioned exception in `.claude/rules/weinstein-faithful-core.md` / `project_edge_is_the_fat_tail` ("winner-touching only as explicit tail-RISK insurance"). The spine (structural support-floor stop, never-loosen, weekly cadence) is untouched.

## Searchable axis (R2)

`stops_config.catastrophic_stop_pct` is a real `Weinstein_strategy.config` `stops_config.*` float field → Variant_matrix-searchable exactly like `vol_scaled_stop_atr_mult` (`((stops_config ((catastrophic_stop_pct 0.05))))`).

## Test plan

- `test_weinstein_stops.ml` (8 new): `Catastrophic_stop.check_hit` fires on a long when `armed && low ≤ trail*(1-pct)`; no-op when `armed=false`; no-op when `pct=0.0`; mirror for short; `trailing_high_of_state` returns the trend extreme for Trailing / `None` for Initial+Tightened.
- `test_stops_runner.ml` (3 new): with `catastrophic_stop_pct>0` + `catastrophic_armed=true`, a Trailing position whose bar breaches `trailing_high*(1-pct)` (but stays above the structural stop) gets a `TriggerExit`; with `armed=false` or `pct=0` it does **not** (structural stop unchanged). Asserts the transition outcome.
- All target tests pass: 41 `test_weinstein_stops`, 14 `test_stops_runner`, 9 `test_force_liquidation_strategy`.

## No core-module edits

All work is in the weinstein `stops` + `strategy` subtree libs/tests + the status doc. Portfolio / Orders / Position / `trading_strategy` / Engine / Simulator untouched.

## Code-health

`weinstein_stops.ml` (491) and `weinstein_strategy.ml` (500) were both at the 500-line `@large` cap, and `_process_market_day` at the 50-line fn cap — zero headroom. To stay under the caps the PR carries proportionate extractions: `Catastrophic_stop` (the trigger), `Transition_assembly` (the pure transition-assembly + exited-id helpers), `Exit_audit_capture.emit_for_list` (the exit-audit list wrapper moved to its natural home), and `_run_dials_and_entries` (the dials+entries tail of `_process_market_day`). Final: `weinstein_stops.ml` 492, `weinstein_strategy.ml` 481, all new files small. fn_length / nesting / file_length linters clean for all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)