### PR TITLE
feat(barbell): floor_weight searchable axis (R2 completion)

### DIFF
--- a/dev/plans/barbell-floor-weight-axis-2026-06-22.md
+++ b/dev/plans/barbell-floor-weight-axis-2026-06-22.md
@@ -1,0 +1,149 @@
+# Plan: expose `barbell_floor_weight` as a searchable axis (R2 completion)
+
+Date: 2026-06-22
+Track: `barbell-overlay`
+Branch: `feat/barbell-floor-weight-axis`
+
+## 1. Context
+
+The deployable barbell overlay (gate #2, PR #1683) landed `Barbell_config.t`
+with three default-off fields (`enable`, `floor_weight`, `rebalance_weeks`).
+Per `.claude/rules/experiment-flag-discipline.md`:
+
+- **R1 (default-off on merge)** — satisfied: every field is a no-op at default
+  (`floor_weight = 0.0` ≡ pure engine).
+- **R2 (an axis the day it lands)** — **not yet satisfied**. The mechanism is
+  not searchable: a session that wants to compare 70/30 vs neighbouring floor
+  weights (0.20 / 0.30 / 0.40 / …) must hand-run `barbell_overlay_runner.exe`
+  once per weight and `paste`/`awk` the metric rows together by hand.
+- **R3 (no default-on without ACCEPT)** — out of scope here; we flip no default.
+
+This task closes **R2**: make `floor_weight` enumerable into a searchable
+surface — one barbell run + one metric row per weight value — as a small, pure,
+unit-testable expander.
+
+### Why the existing axis machinery cannot be reused as-is
+
+`Variant_matrix` (`trading/trading/backtest/walk_forward/lib/variant_matrix.mli`)
+expands axes into `Walk_forward_runner.variant`s and **validates every override
+at expansion time against the canonical `Weinstein_strategy.config`** via
+`Overlay_validator.apply_overrides` (its `.mli` hard-codes that config type).
+But `floor_weight` lives in a **separate** `Barbell_config.t`, and the barbell
+overlay runs through its **own** `Barbell_scenario.run` →
+`Barbell_runner.run` path, not the walk-forward / variant-matrix path. So a
+`(barbell floor_weight)` override would fail `Overlay_validator` validation —
+`floor_weight` is not a `Weinstein_strategy.config` field.
+
+## 2. Approach — Option 1 (self-contained barbell floor-weight sweep) — CHOSEN
+
+A small, pure module **`Barbell_floor_sweep`** in
+`trading/trading/backtest/barbell/lib/` that:
+
+- Declares a floor-weight axis: a list of `floor_weight` values to search.
+- Expands it into one **cell per value**, each carrying the resolved
+  `Barbell_config.t` (`enable = true`, that `floor_weight`, the shared
+  `rebalance_weeks`) and a deterministic `label` (`floor_weight=0.30`).
+- Provides a pure `metrics_table` that, given a per-cell *blend thunk*
+  (`Barbell_config.t -> Barbell_blend.metrics`), forces each cell and returns
+  the `(label, floor_weight, metrics)` rows — the searchable surface, ordered
+  by ascending weight. The thunk indirection keeps the expander unit-testable
+  without forking a real backtest, mirroring `Barbell_runner`'s
+  leg-thunk / `Rolling_start_runner`'s pure-executable split.
+
+This mirrors `Variant_matrix`'s "declare axis → expand to cells" ergonomics but
+scoped entirely to `Barbell_config`, validated against `Barbell_config.validate`
+(not `Overlay_validator`). No edit to `Weinstein_strategy.config`,
+`Overlay_validator`, or `Variant_matrix`.
+
+A thin executable **`barbell_floor_sweep_runner.exe`** under
+`scenario/bin/` reuses `Barbell_scenario.run` once per cell (real backtest legs,
+the engine leg run once and shared across weights since only the blend weight
+varies) and writes a `floor_sweep.csv` metric table — so the surface is
+producible from a single CLI invocation instead of N manual runs.
+
+### Axis-value reuse: run the legs once, blend N times
+
+`floor_weight` only changes the **blend weight** of two fixed equity curves; it
+does not change either leg's backtest. So the runner runs the FLOOR and ENGINE
+legs **once each**, then calls `Barbell_blend.blend` per weight against the same
+two curves. This is both correct (the legs are weight-independent) and ~N× faster
+than N full barbell runs. The pure `Barbell_floor_sweep.metrics_table` is given a
+blend thunk that closes over the two shared curves, so this optimisation lives in
+the runner, not the pure core.
+
+### Rejected: Option 2 (generalize the axis machinery)
+
+Generalizing `Overlay_validator` / `Variant_matrix` to validate against config
+types other than `Weinstein_strategy.config` (functor/typeclass over the base
+record) is a cross-cutting experiment-platform change touching shared modules the
+maintainer owns. It is out of scope for an R2-completion follow-up and explicitly
+fenced off by the dispatch guard. Option 1 fully satisfies R2 (the weight becomes
+searchable as a surface) without it.
+
+### Rejected: Option 3 (graft barbell config into `Weinstein_strategy.config`)
+
+Explicitly forbidden by the dispatch (maintainer mid-sprint on those files).
+
+## 3. Files to change
+
+New (all under `trading/trading/backtest/barbell/`):
+- `lib/barbell_floor_sweep.mli` — axis type + `cells` (axis → cells) + pure
+  `metrics_table` (cells × blend-thunk → rows).
+- `lib/barbell_floor_sweep.ml` — implementation.
+- `test/test_barbell_floor_sweep.ml` — unit tests (pure, no backtest fork).
+- `scenario/bin/barbell_floor_sweep_runner.ml` — CLI: run legs once, blend per
+  weight, write `floor_sweep.csv`.
+
+Modified:
+- `test/dune` — add `test_barbell_floor_sweep` to `(names …)`.
+- `scenario/bin/dune` — add the new executable.
+- `dev/status/barbell-overlay.md` — flip the R2 checkbox, add a §Completed entry.
+
+No edits to `lib/dune` libraries needed (the sweep module depends only on
+`core` + the existing `barbell` lib's `Barbell_config` / `Barbell_blend`, which
+are in the same library).
+
+## 4. Risks / unknowns
+
+- **R2 faithfulness.** R2 says "make it an axis"; the canonical axis type is
+  `Variant_matrix.axis`. Risk: a reviewer reads R2 as *literally a
+  `Variant_matrix` cell*. Mitigation: the plan + module docstring state
+  explicitly that `Variant_matrix` validates against `Weinstein_strategy.config`
+  and so cannot carry a `Barbell_config` field, and that this module is the
+  faithful in-scope equivalent (declare axis → expand → searchable surface,
+  validated against `Barbell_config.validate`). The mechanism *is* now
+  searchable from one invocation, which is R2's purpose.
+- **Default-off invariant.** The sweep enumerates weights but flips no global
+  default; the axis is only realised when a session opts into running the
+  sweep. `floor_weight = 0.0` remains a valid (no-op) cell.
+- **Validation.** Each cell's `Barbell_config` must pass `Barbell_config.validate`
+  (weight in `[0,1]`); the expander rejects an out-of-range weight loudly
+  (mirrors `Variant_matrix` raising on a bad override) rather than silently
+  producing a degenerate cell.
+
+## 5. Acceptance criteria
+
+- `Barbell_floor_sweep` exposes a pure axis → cells expansion and a pure
+  `metrics_table`, every public symbol documented in the `.mli`.
+- Unit tests (Matchers, one `assert_that` per value): cell count = value count,
+  ascending-weight ordering, `Barbell_config` per cell correct, default-weight
+  (0.0) cell present and valid, out-of-range weight rejected, and a
+  `metrics_table` over a stub blend-thunk returns one row per cell in order.
+- `barbell_floor_sweep_runner.exe` builds and reuses `Barbell_scenario`'s leg
+  construction; legs run once, blended per weight.
+- No function > 50 lines, no magic numbers (axis defaults are named / config).
+- `dev/lib/run-in-env.sh dune build && dune runtest` green, `dune build @fmt`
+  clean.
+- No edits to `Weinstein_strategy.{ml,mli}`, `Overlay_validator`,
+  `Variant_matrix`, or any core module. Diff confined to `barbell/` + plan +
+  the one status row.
+
+## 6. Out of scope
+
+- Flipping any default on (promotion) — ledger-gated per R3 /
+  `promotion-confirmation.md`.
+- Generalizing `Overlay_validator` / `Variant_matrix` (Option 2).
+- Wiring `floor_weight` into the walk-forward CV / Deflated-Sharpe pipeline —
+  the sweep produces the metric surface; ranking/CV is a separate concern.
+- Any change to the blend math, leg construction, or `Barbell_scenario`/runner
+  semantics beyond the new sweep entrypoint.

--- a/dev/status/barbell-overlay.md
+++ b/dev/status/barbell-overlay.md
@@ -82,10 +82,34 @@ NO
   produced, starts normalised at 1.0, and the 50/50 blend's terminal NAV lies
   between the two legs'. Verify:
   `dune runtest trading/backtest/barbell/scenario/`.
+- [x] **`floor_weight` searchable axis (R2 completion)** —
+  `feat/barbell-floor-weight-axis`. New pure module
+  `trading/trading/backtest/barbell/lib/barbell_floor_sweep.{ml,mli}`:
+  declares a floor-weight axis (a list of weights at a fixed rebalance cadence),
+  `cells` expands it into one ascending-ordered `Barbell_config` cell per weight
+  (each validated via `Barbell_config.validate`, raising loudly on a bad axis
+  like `Variant_matrix.expand`), and `metrics_table` evaluates each cell through
+  a blend thunk into a `(label, weight, metrics)` surface — the R2-completion
+  equivalent of a `Variant_matrix` axis scoped to `Barbell_config` (the canonical
+  axis machinery validates against `Weinstein_strategy.config`, which
+  `floor_weight` is not part of). A thin `barbell_floor_sweep_runner.exe`
+  (`scenario/bin/`) runs the two legs **once** via `Barbell_scenario.run` then
+  blends per weight (the legs are weight-independent), writing `floor_sweep.csv`.
+  Default-off preserved: enumerating weights flips no default; `0.0` stays a
+  valid no-op cell. **No core-module edits, no `Overlay_validator`/`Variant_matrix`
+  changes.** 7 pure unit tests (cell count/order, default-weight cell validity,
+  malformed-axis rejection, `metrics_table` row ordering via a stub thunk).
+  Verify: `dune runtest trading/backtest/barbell/test/`.
 
 ## Next Steps
-- [ ] Expose `barbell_floor_weight` as a `Variant_matrix` axis so 70/30 vs
-  neighbours stays searchable (R2 completion). `[non-blocking]`
+- [x] Expose `barbell_floor_weight` as a searchable axis so 70/30 vs neighbours
+  stays searchable (R2 completion). `feat/barbell-floor-weight-axis`. Built
+  Option 1 (self-contained barbell-local axis) per
+  `dev/plans/barbell-floor-weight-axis-2026-06-22.md` — the canonical
+  `Variant_matrix` cannot carry this field (it validates axis overrides against
+  `Weinstein_strategy.config` via `Overlay_validator`, and `floor_weight` lives
+  in a separate `Barbell_config.t`). Verify:
+  `dune runtest trading/backtest/barbell/test/`.
 
 ## Out of scope
 - Flipping any default on (promotion). Requires a confirmation-grid ACCEPT per

--- a/trading/trading/backtest/barbell/lib/barbell_floor_sweep.ml
+++ b/trading/trading/backtest/barbell/lib/barbell_floor_sweep.ml
@@ -1,0 +1,57 @@
+open Core
+
+type axis = { floor_weights : float list; rebalance_weeks : int }
+[@@deriving sexp, eq, show]
+
+type cell = { label : string; config : Barbell_config.t }
+[@@deriving sexp, eq, show]
+
+type row = {
+  label : string;
+  floor_weight : float;
+  metrics : Barbell_blend.metrics;
+}
+[@@deriving sexp, eq, show]
+
+let _label_of_weight w = Printf.sprintf "floor_weight=%.2f" w
+
+(* Validate the axis itself before expanding: non-empty, no duplicate weights,
+   sane cadence. Per-cell config validity is checked in [_cell_of_weight]. *)
+let _validate_axis (axis : axis) : unit =
+  if List.is_empty axis.floor_weights then
+    invalid_arg "Barbell_floor_sweep: floor_weights must be non-empty";
+  if axis.rebalance_weeks < 1 then
+    invalid_arg
+      (Printf.sprintf
+         "Barbell_floor_sweep: rebalance_weeks must be >= 1, got %d"
+         axis.rebalance_weeks);
+  let sorted = List.sort axis.floor_weights ~compare:Float.compare in
+  match List.find_consecutive_duplicate sorted ~equal:Float.equal with
+  | Some (w, _) ->
+      invalid_arg
+        (Printf.sprintf "Barbell_floor_sweep: duplicate floor_weight %.4f" w)
+  | None -> ()
+
+let _cell_of_weight ~rebalance_weeks floor_weight : cell =
+  let config =
+    { Barbell_config.enable = true; floor_weight; rebalance_weeks }
+  in
+  match Barbell_config.validate config with
+  | Ok () -> { label = _label_of_weight floor_weight; config }
+  | Error msg -> invalid_arg ("Barbell_floor_sweep: " ^ msg)
+
+let cells (axis : axis) : cell list =
+  _validate_axis axis;
+  axis.floor_weights
+  |> List.sort ~compare:Float.compare
+  |> List.map ~f:(_cell_of_weight ~rebalance_weeks:axis.rebalance_weeks)
+
+let metrics_table (axis : axis)
+    ~(blend : Barbell_config.t -> Barbell_blend.metrics) : row list =
+  cells axis
+  |> List.map ~f:(fun (cell : cell) ->
+      {
+        label = cell.label;
+        floor_weight = cell.config.floor_weight;
+        metrics = blend cell.config;
+      })

--- a/trading/trading/backtest/barbell/lib/barbell_floor_sweep.mli
+++ b/trading/trading/backtest/barbell/lib/barbell_floor_sweep.mli
@@ -1,0 +1,99 @@
+(** Floor-weight axis for the deployable barbell overlay (gate #2, R2
+    completion).
+
+    Makes {!Barbell_config.t}'s [floor_weight] a {b searchable surface}: declare
+    a list of weights to compare (e.g. [0.20; 0.30; 0.40]) and expand it into
+    one cell per weight, each carrying a resolved {!Barbell_config.t} and a
+    deterministic label — then evaluate every cell into a
+    [(label, weight, metrics)] row, the comparison table a tuning session reads.
+
+    {b Why a barbell-local axis rather than a {!Backtest.Variant_matrix} cell.}
+    {!Backtest.Variant_matrix} validates every axis override against the
+    canonical {!Weinstein_strategy.config} via
+    [Overlay_validator.apply_overrides] at expansion time. But [floor_weight]
+    lives in a {e separate} {!Barbell_config.t} and the overlay runs through
+    {!Barbell_runner.run}, not the walk-forward / variant-matrix path — so a
+    [(barbell floor_weight)] override would fail that validation (it is not a
+    [Weinstein_strategy.config] field). This module is the faithful in-scope
+    equivalent of an axis scoped to {!Barbell_config}: same "declare axis →
+    expand to cells → evaluate to a searchable surface" ergonomics, validated
+    against {!Barbell_config.validate} rather than [Overlay_validator]. See
+    [dev/plans/barbell-floor-weight-axis-2026-06-22.md].
+
+    Pure and self-contained: the expansion and the table builder take a
+    blend-thunk (so the table is unit-testable without forking a backtest, the
+    same pure/executable split {!Barbell_runner} and
+    {!Backtest.Rolling_start_runner} use). The executable
+    [barbell_floor_sweep_runner] wires the thunk to a real
+    {!Barbell_blend.blend} over two legs run once.
+
+    Default-off per [.claude/rules/experiment-flag-discipline.md]: enumerating
+    weights flips no default; the axis is only realised when a session opts into
+    running the sweep, and [floor_weight = 0.0] remains a valid (no-op = pure
+    engine) cell. Promoting any weight to the default is a separate,
+    ledger-gated decision (R3 / [.claude/rules/promotion-confirmation.md]). *)
+
+type axis = {
+  floor_weights : float list;
+      (** The [floor_weight] values to search, each in [[0.0, 1.0]]. Order is
+          irrelevant — {!cells} sorts ascending. Must be non-empty and contain
+          no duplicates. *)
+  rebalance_weeks : int;
+      (** The rebalance cadence shared by every cell (only [floor_weight] varies
+          across the surface). Must be [>= 1]; see
+          {!Barbell_config.rebalance_weeks}. *)
+}
+[@@deriving sexp, eq, show]
+(** A floor-weight axis declaration: a list of weights to compare at a fixed
+    rebalance cadence. Mirrors a single-axis {!Backtest.Variant_matrix.t} scoped
+    to {!Barbell_config}. *)
+
+type cell = {
+  label : string;
+      (** Deterministic compact label for the cell, [Printf]-formatted as
+          ["floor_weight=0.30"] (two decimals) — the row key in the surface. *)
+  config : Barbell_config.t;
+      (** The resolved overlay config for this cell: [enable = true], this
+          cell's [floor_weight], and the axis's shared [rebalance_weeks]. Passes
+          {!Barbell_config.validate}. *)
+}
+[@@deriving sexp, eq, show]
+(** One point on the searchable surface: a labelled {!Barbell_config.t}
+    differing from its neighbours only in [floor_weight]. *)
+
+val cells : axis -> cell list
+(** [cells axis] expands [axis] into one {!cell} per weight, in
+    {b ascending weight} order (so the surface reads low→high floor). Each
+    cell's [config] is
+    [{ enable = true; floor_weight; rebalance_weeks = axis.rebalance_weeks }].
+
+    @raise Invalid_argument
+      if [axis.floor_weights] is empty or contains duplicates, if
+      [axis.rebalance_weeks < 1], or if any resulting {!Barbell_config.t} fails
+      {!Barbell_config.validate} (a weight outside [[0,1]]) — loudly, mirroring
+      {!Backtest.Variant_matrix.expand} raising on an invalid axis rather than
+      silently producing a degenerate cell. *)
+
+type row = {
+  label : string;  (** The cell's {!cell.label}. *)
+  floor_weight : float;  (** The cell's [floor_weight]. *)
+  metrics : Barbell_blend.metrics;
+      (** The blend metrics for this cell, from the supplied blend thunk. *)
+}
+[@@deriving sexp, eq, show]
+(** One row of the comparison surface: a cell's label + weight paired with its
+    evaluated blend metrics. *)
+
+val metrics_table :
+  axis -> blend:(Barbell_config.t -> Barbell_blend.metrics) -> row list
+(** [metrics_table axis ~blend] expands [axis] via {!cells} and evaluates each
+    cell's [config] through [blend], returning one {!row} per cell in
+    ascending-weight order — the searchable surface.
+
+    [blend] is the per-cell evaluator: the executable supplies
+    [fun config -> (Barbell_blend.blend ~config ~floor_curve
+     ~engine_curve).metrics] over two legs run once (only the blend weight
+    varies, so the legs need not re-run per cell). A test supplies a
+    deterministic stub.
+
+    @raise Invalid_argument from {!cells} on an invalid axis. *)

--- a/trading/trading/backtest/barbell/scenario/bin/barbell_floor_sweep_runner.ml
+++ b/trading/trading/backtest/barbell/scenario/bin/barbell_floor_sweep_runner.ml
@@ -1,0 +1,216 @@
+(** [barbell_floor_sweep_runner] — sweep the barbell overlay's [floor_weight]
+    over a list of values and write the comparison surface.
+
+    R2 completion for the deployable barbell overlay (gate #2): makes
+    {!Barbell.Barbell_config.floor_weight} a {b searchable surface}. Given a
+    scenario sexp (period + universe + snapshot context) and a list of floor
+    weights, run the FLOOR and ENGINE legs {e once each} over the window, then
+    blend their two equity curves at every requested weight — only the blend
+    weight varies across the surface, so the legs are weight-independent and
+    need not re-run per cell. Writes one metric row per weight to
+    [<out-dir>/floor_sweep.csv].
+
+    This is a thin CLI shim over {!Barbell_scenario.run} (to obtain the two leg
+    curves once) + {!Barbell.Barbell_floor_sweep.metrics_table} (the pure axis
+    expansion + per-cell blend). No core-module edits — each sleeve reuses
+    {!Backtest.Runner.run_backtest} unchanged.
+
+    Default-off per [.claude/rules/experiment-flag-discipline.md]: enumerating
+    weights flips no default; [0.0] is a valid (pure-engine no-op) cell. The
+    documented promotion target is a light floor [~0.30-0.40]
+    ([dev/backtest/barbell-grid-2026-06-20/FINDINGS.md]), but promoting any
+    weight is a separate, ledger-gated decision.
+
+    Usage:
+    {[
+      barbell_floor_sweep_runner --scenario <path.sexp> --out-dir <dir>
+        [--floor-weights 0.2,0.3,0.4] [--rebalance-weeks N]
+        [--floor-symbol SYMBOL] [--floor-ma-weeks N]
+        [--fixtures-root <path>] [--snapshot-dir <path>]
+    ]}
+
+    [--floor-weights] (default [0.2,0.3,0.4,0.5]) is the comma-separated list of
+    FLOOR-sleeve target fractions to compare. The remaining flags match
+    [barbell_overlay_runner]. *)
+
+open Core
+module Scenario = Scenario_lib.Scenario
+module Fixtures_root = Scenario_lib.Fixtures_root
+module Bar_source_resolver = Scenario_lib.Bar_source_resolver
+module Sweep = Barbell.Barbell_floor_sweep
+module Blend = Barbell.Barbell_blend
+
+type _cli_args = {
+  scenario : string;
+  out_dir : string;
+  floor_weights : float list;
+  rebalance_weeks : int;
+  floor_symbol : string;
+  floor_ma_weeks : int;
+  fixtures_root : string option;
+  snapshot_dir : string option;
+}
+
+let _default_floor_weights = [ 0.2; 0.3; 0.4; 0.5 ]
+let _default_rebalance_weeks = 1
+let _default_floor_symbol = "SPY"
+let _default_floor_ma_weeks = 30
+
+let _usage () =
+  eprintf
+    "Usage: barbell_floor_sweep_runner --scenario <path.sexp> --out-dir <dir> \
+     [--floor-weights 0.2,0.3,0.4] [--rebalance-weeks N] [--floor-symbol \
+     SYMBOL] [--floor-ma-weeks N] [--fixtures-root <path>] [--snapshot-dir \
+     <path>]\n";
+  Stdlib.exit 1
+
+let _parse_weights s =
+  String.split s ~on:',' |> List.map ~f:String.strip
+  |> List.filter ~f:(fun t -> not (String.is_empty t))
+  |> List.map ~f:Float.of_string
+
+type _parse_acc = {
+  mutable scenario : string option;
+  mutable out_dir : string option;
+  mutable floor_weights : float list option;
+  mutable rebalance_weeks : int option;
+  mutable floor_symbol : string option;
+  mutable floor_ma_weeks : int option;
+  mutable fixtures_root : string option;
+  mutable snapshot_dir : string option;
+}
+
+let _finalize (acc : _parse_acc) : _cli_args =
+  match (acc.scenario, acc.out_dir) with
+  | Some scenario, Some out_dir ->
+      {
+        scenario;
+        out_dir;
+        floor_weights =
+          Option.value acc.floor_weights ~default:_default_floor_weights;
+        rebalance_weeks =
+          Option.value acc.rebalance_weeks ~default:_default_rebalance_weeks;
+        floor_symbol =
+          Option.value acc.floor_symbol ~default:_default_floor_symbol;
+        floor_ma_weeks =
+          Option.value acc.floor_ma_weeks ~default:_default_floor_ma_weeks;
+        fixtures_root = acc.fixtures_root;
+        snapshot_dir = acc.snapshot_dir;
+      }
+  | _ -> _usage ()
+
+let _parse_flags args : _cli_args =
+  let acc =
+    {
+      scenario = None;
+      out_dir = None;
+      floor_weights = None;
+      rebalance_weeks = None;
+      floor_symbol = None;
+      floor_ma_weeks = None;
+      fixtures_root = None;
+      snapshot_dir = None;
+    }
+  in
+  let rec loop = function
+    | [] -> _finalize acc
+    | "--scenario" :: p :: rest ->
+        acc.scenario <- Some p;
+        loop rest
+    | "--out-dir" :: p :: rest ->
+        acc.out_dir <- Some p;
+        loop rest
+    | "--floor-weights" :: s :: rest ->
+        acc.floor_weights <- Some (_parse_weights s);
+        loop rest
+    | "--rebalance-weeks" :: n :: rest ->
+        acc.rebalance_weeks <- Some (Int.of_string n);
+        loop rest
+    | "--floor-symbol" :: s :: rest ->
+        acc.floor_symbol <- Some s;
+        loop rest
+    | "--floor-ma-weeks" :: n :: rest ->
+        acc.floor_ma_weeks <- Some (Int.of_string n);
+        loop rest
+    | "--fixtures-root" :: p :: rest ->
+        acc.fixtures_root <- Some p;
+        loop rest
+    | "--snapshot-dir" :: p :: rest ->
+        acc.snapshot_dir <- Some p;
+        loop rest
+    | _ -> _usage ()
+  in
+  loop args
+
+(* Run the two legs once (at weight 0.0 — the engine no-op, so the returned
+   per-leg curves are the unblended leg NAVs) and return them. floor_weight only
+   changes the blend, never the legs, so one run feeds the whole surface. *)
+let _run_legs_once ~scenario ~fixtures_root ~bar_data_source ~floor ~engine
+    ~rebalance_weeks : (Date.t * float) list * (Date.t * float) list =
+  let probe_config =
+    {
+      Barbell.Barbell_config.enable = true;
+      floor_weight = 0.0;
+      rebalance_weeks;
+    }
+  in
+  let result =
+    Barbell_scenario.run ~scenario ~fixtures_root ~bar_data_source
+      ~config:probe_config ~floor ~engine
+  in
+  (result.floor.equity_curve, result.engine.equity_curve)
+
+let _write_csv ~out_dir (rows : Sweep.row list) : string =
+  let path = Filename.concat out_dir "floor_sweep.csv" in
+  let header =
+    "floor_weight,total_return_pct,sharpe,max_drawdown_pct,calmar,ulcer_pct,n_points"
+  in
+  let line (r : Sweep.row) =
+    let m = r.metrics in
+    Printf.sprintf "%.2f,%.4f,%.4f,%.4f,%.4f,%.4f,%d" r.floor_weight
+      m.Blend.total_return_pct m.sharpe m.max_drawdown_pct m.calmar m.ulcer_pct
+      m.n_points
+  in
+  let body = List.map rows ~f:line in
+  Out_channel.write_lines path (header :: body);
+  path
+
+let () =
+  let args = _parse_flags (List.tl_exn (Array.to_list (Sys.get_argv ()))) in
+  let fixtures_root =
+    Fixtures_root.resolve ?fixtures_root:args.fixtures_root ()
+  in
+  let bar_data_source = Bar_source_resolver.resolve args.snapshot_dir in
+  let scenario = Scenario.load args.scenario in
+  let floor =
+    Barbell_scenario.spy_floor_leg ~symbol:args.floor_symbol
+      ~ma_period_weeks:args.floor_ma_weeks ()
+  in
+  let engine =
+    Barbell_scenario.engine_leg ~strategy:scenario.strategy
+      ~overrides:scenario.config_overrides ()
+  in
+  Core_unix.mkdir_p args.out_dir;
+  let floor_curve, engine_curve =
+    _run_legs_once ~scenario ~fixtures_root ~bar_data_source ~floor ~engine
+      ~rebalance_weeks:args.rebalance_weeks
+  in
+  let axis =
+    {
+      Sweep.floor_weights = args.floor_weights;
+      rebalance_weeks = args.rebalance_weeks;
+    }
+  in
+  let rows =
+    Sweep.metrics_table axis ~blend:(fun config ->
+        (Blend.blend ~config ~floor_curve ~engine_curve).metrics)
+  in
+  let path = _write_csv ~out_dir:args.out_dir rows in
+  eprintf
+    "barbell floor sweep: scenario=%s weights=[%s] rebalance_weeks=%d -> %s \
+     (%d rows)\n\
+     %!"
+    scenario.name
+    (String.concat ~sep:","
+       (List.map args.floor_weights ~f:(Printf.sprintf "%.2f")))
+    args.rebalance_weeks path (List.length rows)

--- a/trading/trading/backtest/barbell/scenario/bin/dune
+++ b/trading/trading/backtest/barbell/scenario/bin/dune
@@ -1,6 +1,6 @@
-(executable
- (name barbell_overlay_runner)
- (modules barbell_overlay_runner)
+(executables
+ (names barbell_overlay_runner barbell_floor_sweep_runner)
+ (modules barbell_overlay_runner barbell_floor_sweep_runner)
  (libraries core core_unix barbell barbell_scenario scenario_lib)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/barbell/test/dune
+++ b/trading/trading/backtest/barbell/test/dune
@@ -1,5 +1,9 @@
 (tests
- (names test_barbell_blend test_barbell_config test_barbell_runner)
+ (names
+  test_barbell_blend
+  test_barbell_config
+  test_barbell_floor_sweep
+  test_barbell_runner)
  (libraries ounit2 core matchers barbell trading.simulation.types)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/barbell/test/test_barbell_floor_sweep.ml
+++ b/trading/trading/backtest/barbell/test/test_barbell_floor_sweep.ml
@@ -1,0 +1,153 @@
+open Core
+open OUnit2
+open Matchers
+module Sweep = Barbell.Barbell_floor_sweep
+module Config = Barbell.Barbell_config
+module Blend = Barbell.Barbell_blend
+
+let make_axis ?(rebalance_weeks = 1) floor_weights : Sweep.axis =
+  { floor_weights; rebalance_weeks }
+
+(* cells expands one cell per weight, sorted ascending, each carrying the
+   resolved enable=true config at the axis's shared cadence. *)
+let test_cells_one_per_weight_ascending _ =
+  let cells = Sweep.cells (make_axis ~rebalance_weeks:4 [ 0.40; 0.20; 0.30 ]) in
+  let weight (c : Sweep.cell) = c.config.Config.floor_weight in
+  assert_that cells
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : Sweep.cell) -> c.label)
+               (equal_to "floor_weight=0.20");
+             field
+               (fun (c : Sweep.cell) -> c.config.Config.enable)
+               (equal_to true);
+             field weight (float_equal 0.20);
+             field
+               (fun (c : Sweep.cell) -> c.config.Config.rebalance_weeks)
+               (equal_to 4);
+           ];
+         all_of
+           [
+             field
+               (fun (c : Sweep.cell) -> c.label)
+               (equal_to "floor_weight=0.30");
+             field weight (float_equal 0.30);
+           ];
+         all_of
+           [
+             field
+               (fun (c : Sweep.cell) -> c.label)
+               (equal_to "floor_weight=0.40");
+             field weight (float_equal 0.40);
+           ];
+       ])
+
+(* The default weight 0.0 (pure-engine no-op) is a valid cell — enumerating it
+   flips no default, it is just a searchable point. *)
+let test_zero_weight_cell_is_valid _ =
+  let cells = Sweep.cells (make_axis [ 0.0; 0.5 ]) in
+  assert_that cells
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : Sweep.cell) -> c.config.Config.floor_weight)
+               (float_equal 0.0);
+             field
+               (fun (c : Sweep.cell) -> Result.is_ok (Config.validate c.config))
+               (equal_to true);
+           ];
+         field
+           (fun (c : Sweep.cell) -> c.config.Config.floor_weight)
+           (float_equal 0.5);
+       ])
+
+(* cells raises Invalid_argument on a malformed axis (mirrors
+   Variant_matrix.expand raising loudly rather than yielding a degenerate cell);
+   we assert the raise via Result.try_with -> is_error as a bool. *)
+let raises_invalid f =
+  Result.is_error (Result.try_with (fun () -> ignore (f () : Sweep.cell list)))
+
+let test_empty_axis_rejected _ =
+  assert_that
+    (raises_invalid (fun () -> Sweep.cells (make_axis [])))
+    (equal_to true)
+
+let test_duplicate_weight_rejected _ =
+  assert_that
+    (raises_invalid (fun () -> Sweep.cells (make_axis [ 0.3; 0.5; 0.3 ])))
+    (equal_to true)
+
+let test_out_of_range_weight_rejected _ =
+  assert_that
+    (raises_invalid (fun () -> Sweep.cells (make_axis [ 0.3; 1.5 ])))
+    (equal_to true)
+
+let test_zero_rebalance_weeks_rejected _ =
+  assert_that
+    (raises_invalid (fun () ->
+         Sweep.cells (make_axis ~rebalance_weeks:0 [ 0.3 ])))
+    (equal_to true)
+
+(* A deterministic stub metrics whose total_return encodes the weight, so we can
+   assert the table evaluates each cell's config in ascending-weight order. *)
+let stub_metrics_of_weight (config : Config.t) : Blend.metrics =
+  {
+    total_return_pct = config.floor_weight *. 100.0;
+    sharpe = 0.0;
+    max_drawdown_pct = 0.0;
+    calmar = 0.0;
+    ulcer_pct = 0.0;
+    n_points = 1;
+  }
+
+(* metrics_table returns one row per cell, ascending, threading each cell's
+   config through the blend thunk. *)
+let test_metrics_table_one_row_per_cell _ =
+  let table =
+    Sweep.metrics_table (make_axis [ 0.5; 0.2 ]) ~blend:stub_metrics_of_weight
+  in
+  assert_that table
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (r : Sweep.row) -> r.label)
+               (equal_to "floor_weight=0.20");
+             field (fun (r : Sweep.row) -> r.floor_weight) (float_equal 0.20);
+             field
+               (fun (r : Sweep.row) -> r.metrics.Blend.total_return_pct)
+               (float_equal 20.0);
+           ];
+         all_of
+           [
+             field
+               (fun (r : Sweep.row) -> r.label)
+               (equal_to "floor_weight=0.50");
+             field (fun (r : Sweep.row) -> r.floor_weight) (float_equal 0.50);
+             field
+               (fun (r : Sweep.row) -> r.metrics.Blend.total_return_pct)
+               (float_equal 50.0);
+           ];
+       ])
+
+let suite =
+  "barbell_floor_sweep"
+  >::: [
+         "cells_one_per_weight_ascending"
+         >:: test_cells_one_per_weight_ascending;
+         "zero_weight_cell_is_valid" >:: test_zero_weight_cell_is_valid;
+         "empty_axis_rejected" >:: test_empty_axis_rejected;
+         "duplicate_weight_rejected" >:: test_duplicate_weight_rejected;
+         "out_of_range_weight_rejected" >:: test_out_of_range_weight_rejected;
+         "zero_rebalance_weeks_rejected" >:: test_zero_rebalance_weeks_rejected;
+         "metrics_table_one_row_per_cell"
+         >:: test_metrics_table_one_row_per_cell;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Closes the **R2 (searchable axis)** follow-up for the deployable barbell overlay
(gate #2): makes `Barbell_config.floor_weight` a **searchable surface** so the
validated 70/30 vs neighbouring floor weights stay comparable from a single
invocation, per `.claude/rules/experiment-flag-discipline.md` R2.

Plan: `dev/plans/barbell-floor-weight-axis-2026-06-22.md` (committed first).

## Why a barbell-local axis (Option 1) rather than a `Variant_matrix` cell

`Variant_matrix` validates every axis override against the canonical
`Weinstein_strategy.config` via `Overlay_validator.apply_overrides` at expansion
time. But `floor_weight` lives in a **separate** `Barbell_config.t`, and the
overlay runs through its own `Barbell_runner.run` path — so a
`(barbell floor_weight)` override would fail that validation (it is not a
`Weinstein_strategy.config` field). Generalizing `Overlay_validator`/`Variant_matrix`
(Option 2) is a cross-cutting experiment-platform change owned by the maintainer
and out of scope for an R2-completion follow-up. Grafting barbell config into
`Weinstein_strategy.config` (Option 3) is explicitly forbidden.

So this PR adds the **faithful in-scope equivalent**: a self-contained, pure
floor-weight axis scoped to `Barbell_config`, validated against
`Barbell_config.validate`.

## What it does

New pure module `trading/trading/backtest/barbell/lib/barbell_floor_sweep.{ml,mli}`:
- `axis` = a list of `floor_weight` values at a shared `rebalance_weeks` cadence.
- `cells axis` expands it into one `Barbell_config` cell per weight, in
  **ascending-weight** order, each validated; raises `Invalid_argument` loudly on
  an empty/duplicate/out-of-range axis (mirrors `Variant_matrix.expand`).
- `metrics_table axis ~blend` evaluates each cell's config through a blend thunk
  into a `(label, weight, metrics)` surface — the comparison table.

New executable `barbell_floor_sweep_runner.exe` (`scenario/bin/`): a thin CLI over
`Barbell_scenario.run` + `metrics_table`. Because `floor_weight` only changes the
**blend** of two fixed equity curves, the FLOOR and ENGINE legs run **once** and
are re-blended per weight; writes `floor_sweep.csv` (one metric row per weight).

## Default-off / no-op preserved

Enumerating weights flips no default; `floor_weight = 0.0` stays a valid
pure-engine no-op cell. Promoting any weight is a separate, ledger-gated decision
(R3 / `.claude/rules/promotion-confirmation.md`) — **out of scope here**.

## Constraints honoured

- **No core-module edits** — Portfolio/Orders/Position/Strategy/Engine/Simulator
  untouched.
- **No edits to `Weinstein_strategy.config`, `Overlay_validator`, or
  `Variant_matrix`.**
- Diff confined to `trading/trading/backtest/barbell/` + the plan + the one
  status row.

## Test plan

7 pure unit tests in `test_barbell_floor_sweep.ml` (Matchers, one `assert_that`
per value): cell count = value count, ascending-weight ordering, per-cell
`Barbell_config` correctness, default-weight (0.0) cell valid, malformed-axis
rejection (empty / duplicate / out-of-range weight / zero cadence), and
`metrics_table` row ordering via a deterministic stub thunk.

Verify: `dune runtest trading/backtest/barbell/`. Full `dune build && dune runtest`
green; `dune build @fmt` clean.


🤖 Dispatched by GHA orchestrator run [27942558434](https://github.com/dayfine/trading/actions/runs/27942558434)
