### PR TITLE
feat(screener): faithful short — Bearish-only + slow-grind gate (default-off)

### DIFF
--- a/dev/status/decline-character.md
+++ b/dev/status/decline-character.md
@@ -73,20 +73,46 @@ read-only dial, not a spine change. All builds default-off.
   `Weinstein_strategy.config` `stops_config.*` float field →
   Variant_matrix-searchable per R2, same as `vol_scaled_stop_atr_mult`).
 
+- **Build 3 — faithful short** (READY_FOR_REVIEW, PR feat/faithful-short).
+  Two default-off screener knobs that tighten short admission toward Weinstein's
+  confirmed-bear short rule, both bit-identical to baseline when off:
+  - `screener.config.neutral_blocks_shorts` (`[@sexp.default false]`) — short
+    mirror of `neutral_blocks_longs`: new `_shorts_admitted_by_macro`
+    (`Bullish->false | Neutral->not neutral_blocks_shorts | Bearish->true`)
+    rewrites `_evaluate_shorts`. When `true`, a `Neutral` chop tape (the 2020 V,
+    where shorts get squeezed) no longer admits shorts.
+  - `screener.config.enable_slow_grind_short_gate` (`[@sexp.default false]`) —
+    when `true`, shorts are admitted only when the current index decline is a
+    `Decline_character.Slow_grind`. The screener lib stays MACRO-AGNOSTIC (no
+    `macro` dep, A2): it receives a plain `~decline_is_slow_grind:bool` (new
+    optional on `screen_with_cooldown`, default `true` = no-op) and `&&`s it into
+    short admission. The `Slow_grind` bool is classified in the STRATEGY lib
+    (`weinstein_strategy_screening._decline_is_slow_grind`) via
+    `Decline_character_wiring.classify` from the CURRENT cycle's `macro_result` +
+    `index_view` — lookahead-free for an ENTRY gate (entries already gate on the
+    current `macro_trend`; the prior-cycle decline ref is the stops seam).
+  Both knobs are real `Weinstein_strategy.config` fields
+  (`neutral_blocks_shorts`, `enable_slow_grind_short_gate`, both
+  `[@sexp.default false]`) threaded through the `_run_screener` with-override
+  seam into `Screener.config` → Variant_matrix-searchable (R2). No core-module
+  edits. Tests: 6 in `test_screener.ml` (`neutral_blocks_shorts` default-admits /
+  Neutral→0 / Bearish-unaffected; slow-grind gate off-ignores-flag /
+  on-blocks-fast-v / on-admits-slow-grind), all `List.count + equal_to N`.
+
 ## In progress
 
-- None (Build 1 awaiting QC + merge).
+- None.
 
 ## Next steps
 
-1. Merge Build 2 (fast-crash absolute stop, PR feat/fast-crash-stop).
+1. Merge Build 2 (fast-crash absolute stop, PR feat/fast-crash-stop) + Build 3
+   (faithful short, PR feat/faithful-short).
 2. **Build 0** — A/D data wiring (feat-data) `[non-blocking]` — makes the
    A/D-lead leg real (today the indicator is `Neutral` with `~ad_bars:[]`).
-3. **Build 3** — faithful short (Bearish-only + `Slow_grind` gate in screener;
-   depends on Build 1, on main).
-4. Read-only screens (screen-rigor) on the `catastrophic_stop_pct` surface
-   (and the 2020 fast-crash scenario specifically) → WF-CV if promising →
-   promotion grid, before any default flip.
+3. Read-only screens (screen-rigor) on the `catastrophic_stop_pct` surface
+   (and the 2020 fast-crash scenario specifically) and the faithful-short knobs
+   (`neutral_blocks_shorts` × `enable_slow_grind_short_gate`) → WF-CV if
+   promising → promotion grid, before any default flip.
 
 ## Follow-ups
 

--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -45,6 +45,8 @@ type config = {
   max_short_candidates : int;
   cascade_post_stop_cooldown_weeks : int; [@sexp.default 0]
   neutral_blocks_longs : bool; [@sexp.default false]
+  neutral_blocks_shorts : bool; [@sexp.default false]
+  enable_slow_grind_short_gate : bool; [@sexp.default false]
   min_price : float; [@sexp.default 0.0]
 }
 [@@deriving sexp]
@@ -62,6 +64,8 @@ let default_config =
     max_short_candidates = 10;
     cascade_post_stop_cooldown_weeks = 0;
     neutral_blocks_longs = false;
+    neutral_blocks_shorts = false;
+    enable_slow_grind_short_gate = false;
     min_price = 0.0;
   }
 
@@ -247,6 +251,23 @@ let _longs_admitted_by_macro ~neutral_blocks_longs macro_trend =
   | Neutral -> not neutral_blocks_longs
   | Bullish -> true
 
+(** Whether the macro tape admits new short entries.
+
+    Mirror of {!_longs_admitted_by_macro} for the short side.
+    [neutral_blocks_shorts] defaults to [false] = the historical gate (shorts
+    admitted under both [Bearish] and [Neutral]; blocked only under [Bullish]).
+    When [true], [Neutral] also blocks shorts — only [Bearish] admits. This
+    tightens the short side to Weinstein's confirmed-bear rule
+    (weinstein-book-reference.md §Short-Selling Rules: short only in a confirmed
+    bear market), so a non-confirmed ([Neutral]) chop tape — exactly where
+    shorts get squeezed — no longer admits shorts. The long-side gate is
+    unaffected. *)
+let _shorts_admitted_by_macro ~neutral_blocks_shorts macro_trend =
+  match macro_trend with
+  | Bullish -> false
+  | Neutral -> not neutral_blocks_shorts
+  | Bearish -> true
+
 (** Filter, score, grade, sort, and cap long candidates. *)
 let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_score_override ~volume_ratio_exclude_range ~min_price
