### PR TITLE
docs+fixtures: faithful-short (Build 3) screen 2026-06-22

### DIFF
--- a/dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md
+++ b/dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md
@@ -1,0 +1,117 @@
+# Faithful short (Build 3) — screen FINDINGS (2026-06-22)
+
+Read-only screen of the Build-3 mechanism (`Weinstein_strategy.config`
+`neutral_blocks_shorts` + `enable_slow_grind_short_gate`; merged #1696,
+both default-off). Question: does tightening shorts to confirmed bears
+(Bearish tape) and/or slow-grind declines flip the short leg from a
+net-negative drag (squeezed on fast-V bounces) to a contributor?
+Screen-rigor per `.claude/rules/mechanism-validation-rigor.md`.
+
+Scenarios: `trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/`
+(00-longonly-reference, 01-baseline-longshort, 02-neutral-only,
+03-grind-only, 04-both) on `universes/sp500-historical/sp500-2010-01-01.sexp`,
+CSV mode, 2010-2026. Overlay config copied verbatim from the
+`sp500-2010-2026-longshort` golden — the ONLY thing varied across arms is the
+two faithful-short flags (plus `enable_short_side=false` for the long-only ref).
+
+## Headline — the gates admit ZERO shorts; all three revert to long-only
+
+| arm | flags | return | trades | win% | MaxDD | Sharpe | Calmar |
+|---|---|---|---|---|---|---|---|
+| 00 long-only ref | short off | **53.46%** | 291 | 38.5 | **10.63%** | 0.498 | 0.250 |
+| 01 baseline longshort | un-gated short | 47.87% | 296 | 37.8 | 12.89% | 0.456 | 0.188 |
+| 02 neutral_blocks_shorts | Bearish-tape only | 53.46% | 291 | 38.5 | 10.63% | 0.498 | 0.250 |
+| 03 slow_grind_gate | slow-grind only | 53.46% | 291 | 38.5 | 10.63% | 0.498 | 0.250 |
+| 04 both | Bearish + slow-grind | 53.46% | 291 | 38.5 | 10.63% | 0.498 | 0.250 |
+
+`actual.sexp` AND `trades.csv` are **md5-identical** across 00/02/03/04. Each
+faithful gate reduces the short book to **zero** → the long-short collapses
+exactly onto long-only. Only the un-gated baseline (01) differs.
+
+## What the un-gated short leg actually was: 5 early-2010 squeeze losses
+
+The entire un-gated short book on 2010-2026 = **5 SHORT trades, all in
+Feb-Aug 2010, all Stage-4 entries, all stopped out (squeezed), net −$33,684**:
+
+| symbol | entry | exit | days | pnl$ | pnl% | exit |
+|---|---|---|---|---|---|---|
+| ADBE | 2010-02-13 | 2010-02-18 | 5 | −1,496 | −0.78 | stop_loss (gap_down) |
+| JPM | 2010-02-20 | 2010-03-03 | 11 | −6,437 | −3.94 | stop_loss (intraday) |
+| BAC | 2010-02-20 | 2010-03-11 | 19 | −6,112 | −9.33 | stop_loss (gap_down) |
+| UNH | 2010-05-22 | 2010-08-04 | 74 | −10,405 | −13.74 | stop_loss (gap_down) |
+| COST | 2010-05-22 | 2010-05-28 | 6 | −9,233 | −5.22 | stop_loss (gap_down) |
+
+These are residual post-GFC Stage-4 names shorted into the **2009-2010 V-recovery
+rip** — every one squeezed out at a stop. They (plus their portfolio-state ripple
+on the longs) cost the baseline **−5.6pp total return and +2.3pp MaxDD** vs
+long-only. The faithful gates remove all 5.
+
+## Verdict: NEEDS-DEEP-DATA (mechanism SAFE + faithful; benefit untestable here)
+
+Not a rejection, not a promotion. Calibrated per screen-rigor — a proxy window
+that cannot exercise the mechanism's intended benefit:
+
+- **SAFE / faithful (confirmed).** The gates correctly remove exactly the
+  un-faithful, loss-making shorts (early-2010 recovery squeezes). At worst they
+  neutralize a money-losing leg; they never add a losing short. Spine intact
+  (`weinstein-faithful-core.md` W1) — they only tighten the short admission gate.
+- **Benefit UNCONFIRMABLE on 2010-2026.** The hypothesis was "the slow-grind /
+  Bearish gate keeps profitable 2000-02/2008-style sustained-distribution shorts
+  while skipping V-squeezes." This window has **no such slow-bear regime** — the
+  only shorts that ever occurred were the early-2010 squeezes, which the gate
+  rightly skips. There were 0 confirmed-Bearish-tape stock shorts to keep. So the
+  screen confirms the *skip* half of the thesis but cannot test the *keep* half.
+
+The mechanism stays **default-off + an axis** (no promote, no reject), exactly
+mirroring the fast-crash-stop screen (`dev/backtest/fast-crash-stop-screen-2026-06-22`).
+
+## The WHY (transferable deliverable)
+
+1. **The gate decision is macro/index-driven, hence universe-independent.**
+   `neutral_blocks_shorts` keys off the ^GSPC macro tape; `slow_grind_gate` keys
+   off the ^GSPC decline character. So "the gate opened on 0 short-bearing weeks"
+   is robust to the universe — the gate's open/close is the same regardless of
+   which names are loaded.
+2. **2010-2026 is a secular bull with no sustained distribution bear.** 161
+   Bearish weeks existed (mostly brief: 2011, 2018-Q4, 2020-V, 2022) but produced
+   zero qualifying stock-level Stage-4 shorts under the gate — the bear windows
+   were too short/sharp to be `Slow_grind`, and (with `~ad_bars:[]`, A-D inert)
+   the slow-grind leg leans entirely on weeks-below-falling-MA ≥ 8 + shallow rate,
+   which a V-crash never satisfies.
+3. **The un-gated short edge here was negative by construction** — Weinstein
+   shorts squeezed on a V-recovery. This re-derives `project_edge_is_the_fat_tail`
+   from the short side: an un-gated short leg in a bull regime is a tail-RISK
+   *cost*, and the faithful gate is the tail-RISK *insurance* that removes it.
+
+## Forward guidance (capitalize the finding)
+
+- **The benefit test requires a slow-bear regime — re-screen on 2000-02 + 2008.**
+  Build the deep universe via the `fetch-historical-data` skill +
+  `dev/scripts/build_deep_universe.sh` (top-500/1000 PIT, 1998-2010), then re-run
+  these 5 arms over a window spanning the dot-com bust + GFC. Only there can the
+  gate demonstrate it KEEPS profitable sustained-bear shorts. This is the same
+  deep-data unblock the fast-crash screen needs — fetch once, serves both.
+- **Do NOT promote on this window.** A "no-drag" result on a bull window is the
+  *necessary* safety check, not the *sufficient* benefit case
+  (`promotion-confirmation.md` — needs a macro-regime-diverse grid cell covering
+  2000-02 + 2008).
+- **A/D wiring (Build 0) sharpens the slow-grind leg.** With `~ad_bars:[]` the
+  classifier's A-D-lead leg is inert, so `Slow_grind` currently fires only on the
+  weeks-below-falling-MA leg. Build 0 (wire `Ad_bars.load` into `pipeline.ml:103`)
+  would let the gate catch distribution tops earlier — relevant to the deep
+  re-screen.
+
+## Caveats / infra
+
+- **Decimated universe: 309/510 SP500 names have committed bars** (39% missing,
+  store cleaned). The baseline short *count* (5) is therefore a lower bound — a
+  full universe might surface a few more Stage-4 shorts. But (a) the gate decision
+  is universe-independent (point 1), and (b) the qualitative finding (un-gated
+  bull-regime shorts lose; gates remove them) is robust. A clean-data re-baseline
+  is nice-to-have, not load-bearing for this verdict.
+- The `all_eligible` diagnostic post-step errored (looked for the universe under
+  `data/` not `test_data/` — a fixtures-root path bug in the all-eligible emitter,
+  not the main backtest). Main metrics (`actual.sexp`) are valid.
+- Shorts surface in `trades.csv` as explicit `side=SHORT` rows here (5 of them);
+  the older "shorts invisible as Sell→Buy round-trips" note (weinstein_strategy.mli)
+  did not apply to this run.

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/00-longonly-reference.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/00-longonly-reference.sexp
@@ -1,0 +1,38 @@
+;; Faithful-short screen (Build 3) — LONG-ONLY REFERENCE FLOOR.
+;;
+;; enable_short_side=false: the short leg is dropped entirely. This is the
+;; reference the gated-short arms must beat for the short leg to be additive.
+;; If a faithful-short arm's risk-adjusted result rises toward / above this
+;; floor, the gate has turned the short leg from a drag into a contributor.
+;; Identical overlay to the long-short arms (only enable_short_side differs).
+((name "faithful-short-00-longonly-reference")
+ (description
+   "Faithful-short screen reference: LONG-ONLY (short leg off). SP500 2010-2026.")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/01-baseline-longshort.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/01-baseline-longshort.sexp
@@ -1,0 +1,44 @@
+;; Faithful-short screen (Build 3) — BASELINE: long-short, faithful flags OFF.
+;;
+;; Reproduces current un-gated short behavior (neutral_blocks_shorts=false,
+;; enable_slow_grind_short_gate=false): both Bearish AND Neutral tapes admit
+;; shorts, and shorts are admitted in fast-V crashes as well as slow grinds.
+;; This is the arm the night's screen flagged as net-negative (squeezed on
+;; the 2020 fast-V bounce). Overlay config copied verbatim from the
+;; sp500-2010-2026-longshort golden so the ONLY difference across the screen
+;; arms is the two faithful-short flags.
+;;
+;; Window 2010-2026 spans 2018-Q4, the 2020 fast-V, and the 2022 grind on
+;; committed data. Deep slow-bear (2000-02/2008) confirmation is a follow-up
+;; needing an EODHD fetch. CSV mode. Research-tier; sentinel bands only.
+((name "faithful-short-01-baseline-longshort")
+ (description
+   "Faithful-short screen baseline: long-short, faithful flags OFF (un-gated short). SP500 2010-2026.")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/02-neutral-only.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/02-neutral-only.sexp
@@ -1,0 +1,38 @@
+;; Faithful-short screen (Build 3) — ARM: neutral_blocks_shorts ONLY.
+;;
+;; neutral_blocks_shorts=true: only a Bearish tape admits shorts (Neutral no
+;; longer does). Tightens the short side to Weinstein's confirmed-bear rule.
+;; Isolates the macro-gate leg of the faithful short. Overlay identical to
+;; baseline; the slow-grind gate stays OFF here.
+((name "faithful-short-02-neutral-only")
+ (description
+   "Faithful-short screen: neutral_blocks_shorts=true only (Bearish-tape-only shorts). SP500 2010-2026.")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side true))
+   ((neutral_blocks_shorts true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/03-grind-only.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/03-grind-only.sexp
@@ -1,0 +1,40 @@
+;; Faithful-short screen (Build 3) — ARM: enable_slow_grind_short_gate ONLY.
+;;
+;; enable_slow_grind_short_gate=true: shorts admitted only when the current
+;; index decline is a Decline_character.Slow_grind (fast-V crashes and
+;; non-declines excluded). This is THE arm that targets the 2020 fast-V
+;; squeeze — it should block short entries during the V so the bounce cannot
+;; squeeze them. neutral_blocks_shorts stays OFF here. Overlay identical to
+;; baseline.
+((name "faithful-short-03-grind-only")
+ (description
+   "Faithful-short screen: enable_slow_grind_short_gate=true only (slow-grind-only shorts). SP500 2010-2026.")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side true))
+   ((enable_slow_grind_short_gate true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/04-both.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/04-both.sexp
@@ -1,0 +1,39 @@
+;; Faithful-short screen (Build 3) — ARM: BOTH faithful flags ON.
+;;
+;; neutral_blocks_shorts=true AND enable_slow_grind_short_gate=true: the full
+;; Build-3 faithful short — shorts admitted only on a Bearish tape AND only
+;; when the index decline is a slow grind (no Neutral-tape shorts, no fast-V
+;; shorts). The most restrictive arm. Overlay identical to baseline.
+((name "faithful-short-04-both")
+ (description
+   "Faithful-short screen: BOTH faithful flags ON (Bearish + slow-grind only shorts). SP500 2010-2026.")
+ (period ((start_date 2010-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2010-01-01.sexp")
+ (universe_size 510)
+ (config_overrides
+  (((enable_short_side true))
+   ((neutral_blocks_shorts true))
+   ((enable_slow_grind_short_gate true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))


### PR DESCRIPTION
First-signal screen of the **Build-3 faithful-short gates** (\`neutral_blocks_shorts\` + \`enable_slow_grind_short_gate\`, #1696, both default-off) on SP500 2010-2026, CSV mode. Per next-session-priorities-2026-06-22 §1.

## Result — gates admit ZERO shorts, revert byte-identical to long-only

| arm | flags | return | trades | MaxDD | Sharpe |
|---|---|---|---|---|---|
| long-only ref | short off | 53.46% | 291 | 10.63% | 0.498 |
| baseline longshort | un-gated | 47.87% | 296 | 12.89% | 0.456 |
| neutral_blocks_shorts | Bearish-only | **53.46%** | 291 | 10.63% | 0.498 |
| slow_grind_gate | slow-grind only | **53.46%** | 291 | 10.63% | 0.498 |
| both | Bearish + slow-grind | **53.46%** | 291 | 10.63% | 0.498 |

`actual.sexp` + `trades.csv` md5-identical across all gated arms and long-only. The entire un-gated short book = **5 early-2010 Stage-4 squeeze losses** (net −\$33.7K), which the gates remove exactly.

## Verdict: NEEDS-DEEP-DATA (mechanism SAFE + faithful; benefit untestable here)

Not a rejection, not a promotion (screen-rigor calibrated). The gates correctly remove the un-faithful loss-making shorts, but the hypothesized *benefit* (keep profitable 2000-02/2008-style slow-bear shorts) can't be tested on a bull window with no such regime. Re-screen on deep 2000-02 + 2008 data (needs EODHD fetch — same unblock the fast-crash screen needs). Mechanism stays default-off + axis.

Full writeup: `dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md`.

## Contents (docs + test fixtures only — no code)
- `dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md`
- `trading/test_data/backtest_scenarios/experiments/faithful-short-screen-2026-06-22/{00..04}*.sexp` (5 screen scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)