### PR TITLE
docs+fixtures: fast-crash stop screen 2026-06-22

### DIFF
--- a/dev/backtest/fast-crash-stop-screen-2026-06-22/FINDINGS.md
+++ b/dev/backtest/fast-crash-stop-screen-2026-06-22/FINDINGS.md
@@ -1,0 +1,67 @@
+# Fast-crash absolute stop — screen FINDINGS (2026-06-22)
+
+Read-only screen of the Build-2 mechanism (`stops_config.catastrophic_stop_pct`,
+armed on `Fast_v`; merged #1695, default-off). Question: does the absolute stop
+cut the 2020 fast-V drawdown without taxing returns elsewhere? Screen-rigor per
+`.claude/rules/mechanism-validation-rigor.md`.
+
+Scenarios: `trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/`
+(cat-00/08/10/12) on `universes/fast-crash-screen.sexp` (27 continuing-listing
+names), CSV mode, 2019-2021 (spans the 2020-V). Baseline-vs-{0.08,0.10,0.12}.
+
+## Headline — the stop NEVER FIRED (all variants byte-identical)
+
+| catastrophic_stop_pct | total return | window MaxDD | Sharpe | Calmar | trades | 2020-Q1 long exits |
+|---|---|---|---|---|---|---|
+| 0.00 (baseline) | 18.50% | 15.27% | 0.534 | 0.381 | 33 | Feb 28 – Mar 13, all `stop_loss` |
+| 0.08 | 18.50% | 15.27% | 0.534 | 0.381 | 33 | identical |
+| 0.10 | 18.50% | 15.27% | 0.534 | 0.381 | 33 | identical |
+| 0.12 | 18.50% | 15.27% | 0.534 | 0.381 | 33 | identical |
+
+`trades.csv` md5 identical across all four. The catastrophic stop never bit.
+
+## Verdict: NEEDS-DIFFERENT-TEST-DESIGN
+Not "no-benefit," not "promising" — the test **cannot exercise the mechanism**, so
+the 2020-DD-cut hypothesis is neither confirmed nor refuted. The mechanism stays
+default-off + an axis (no promote, no reject).
+
+## The WHY (the transferable deliverable)
+
+1. **Structural gap-down stops exit first and faster.** Every 2020 crash-window
+   long exited on `stop_loss` (gap-down) **Feb 28 – Mar 13** (e.g. MCD/META Feb 28,
+   V Feb 29, GOOGL Mar 13 last out). Zero positions held past mid-March.
+2. **`Fast_v` cannot arm until the MA turns down — mid-March, too late.**
+   `Decline_character.classify` returns `Fast_v` only with the index *below a
+   falling MA* + 4wk drawdown >8%. After the 2019 bull the 30-week MA was still
+   **rising** through late Feb; macro went `Bullish`→`Neutral` (02-28)→`Bearish`
+   (03-06). By the time `Fast_v` could arm (~mid-March) there was **no long left**.
+3. **The two stops never compete.** The arming gate (`Fast_v`, needs a confirmed
+   falling MA) is structurally **slower** than the gap-down trigger it was meant to
+   pre-empt. **The binding constraint is arming LATENCY, not stop width.**
+4. **The motivating -38% DD did not reproduce here** — this survivor-biased 27-name
+   universe peaked→troughed only -13.8% (struct stops exited early, clean). The
+   -38% came from a broad PIT universe holding laggard/thinner names INTO the bottom
+   — exactly the longs that could still be open when `Fast_v` finally arms.
+
+## Inert-elsewhere check
+Trivially PASS (inert everywhere, return == baseline) — but **vacuous**: inert
+because it never fired at all, not because it fired only in the crash.
+
+## Forward guidance (capitalize the finding)
+- **The lever is the ARMING SPEED, not `catastrophic_stop_pct`.** The `Fast_v`
+  falling-MA precondition lags the price crash ~3 weeks. To pre-empt a gap-down
+  structural exit, the fast-V path likely needs to arm on **rate-of-decline alone**
+  (drop the falling-MA requirement for `Fast_v`). This is a `Decline_character`
+  threshold/config question — re-open there, NOT on `catastrophic_stop_pct`.
+- **Re-run on a broad PIT universe (top-500/1000, 2019-2021)** — the longs that ride
+  to the bottom (where the absolute stop could bite) live there, not in survivors.
+  Needs a snapshot-warehouse rebuild (`build_scenario_snapshots`, ~26 min).
+- **Paired 2×2** (structural-loose × {cat-off, cat-on}): loosen `min_correction_pct`
+  so the structural stop doesn't gap longs out by Mar 13, isolating whether the
+  catastrophic stop then bites.
+
+## Caveats / infra
+- Survivor-biased universe (27 continuing names) is biased AGAINST finding a benefit.
+- No bars on disk at start (store cleaned); 42 symbols fetched fresh from EODHD for
+  the run. (Note: the run's `inventory.sexp` rebuild was reverted — it had shrunk the
+  full inventory to only the fetched symbols.)

--- a/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-00-baseline.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-00-baseline.sexp
@@ -1,0 +1,24 @@
+;; Fast-crash-stop screen — BASELINE (catastrophic_stop_pct = 0.0 = off).
+;;
+;; 2019-2021 spans the 2020 fast-V crash with a 2019 bull warmup and a 2021
+;; bull recovery. Default config except the universe. The catastrophic stop is
+;; off (default), so this reproduces the "structural stop exits at the bottom"
+;; behavior the screen is testing against.
+((name "cat-00-baseline-2019-2021")
+ (description
+   "Fast-crash-stop screen baseline: catastrophic_stop_pct=0.0 (off), 2019-2021.")
+ (period ((start_date 2019-01-01) (end_date 2021-12-31)))
+ (universe_path "universes/fast-crash-screen.sexp")
+ (config_overrides
+  (((stops_config ((catastrophic_stop_pct 0.0))))))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 1000.0)))
+   (total_trades            ((min   1)    (max 2000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-08.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-08.sexp
@@ -1,0 +1,23 @@
+;; Fast-crash-stop screen — catastrophic_stop_pct = 0.08.
+;;
+;; Identical to cat-00-baseline except the fast-crash absolute stop is enabled
+;; at 0.08. When the index is in a Fast_v decline (Decline_character.classify),
+;; a long's stop fires at trailing_high * (1 - 0.08). Dormant otherwise.
+((name "cat-08-2019-2021")
+ (description
+   "Fast-crash-stop screen: catastrophic_stop_pct=0.08, 2019-2021.")
+ (period ((start_date 2019-01-01) (end_date 2021-12-31)))
+ (universe_path "universes/fast-crash-screen.sexp")
+ (config_overrides
+  (((stops_config ((catastrophic_stop_pct 0.08))))))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 1000.0)))
+   (total_trades            ((min   1)    (max 2000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-10.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-10.sexp
@@ -1,0 +1,23 @@
+;; Fast-crash-stop screen — catastrophic_stop_pct = 0.10.
+;;
+;; Identical to cat-00-baseline except the fast-crash absolute stop is enabled
+;; at 0.10. When the index is in a Fast_v decline (Decline_character.classify),
+;; a long's stop fires at trailing_high * (1 - 0.10). Dormant otherwise.
+((name "cat-10-2019-2021")
+ (description
+   "Fast-crash-stop screen: catastrophic_stop_pct=0.10, 2019-2021.")
+ (period ((start_date 2019-01-01) (end_date 2021-12-31)))
+ (universe_path "universes/fast-crash-screen.sexp")
+ (config_overrides
+  (((stops_config ((catastrophic_stop_pct 0.10))))))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 1000.0)))
+   (total_trades            ((min   1)    (max 2000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-12.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/fast-crash-stop-screen-2026-06-22/cat-12.sexp
@@ -1,0 +1,23 @@
+;; Fast-crash-stop screen — catastrophic_stop_pct = 0.12.
+;;
+;; Identical to cat-00-baseline except the fast-crash absolute stop is enabled
+;; at 0.12. When the index is in a Fast_v decline (Decline_character.classify),
+;; a long's stop fires at trailing_high * (1 - 0.12). Dormant otherwise.
+((name "cat-12-2019-2021")
+ (description
+   "Fast-crash-stop screen: catastrophic_stop_pct=0.12, 2019-2021.")
+ (period ((start_date 2019-01-01) (end_date 2021-12-31)))
+ (universe_path "universes/fast-crash-screen.sexp")
+ (config_overrides
+  (((stops_config ((catastrophic_stop_pct 0.12))))))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 1000.0)))
+   (total_trades            ((min   1)    (max 2000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/universes/fast-crash-screen.sexp
+++ b/trading/test_data/backtest_scenarios/universes/fast-crash-screen.sexp
@@ -1,0 +1,46 @@
+;; Fast-crash-stop screen universe (2026-06-22).
+;;
+;; ~27 large-cap US equities across all 11 GICS sectors, curated so that a
+;; default Weinstein run holds longs INTO the 2020 fast-V crash. Used by the
+;; experiments/fast-crash-stop-screen-2026-06-22 scenario set to screen
+;; [stops_config.catastrophic_stop_pct] (default-off fast-crash absolute stop,
+;; armed only when Decline_character.classify labels the index Fast_v).
+;;
+;; The primary index (GSPC.INDX), the 11 SPDR sector ETFs, and the 3 global
+;; indices the macro gate / decline-character read are NOT listed here — the
+;; runner stages those automatically (_all_runner_symbols in runner.ml). They
+;; were fetched into the local store alongside these equities.
+;;
+;; CAVEAT (survivorship): these are continuing-listing names with full history,
+;; so the universe is survivor-biased. For a regime-gated insurance stop the
+;; bias cuts equally across baseline and catastrophic variants (the RELATIVE
+;; comparison holds); the absolute return level is not the deliverable.
+(Pinned (
+  ((symbol AAPL)  (sector "Information Technology"))
+  ((symbol MSFT)  (sector "Information Technology"))
+  ((symbol NVDA)  (sector "Information Technology"))
+  ((symbol ADBE)  (sector "Information Technology"))
+  ((symbol CRM)   (sector "Information Technology"))
+  ((symbol V)     (sector "Information Technology"))
+  ((symbol MA)    (sector "Information Technology"))
+  ((symbol GOOGL) (sector "Communication Services"))
+  ((symbol META)  (sector "Communication Services"))
+  ((symbol DIS)   (sector "Communication Services"))
+  ((symbol AMZN)  (sector "Consumer Discretionary"))
+  ((symbol HD)    (sector "Consumer Discretionary"))
+  ((symbol NKE)   (sector "Consumer Discretionary"))
+  ((symbol MCD)   (sector "Consumer Discretionary"))
+  ((symbol JPM)   (sector "Financials"))
+  ((symbol BAC)   (sector "Financials"))
+  ((symbol XOM)   (sector "Energy"))
+  ((symbol CVX)   (sector "Energy"))
+  ((symbol JNJ)   (sector "Health Care"))
+  ((symbol UNH)   (sector "Health Care"))
+  ((symbol PG)    (sector "Consumer Staples"))
+  ((symbol KO)    (sector "Consumer Staples"))
+  ((symbol WMT)   (sector "Consumer Staples"))
+  ((symbol COST)  (sector "Consumer Staples"))
+  ((symbol CAT)   (sector "Industrials"))
+  ((symbol BA)    (sector "Industrials"))
+  ((symbol GE)    (sector "Industrials"))
+))


### PR DESCRIPTION
Read-only screen of the Build-2 fast-crash stop (#1695). Finding: the catastrophic stop NEVER FIRES — Fast_v (gated on a falling MA) arms ~3 weeks too late, slower than the structural gap-down stop it was meant to pre-empt. The lever is arming LATENCY (Decline_character thresholds), not catastrophic_stop_pct. Verdict: needs-different-test-design; mechanism stays default-off. FINDINGS + scenario fixtures only (no code/config changes).