@@ -261,19 +282,36 @@ let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
     in
     _filter_and_cap ~candidate_fn ~max_n:max_buy_candidates candidates
 
-(** Filter, score, grade, sort, and cap short candidates. *)
+(** Filter, score, grade, sort, and cap short candidates.
+
+    Two default-off gates tighten short admission toward Weinstein's
+    confirmed-bear short rule:
+    - [neutral_blocks_shorts]: when [true], a [Neutral] tape no longer admits
+      shorts (see {!_shorts_admitted_by_macro}).
+    - [enable_slow_grind_short_gate]: when [true], shorts are admitted only when
+      the current index decline is a slow grind ([decline_is_slow_grind]).
+      [decline_is_slow_grind] is computed by the caller (the strategy lib, which
+      owns the macro/decline-character classification) and passed in as a plain
+      bool so this lib stays macro-agnostic. When the gate is [false] (default)
+      the bool is ignored entirely — bit-identical to the prior behaviour. *)
 let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_score_override ~volume_ratio_exclude_range ~min_price
-    ~max_short_candidates ~candidates ~macro_trend : scored_candidate list =
-  match macro_trend with
-  | Bullish -> []
-  | Bearish | Neutral ->
-      let candidate_fn =
-        _short_candidate ~weights ~thresholds ~params ~min_grade
-          ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-          ~min_price
-      in
-      _filter_and_cap ~candidate_fn ~max_n:max_short_candidates candidates
+    ~max_short_candidates ~neutral_blocks_shorts ~enable_slow_grind_short_gate
+    ~decline_is_slow_grind ~candidates ~macro_trend : scored_candidate list =
+  let macro_admits =
+    _shorts_admitted_by_macro ~neutral_blocks_shorts macro_trend
+  in
+  let slow_grind_admits =
+    (not enable_slow_grind_short_gate) || decline_is_slow_grind
+  in
+  if not (macro_admits && slow_grind_admits) then []
+  else
+    let candidate_fn =
+      _short_candidate ~weights ~thresholds ~params ~min_grade
+        ~min_score_override ~max_score_override ~volume_ratio_exclude_range
+        ~min_price
+    in
+    _filter_and_cap ~candidate_fn ~max_n:max_short_candidates candidates
 
 (** Build watchlist: breakout candidates with grade C/D not in the buy list.
     Empty when buys are inactive (Bearish market). *)
@@ -347,7 +385,8 @@ let _prepare_candidates ~stocks ~held_set ~cooldown_set ~sector_map ~is_member =
 (** Evaluate the long and short cascade paths for one screen call. Returns
     [(buy_candidates, short_candidates)]; decoupled from [_screen] so the latter
     stays within the 50-line linter cap. *)
-let _evaluate_candidates ~config ~candidates ~macro_trend =
+let _evaluate_candidates ~config ~decline_is_slow_grind ~candidates ~macro_trend
+    =
   let buy_candidates =
     _evaluate_longs ~weights:config.weights ~thresholds:config.grade_thresholds
       ~params:config.candidate_params ~min_grade:config.min_grade
@@ -364,12 +403,15 @@ let _evaluate_candidates ~config ~candidates ~macro_trend =
       ~max_score_override:config.max_score_override
       ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
       ~min_price:config.min_price
-      ~max_short_candidates:config.max_short_candidates ~candidates ~macro_trend
+      ~max_short_candidates:config.max_short_candidates
+      ~neutral_blocks_shorts:config.neutral_blocks_shorts
+      ~enable_slow_grind_short_gate:config.enable_slow_grind_short_gate
+      ~decline_is_slow_grind ~candidates ~macro_trend
   in
   (buy_candidates, short_candidates)
 
-let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
-    ~is_member : result =
+let _screen ~config ~decline_is_slow_grind ~macro_trend ~sector_map ~stocks
+    ~held_tickers ~cooldown_set ~is_member : result =
   let held_set = String.Set.of_list held_tickers in
   let buys_active =
     _longs_admitted_by_macro ~neutral_blocks_longs:config.neutral_blocks_longs
@@ -381,7 +423,7 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
   in
   let candidates_after_held = List.length candidates in
   let buy_candidates, short_candidates =
-    _evaluate_candidates ~config ~candidates ~macro_trend
+    _evaluate_candidates ~config ~decline_is_slow_grind ~candidates ~macro_trend
   in
   {
     buy_candidates;
@@ -402,11 +444,12 @@ let _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
   }
 
 let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =
-  _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers
-    ~cooldown_set:String.Set.empty ~is_member:(fun _ -> true)
+  _screen ~config ~decline_is_slow_grind:true ~macro_trend ~sector_map ~stocks
+    ~held_tickers ~cooldown_set:String.Set.empty ~is_member:(fun _ -> true)
 
-let screen_with_cooldown ?membership_at ~config ~macro_trend ~sector_map ~stocks
-    ~held_tickers ~as_of ~last_stop_out_dates () : result =
+let screen_with_cooldown ?membership_at ?(decline_is_slow_grind = true) ~config
+    ~macro_trend ~sector_map ~stocks ~held_tickers ~as_of ~last_stop_out_dates
+    () : result =
   let cooldown_set =
     _cooldown_block_set ~cooldown_weeks:config.cascade_post_stop_cooldown_weeks
       ~as_of ~last_stop_out_dates
@@ -414,5 +457,5 @@ let screen_with_cooldown ?membership_at ~config ~macro_trend ~sector_map ~stocks
   let is_member ticker =
     match membership_at with None -> true | Some m -> m ticker as_of
   in
-  _screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers ~cooldown_set
-    ~is_member
+  _screen ~config ~decline_is_slow_grind ~macro_trend ~sector_map ~stocks
+    ~held_tickers ~cooldown_set ~is_member

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -175,6 +175,37 @@ type config = {
           diagnosis). Mirrored from the top-level
           [Weinstein_strategy.config.neutral_blocks_longs] field so the flag is
           a [Variant_matrix] axis. *)
+  neutral_blocks_shorts : bool; [@sexp.default false]
+      (** Short-side mirror of [neutral_blocks_longs]. When [true], a
+          macro-[Neutral] tape blocks new short candidates exactly as a
+          [Bullish] tape does — only [Bearish] admits shorts. Default [false]
+          preserves the historical gate bit-equally: shorts are admitted under
+          both [Bearish] and [Neutral], blocked only under [Bullish].
+
+          This *tightens* the short side to Weinstein's confirmed-bear rule
+          (weinstein-book-reference.md §Short-Selling Rules — "only short in a
+          confirmed bear market"): it removes the [Neutral] chop tape where
+          shorts are most likely to be squeezed (the 2020 V). The long-side gate
+          is unaffected by this flag.
+
+          Default-off short-side entry-gate axis. Mirrored from the top-level
+          [Weinstein_strategy.config.neutral_blocks_shorts] field so the flag is
+          a [Variant_matrix] axis. *)
+  enable_slow_grind_short_gate : bool; [@sexp.default false]
+      (** When [true], shorts are admitted only when the current index decline
+          is a slow grind — i.e. the caller-supplied [~decline_is_slow_grind]
+          (see {!screen_with_cooldown}) is [true]. When [false] (default) the
+          gate is a no-op and [~decline_is_slow_grind] is ignored entirely,
+          bit-identical to the prior behaviour.
+
+          Faithful short tightening (weinstein-book-reference.md §Short-Selling
+          Rules): Weinstein shorts a sustained distribution bear, not a fast
+          V-crash that snaps back. The slow-grind classification is computed by
+          the strategy lib (which owns the macro / decline-character analysis)
+          and passed in as a plain bool so this lib stays macro-agnostic — the
+          screener only [&&]s it into short admission. Default-off short-side
+          axis mirrored from
+          [Weinstein_strategy.config.enable_slow_grind_short_gate]. *)
   min_price : float; [@sexp.default 0.0]
       (** Minimum candidate price to admit — a liquidity floor. [0.0] (default)
           = no floor, bit-identical to pre-floor behaviour. A positive value
@@ -315,6 +346,7 @@ val screen :
 
 val screen_with_cooldown :
   ?membership_at:(string -> Core.Date.t -> bool) ->
+  ?decline_is_slow_grind:bool ->
   config:config ->
   macro_trend:Weinstein_types.market_trend ->
   sector_map:(string, sector_context) Core.Hashtbl.t ->
@@ -326,6 +358,16 @@ val screen_with_cooldown :
   result
 (** [screen_with_cooldown] is {!screen} with the per-symbol post-stop-out
     cooldown gate active and an optional point-in-time (PI) membership gate.
+
+    @param decline_is_slow_grind
+      Whether the current index decline is a slow grind (vs a fast V-crash or no
+      decline). Only consulted when [config.enable_slow_grind_short_gate] is
+      [true], in which case shorts are admitted only when this is [true].
+      Defaults to [true] so that when the gate is off — or the caller has no
+      decline-character information — short admission is bit-identical to the
+      pre-gate behaviour. The caller (the strategy lib) computes this via its
+      decline-character classifier; passing a plain bool keeps this lib
+      macro-agnostic.
 
     @param membership_at
       Optional point-in-time universe-membership predicate. When supplied, the

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -650,6 +650,88 @@ let test_neutral_macro_produces_shorts _ =
   assert_bool "expected short candidate"
     (not (List.is_empty result.short_candidates))
 
+(* A Stage4 short candidate in a Weak sector — same setup as
+   {!test_neutral_macro_produces_shorts}, reused by the faithful-short gate
+   tests below. *)
+let short_setup () =
+  let bars = declining_bars_with_spike ~n:60 100.0 30.0 ~spike_idx:55 in
+  let prior = Some (Stage3 { weeks_topping = 8 }) in
+  let stocks = [ make_analysis "SHORT" prior bars ] in
+  let sector_map =
+    sector_map_of [ ("SHORT", make_sector ~rating:Weak "Energy") ]
+  in
+  (stocks, sector_map)
+
+let screen_short ?(decline_is_slow_grind = true) ~config ~macro_trend () =
+  let stocks, sector_map = short_setup () in
+  Screener.screen_with_cooldown ~decline_is_slow_grind ~config ~macro_trend
+    ~sector_map ~stocks ~held_tickers:[] ~as_of ~last_stop_out_dates:[] ()
+
+(* ------------------------------------------------------------------ *)
+(* neutral_blocks_shorts: Neutral tape blocks shorts when set          *)
+(* ------------------------------------------------------------------ *)
+
+(* Default ([neutral_blocks_shorts=false]) admits shorts in a Neutral tape. *)
+let test_neutral_blocks_shorts_default_admits _ =
+  let result = screen_short ~config:cfg ~macro_trend:Neutral () in
+  assert_that
+    (List.count result.short_candidates ~f:(fun _ -> true))
+    (equal_to 1)
+
+(* With the flag set, a Neutral tape produces zero shorts — symmetric to the
+   [neutral_blocks_longs] gate. *)
+let test_neutral_blocks_shorts_neutral_zero _ =
+  let gated_cfg = { cfg with neutral_blocks_shorts = true } in
+  let result = screen_short ~config:gated_cfg ~macro_trend:Neutral () in
+  assert_that
+    (List.count result.short_candidates ~f:(fun _ -> true))
+    (equal_to 0)
+
+(* The flag does not affect the Bearish tape — shorts still admitted. *)
+let test_neutral_blocks_shorts_bearish_unaffected _ =
+  let gated_cfg = { cfg with neutral_blocks_shorts = true } in
+  let result = screen_short ~config:gated_cfg ~macro_trend:Bearish () in
+  assert_that
+    (List.count result.short_candidates ~f:(fun _ -> true))
+    (equal_to 1)
+
+(* ------------------------------------------------------------------ *)
+(* enable_slow_grind_short_gate: gate short admission on slow-grind     *)
+(* ------------------------------------------------------------------ *)
+
+(* Gate off (default): [decline_is_slow_grind] is ignored — shorts admitted in
+   a Bearish tape even when the decline is not a slow grind. *)
+let test_slow_grind_gate_off_ignores_flag _ =
+  let result =
+    screen_short ~decline_is_slow_grind:false ~config:cfg ~macro_trend:Bearish
+      ()
+  in
+  assert_that
+    (List.count result.short_candidates ~f:(fun _ -> true))
+    (equal_to 1)
+
+(* Gate on + not a slow grind: zero shorts even in a Bearish tape. *)
+let test_slow_grind_gate_on_blocks_fast_v _ =
+  let gated_cfg = { cfg with enable_slow_grind_short_gate = true } in
+  let result =
+    screen_short ~decline_is_slow_grind:false ~config:gated_cfg
+      ~macro_trend:Bearish ()
+  in
+  assert_that
+    (List.count result.short_candidates ~f:(fun _ -> true))
+    (equal_to 0)
+
+(* Gate on + slow grind: shorts present in a Bearish tape. *)
+let test_slow_grind_gate_on_admits_slow_grind _ =
+  let gated_cfg = { cfg with enable_slow_grind_short_gate = true } in
+  let result =
+    screen_short ~decline_is_slow_grind:true ~config:gated_cfg
+      ~macro_trend:Bearish ()
+  in
+  assert_that
+    (List.count result.short_candidates ~f:(fun _ -> true))
+    (equal_to 1)
+
 (* ------------------------------------------------------------------ *)
 (* Short candidate fields: stop above entry                            *)
 (* ------------------------------------------------------------------ *)
@@ -1575,6 +1657,18 @@ let suite =
          >:: test_min_and_max_score_override_compose;
          "test_neutral_macro_produces_shorts"
          >:: test_neutral_macro_produces_shorts;
+         "test_neutral_blocks_shorts_default_admits"
+         >:: test_neutral_blocks_shorts_default_admits;
+         "test_neutral_blocks_shorts_neutral_zero"
+         >:: test_neutral_blocks_shorts_neutral_zero;
+         "test_neutral_blocks_shorts_bearish_unaffected"
+         >:: test_neutral_blocks_shorts_bearish_unaffected;
+         "test_slow_grind_gate_off_ignores_flag"
+         >:: test_slow_grind_gate_off_ignores_flag;
+         "test_slow_grind_gate_on_blocks_fast_v"
+         >:: test_slow_grind_gate_on_blocks_fast_v;
+         "test_slow_grind_gate_on_admits_slow_grind"
+         >:: test_slow_grind_gate_on_admits_slow_grind;
          "test_short_candidate_stop_above_entry"
          >:: test_short_candidate_stop_above_entry;
          "test_candidate_grade_matches_score"

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -49,6 +49,8 @@ let _permissive_screener_config (config : config) : Screener.config =
     max_short_candidates = Int.max_value;
     cascade_post_stop_cooldown_weeks = 0;
     neutral_blocks_longs = false;
+    neutral_blocks_shorts = false;
+    enable_slow_grind_short_gate = false;
     min_price = 0.0;
   }
 

--- a/trading/trading/weinstein/strategy/lib/screening_notional.ml
+++ b/trading/trading/weinstein/strategy/lib/screening_notional.ml
@@ -1,0 +1,37 @@
+open Core
+open Trading_strategy
+
+(* Entry-price notional for a single [Holding] short position; 0.0 for all
+   other position types. Folded over the position map without a deep nested
+   match by [initial_short_notional]. *)
+let _short_holding_notional (pos : Position.t) =
+  match (pos.side, pos.state) with
+  | Trading_base.Types.Short, Position.Holding { quantity; entry_price; _ } ->
+      Float.abs quantity *. entry_price
+  | _ -> 0.0
+
+let initial_short_notional (positions : Position.t Map.M(String).t) =
+  Map.fold positions ~init:0.0 ~f:(fun ~key:_ ~data:pos acc ->
+      acc +. _short_holding_notional pos)
+
+(* Entry-price-denominated absolute notional for a single [Holding] position
+   (long or short); 0.0 for all other states. Companion to
+   [_short_holding_notional] for the sector-exposure cap, which counts long +
+   short exposure to the same sector toward the same bucket. *)
+let _holding_abs_notional (pos : Position.t) =
+  match pos.state with
+  | Position.Holding { quantity; entry_price; _ } ->
+      Float.abs quantity *. entry_price
+  | _ -> 0.0
+
+let initial_sector_exposures ~(positions : Position.t Map.M(String).t)
+    ~sector_lookup =
+  let acc = Hashtbl.create (module String) in
+  Map.iter positions ~f:(fun pos ->
+      let notional = _holding_abs_notional pos in
+      if Float.( > ) notional 0.0 then
+        let sector = sector_lookup pos.symbol |> Option.value ~default:"" in
+        Hashtbl.update acc sector ~f:(function
+          | None -> notional
+          | Some v -> v +. notional));
+  acc

--- a/trading/trading/weinstein/strategy/lib/screening_notional.mli
+++ b/trading/trading/weinstein/strategy/lib/screening_notional.mli
@@ -1,0 +1,22 @@
+(** Per-Friday entry-price-denominated notional / sector-exposure seeds for the
+    screening entry walk. Extracted from {!Weinstein_strategy_screening} to keep
+    that coordinator under its line cap — pure, no behavior change. *)
+
+open Core
+open Trading_strategy
+
+val initial_short_notional : Position.t Map.M(String).t -> float
+(** Sum entry-price-denominated short notional across all open [Holding] shorts.
+    Seeds the per-Friday short-notional accumulator before the entry walk begins
+    (entry-price-denominated so the cap measures committed-at-entry exposure).
+*)
+
+val initial_sector_exposures :
+  positions:Position.t Map.M(String).t ->
+  sector_lookup:(string -> string option) ->
+  (string, float) Hashtbl.t
+(** Build the per-sector exposure accumulator seeded with existing [Holding]
+    positions' entry-price-denominated absolute notional. [sector_lookup]
+    resolves each held symbol to its sector — same source the entry walk uses
+    for new candidates; symbols it can't resolve bucket under the empty string
+    (which the cap exempts). *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -401,6 +401,26 @@ type config = {
           [screening_config.neutral_blocks_longs] at screen time so it is a
           [Variant_matrix] flag axis. See [Weinstein_strategy_config] for full
           semantics. *)
+  neutral_blocks_shorts : bool; [@sexp.default false]
+      (** Short-side mirror of {!neutral_blocks_longs} (default-off): when
+          [true], a macro-[Neutral] tape blocks new short entries (only
+          [Bearish] admits shorts). Default [false] preserves the historical
+          gate where both [Bearish] and [Neutral] admit shorts. Tightens the
+          short side to Weinstein's confirmed-bear rule; the Stage-4 breakdown
+          criteria and the macro gate are unaffected. Threaded into
+          [screening_config.neutral_blocks_shorts] at screen time so it is a
+          [Variant_matrix] flag axis. See [Weinstein_strategy_config] for full
+          semantics. *)
+  enable_slow_grind_short_gate : bool; [@sexp.default false]
+      (** Faithful-short decline-character gate (default-off): when [true],
+          shorts are admitted only when the current primary-index decline is a
+          [Decline_character.Slow_grind] (fast-V crashes and non-declines are
+          excluded). Default [false] is a no-op. The slow-grind bool is
+          classified at screen time from the current macro result + index bars
+          and threaded into
+          [Screener.screen_with_cooldown ~decline_is_slow_grind] (the screener
+          lib stays macro-agnostic). [Variant_matrix] flag axis. See
+          [Weinstein_strategy_config] for full semantics. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -92,18 +92,11 @@ type config = {
           where both [Bullish] and [Neutral] admit longs. Threaded into
           [screening_config.neutral_blocks_longs] at screen time. See [.mli]. *)
   neutral_blocks_shorts : bool; [@sexp.default false]
-      (** Short-side mirror of [neutral_blocks_longs]. When [true], a
-          macro-[Neutral] tape blocks new short entries (only [Bearish] admits
-          shorts); default [false] preserves the historical gate where both
-          [Bearish] and [Neutral] admit shorts. Threaded into
-          [screening_config.neutral_blocks_shorts] at screen time. See [.mli].
-      *)
+      (** Short-side mirror of [neutral_blocks_longs]; default [false] = prior
+          gate (both [Bearish] and [Neutral] admit shorts). See [.mli]. *)
   enable_slow_grind_short_gate : bool; [@sexp.default false]
-      (** When [true], shorts are admitted only when the current index decline
-          is a slow grind (skipping fast-V crashes). Default [false] is a no-op.
-          The slow-grind bool is classified at screen time via
-          [Decline_character] and threaded into [screening_config] +
-          [Screener.screen_with_cooldown ~decline_is_slow_grind]. See [.mli]. *)
+      (** Admit shorts only in a slow-grind decline; default [false] = no-op.
+          See [.mli]. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Master switch for the late-Stage-2 stop-tighten runner; see [.mli]. *)
   late_stage2_stop_buffer_pct : float; [@sexp.default 0.0]
@@ -134,9 +127,10 @@ type config = {
 [@@deriving sexp]
 
 let default_config ~universe ~index_symbol =
+  let indices = { primary = index_symbol; global = [] } in
   {
     universe;
-    indices = { primary = index_symbol; global = [] };
+    indices;
     sector_etfs = [];
     stage_config = Stage.default_config;
     macro_config = Macro.default_config;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -91,6 +91,19 @@ type config = {
           [Bullish] admits longs); default [false] preserves the historical gate
           where both [Bullish] and [Neutral] admit longs. Threaded into
           [screening_config.neutral_blocks_longs] at screen time. See [.mli]. *)
+  neutral_blocks_shorts : bool; [@sexp.default false]
+      (** Short-side mirror of [neutral_blocks_longs]. When [true], a
+          macro-[Neutral] tape blocks new short entries (only [Bearish] admits
+          shorts); default [false] preserves the historical gate where both
+          [Bearish] and [Neutral] admit shorts. Threaded into
+          [screening_config.neutral_blocks_shorts] at screen time. See [.mli].
+      *)
+  enable_slow_grind_short_gate : bool; [@sexp.default false]
+      (** When [true], shorts are admitted only when the current index decline
+          is a slow grind (skipping fast-V crashes). Default [false] is a no-op.
+          The slow-grind bool is classified at screen time via
+          [Decline_character] and threaded into [screening_config] +
+          [Screener.screen_with_cooldown ~decline_is_slow_grind]. See [.mli]. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Master switch for the late-Stage-2 stop-tighten runner; see [.mli]. *)
   late_stage2_stop_buffer_pct : float; [@sexp.default 0.0]
@@ -153,6 +166,8 @@ let default_config ~universe ~index_symbol =
     enable_pi_filter = false;
     margin_config = Trading_portfolio.Margin_config.default_config;
     neutral_blocks_longs = false;
+    neutral_blocks_shorts = false;
+    enable_slow_grind_short_gate = false;
     enable_late_stage2_stop_tighten = false;
     late_stage2_stop_buffer_pct = 0.0;
     enable_macro_bearish_exposure_trim = false;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -156,6 +156,50 @@ type config = {
           through the [Neutral]/[Bullish] bear-rally blips, contributing to the
           false-breakout stop-out churn. Default-off until an experiment-ledger
           ACCEPT (per [.claude/rules/experiment-flag-discipline.md]). *)
+  neutral_blocks_shorts : bool; [@sexp.default false]
+      (** Short-side mirror of {!neutral_blocks_longs} (default-off). When
+          [true], a macro-[Neutral] tape blocks new short entries exactly as a
+          [Bullish] tape does — only a [Bearish] tape admits shorts. Default
+          [false] preserves the historical macro gate bit-equally (shorts
+          admitted under both [Bearish] and [Neutral], blocked only under
+          [Bullish]).
+
+          This *tightens* the short side to Weinstein's confirmed-bear rule
+          (weinstein-book-reference.md §Short-Selling Rules — short only in a
+          confirmed bear market) — a faithful exit/entry-aggressiveness dial,
+          not a spine change: the Stage-4-breakdown + negative-RS + weak-sector
+          \+ volume short criteria and the macro gate itself are unaffected. It
+          removes the [Neutral] chop tape (the 2020 V) where shorts are most
+          likely squeezed.
+
+          Wired by threading into [screening_config.neutral_blocks_shorts] at
+          screen time, so the flag is a single-component [Variant_matrix] flag
+          axis ([((flag neutral_blocks_shorts) (values (true false)))]).
+          Default-off until an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md]). *)
+  enable_slow_grind_short_gate : bool; [@sexp.default false]
+      (** Faithful-short decline-character gate (default-off). When [true],
+          shorts are admitted only when the current primary-index decline is a
+          slow grind ([Decline_character.Slow_grind]) — fast-V crashes and
+          non-declines are excluded. Default [false] is a no-op (bit-identical
+          to baseline; the decline classification is not even consumed).
+
+          Weinstein shorts a sustained distribution bear, not a fast V-crash
+          that snaps back (weinstein-book-reference.md §Short-Selling Rules).
+          The slow-grind bool is classified at screen time from the current
+          macro result + index bars via [Decline_character] /
+          [Decline_character_wiring] (which live in this lib, so
+          [weinstein.screener] stays macro-agnostic) and threaded into
+          [Screener.screen_with_cooldown ~decline_is_slow_grind] alongside
+          [screening_config.enable_slow_grind_short_gate]. The classification
+          uses the *current* cycle's macro + bars — lookahead-free for an entry
+          gate, since entries already gate on the current [macro_trend] (the
+          prior-cycle decline-character ref is for the stop, not entries).
+
+          Single-component [Variant_matrix] flag axis
+          ([((flag enable_slow_grind_short_gate) (values (true false)))]).
+          Default-off until an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md]). *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -409,22 +409,51 @@ let _sector_lookup_of ~sector_map symbol =
   Hashtbl.find sector_map symbol
   |> Option.map ~f:(fun (ctx : Screener.sector_context) -> ctx.sector_name)
 
+(** Whether the current primary-index decline is a slow grind, for the faithful
+    short's [enable_slow_grind_short_gate]. Classified from the {b current}
+    cycle's macro result + index bars via {!Decline_character_wiring} — this is
+    lookahead-free for an entry gate (entries already gate on the current
+    [macro_trend]; the prior-cycle decline-character ref is the stops seam, not
+    the entry seam). Only consulted when the gate is enabled; returns [true]
+    otherwise so short admission stays bit-identical to the pre-gate behaviour
+    (the screener ignores the value when the gate is off). The classification
+    lives here, in the strategy lib (which depends on [weinstein.macro]), so the
+    screener lib stays macro-agnostic — it receives a plain bool. *)
+let _decline_is_slow_grind ~config ~macro_result ~index_view =
+  if not config.enable_slow_grind_short_gate then true
+  else
+    match
+      Decline_character_wiring.classify ~config:Decline_character.default_config
+        ~macro:macro_result ~index_view
+    with
+    | Decline_character.Slow_grind -> true
+    | Decline_character.Fast_v | Decline_character.Not_declining -> false
+
 (** Run the cascade screener over the Phase-2 [stocks], threading the top-level
-    [neutral_blocks_longs] entry-gate flag into the screener config so it is
-    expressible as a [Weinstein_strategy.config] flag axis. Default [false]
-    leaves the screener config untouched bit-equally. Factored out of
-    {!screen_universe} to keep that function under the 50-line linter cap. *)
-let _run_screener ?membership_at ~config ~macro_result ~sector_map ~stocks
-    ~portfolio ~last_stop_out_dates ~current_date () =
+    [neutral_blocks_longs] / [neutral_blocks_shorts] entry-gate flags and the
+    [enable_slow_grind_short_gate] decline-character gate into the screener
+    config so they are expressible as [Weinstein_strategy.config] flag axes.
+    Default [false] on all three leaves the screener config untouched
+    bit-equally. Factored out of {!screen_universe} to keep that function under
+    the 50-line linter cap. *)
+let _run_screener ?membership_at ~config ~(macro_result : Macro.result)
+    ~index_view ~sector_map ~stocks ~portfolio ~last_stop_out_dates
+    ~current_date () =
   let screening_config =
     {
       config.screening_config with
       Screener.neutral_blocks_longs = config.neutral_blocks_longs;
+      Screener.neutral_blocks_shorts = config.neutral_blocks_shorts;
+      Screener.enable_slow_grind_short_gate =
+        config.enable_slow_grind_short_gate;
     }
   in
-  Screener.screen_with_cooldown ?membership_at ~config:screening_config
-    ~macro_trend:macro_result.Macro.trend ~sector_map ~stocks
-    ~held_tickers:(held_symbols portfolio) ~as_of:current_date
+  let decline_is_slow_grind =
+    _decline_is_slow_grind ~config ~macro_result ~index_view
+  in
+  Screener.screen_with_cooldown ?membership_at ~decline_is_slow_grind
+    ~config:screening_config ~macro_trend:macro_result.Macro.trend ~sector_map
+    ~stocks ~held_tickers:(held_symbols portfolio) ~as_of:current_date
     ~last_stop_out_dates:(Hashtbl.to_alist last_stop_out_dates)
     ()
 
@@ -458,8 +487,8 @@ let screen_universe ?active_through_for ?fold_start_date ?membership_at ~config
   in
   _commit_prior_stages ~prior_stages classified;
   let screen_result =
-    _run_screener ?membership_at ~config ~macro_result ~sector_map ~stocks
-      ~portfolio ~last_stop_out_dates ~current_date ()
+    _run_screener ?membership_at ~config ~macro_result ~index_view ~sector_map
+      ~stocks ~portfolio ~last_stop_out_dates ~current_date ()
   in
   let combined_candidates =
     Short_side_gate.combine ~enable_short_side:config.enable_short_side

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -24,51 +24,6 @@ let held_symbols (portfolio : Portfolio_view.t) =
       | Entering _ | Holding _ | Exiting _ -> Some p.symbol
       | Closed _ -> None)
 
-(** Entry-price notional for a single [Holding] short position; 0.0 for all
-    other position types. Used by [_initial_short_notional] to fold over the
-    position map without introducing a deep nested match. *)
-let _short_holding_notional (pos : Position.t) =
-  match (pos.side, pos.state) with
-  | Trading_base.Types.Short, Position.Holding { quantity; entry_price; _ } ->
-      Float.abs quantity *. entry_price
-  | _ -> 0.0
-
-(** Sum entry-price-denominated short notional across all open [Holding] shorts.
-    Used to seed the per-Friday accumulator in [entries_from_candidates] before
-    the entry walk begins. Entry-price-denominated rather than current-price so
-    the cap measures committed-at-entry exposure. *)
-let _initial_short_notional (positions : Position.t Map.M(String).t) =
-  Map.fold positions ~init:0.0 ~f:(fun ~key:_ ~data:pos acc ->
-      acc +. _short_holding_notional pos)
-
-(** Entry-price-denominated absolute notional for a single [Holding] position
-    (long or short); 0.0 for all other states. P1 2026-05-15: companion to
-    [_short_holding_notional] for the sector-exposure cap, which counts long +
-    short exposure to the same sector toward the same bucket. *)
-let _holding_abs_notional (pos : Position.t) =
-  match pos.state with
-  | Position.Holding { quantity; entry_price; _ } ->
-      Float.abs quantity *. entry_price
-  | _ -> 0.0
-
-(** Build the per-sector exposure accumulator seeded with existing [Holding]
-    positions' entry-price-denominated absolute notional. Uses [sector_lookup]
-    to resolve each held symbol to its sector — same source the entry walk uses
-    for new candidates, so the seed and the per-tick bumps stay consistent. Held
-    symbols not in [sector_lookup] are bucketed under the empty string, which
-    the cap exempts (caller can ignore the bucket). *)
-let _initial_sector_exposures ~(positions : Position.t Map.M(String).t)
-    ~sector_lookup =
-  let acc = Hashtbl.create (module String) in
-  Map.iter positions ~f:(fun pos ->
-      let notional = _holding_abs_notional pos in
-      if Float.( > ) notional 0.0 then
-        let sector = sector_lookup pos.symbol |> Option.value ~default:"" in
-        Hashtbl.update acc sector ~f:(function
-          | None -> notional
-          | Some v -> v +. notional));
-  acc
-
 (* Bundle of per-Friday entry-walk accumulators + caps, seeded from
    [portfolio] and [config]. Factored out of [entries_from_candidates] to
    keep that function under the line cap; the accumulators are mutated
@@ -97,7 +52,9 @@ type _entry_walk_state = {
 let _make_entry_walk_state ~cash ~config ~portfolio ~portfolio_value
     ~sector_lookup =
   let short_notional_acc =
-    ref (_initial_short_notional portfolio.Portfolio_view.positions)
+    ref
+      (Screening_notional.initial_short_notional
+         portfolio.Portfolio_view.positions)
   in
   let short_notional_cap =
     portfolio_value *. config.portfolio_config.max_short_notional_fraction
@@ -106,8 +63,8 @@ let _make_entry_walk_state ~cash ~config ~portfolio ~portfolio_value
     match sector_lookup with
     | None -> Hashtbl.create (module String)
     | Some lookup ->
-        _initial_sector_exposures ~positions:portfolio.Portfolio_view.positions
-          ~sector_lookup:lookup
+        Screening_notional.initial_sector_exposures
+          ~positions:portfolio.Portfolio_view.positions ~sector_lookup:lookup
   in
   {
     remaining_cash = ref cash;


### PR DESCRIPTION
## Build 3 — faithful short (Bearish-only + slow-grind decline-character gate)

Design: `dev/notes/decline-character-exploration-2026-06-21-PM.md` §"Build 3".
Today the screener admits shorts whenever macro is `Bearish | Neutral` — there's
a `neutral_blocks_longs` knob but no symmetric short knob, so shorts fire in
`Neutral` chop too (exactly where they get squeezed — the 2020 V). Weinstein
shorts only confirmed bears. This adds two **default-off** knobs to make the
short leg faithful.

### What it does (both default-off → bit-identical to baseline)
**3a — `neutral_blocks_shorts`** (screener config, `[@sexp.default false]`):
short-side mirror of `neutral_blocks_longs`. New `_shorts_admitted_by_macro`
(`Bullish -> false | Neutral -> not neutral_blocks_shorts | Bearish -> true`)
rewrites `_evaluate_shorts`. When `true`, a `Neutral` tape no longer admits
shorts (only `Bearish`).

**3b — `enable_slow_grind_short_gate`** (screener config, `[@sexp.default false]`):
when `true`, shorts are admitted only when the current index decline is a
`Decline_character.Slow_grind` (skip `Fast_v` / `Not_declining`). The screener
lib stays **macro-agnostic** (A2 — no `macro` dep added): it receives a plain
`~decline_is_slow_grind:bool` (new optional on `screen_with_cooldown`, default
`true` = no-op) and `&&`s it into short admission. When the gate is off, the
bool is ignored entirely.

**Where the `Slow_grind` bool is computed (+ lookahead):** in the STRATEGY lib
(`weinstein_strategy_screening._decline_is_slow_grind`), which already deps
`weinstein.macro`, via `Decline_character_wiring.classify` from the **current**
cycle's `macro_result` + `index_view`. This is lookahead-free for an ENTRY gate:
entries already gate on the current `macro_trend`, so classifying with the
current macro/bars introduces no future information (the prior-cycle
decline-character ref is the stops seam from Build 2, not the entry seam).

**Plumbing (R2 searchability):** `neutral_blocks_shorts` +
`enable_slow_grind_short_gate` are real `Weinstein_strategy.config` fields (both
`[@sexp.default false]`), added to `default_config`, threaded through the
`_run_screener` with-override seam into `Screener.config` → both are
`Variant_matrix` flag axes.

### Constraints honored
- **No core-module edits** (`portfolio/orders/position/strategy/engine`). The
  only `trading/trading/` non-feature edit is one literal field-add in
  `backtest/optimal/lib/stage_transition_scanner.ml` (a `Screener.config` record
  literal that must list the two new fields; both set `false` = its existing
  permissive behavior).
- **No `macro` dep added to the screener lib** (A2) — plain bool passed in;
  classification lives in the strategy lib.
- **Default-off (R1):** with both knobs off, every existing golden replays
  bit-identically.
- **Weinstein-faithful (W1/W2):** tightens short admission only (still Stage-4
  breakdown + negative RS + weak-sector + volume + macro gate — spine intact);
  faithful exit/entry-aggressiveness dial per book §Short-Selling Rules (short
  only in confirmed bear markets).

### Tests
6 new tests in `test_screener.ml` (all `List.count + equal_to N`):
- `neutral_blocks_shorts`: default-admits (Neutral→1) / set→Neutral→0 /
  set→Bearish-unaffected→1.
- `enable_slow_grind_short_gate`: off→ignores `decline_is_slow_grind:false`→1 /
  on + `false`→0 / on + `true`→1.

The `Slow_grind` classification reuses Build-2's `Decline_character_wiring`
(itself unit-tested); `_decline_is_slow_grind` is a 1:1 variant→bool wrapper, so
the gate's behavioral contract is pinned end-to-end at the screener level.

### Verification
`dune build @fmt && dune build && dune runtest devtools/checks && dune runtest
analysis/weinstein/screener/ trading/weinstein/strategy/` — the full `&&` chain
exits 0 on the formatted tree (fmt clean; no nesting/fn/file-length FAIL for the
changed files; all suites pass).

Do not modify `dev/status/_index.md` from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)