### PR TITLE
feat(decline-character): fast_v_arm_on_rate_alone knob (default-off arming-speed)

### DIFF
--- a/dev/status/decline-character.md
+++ b/dev/status/decline-character.md
@@ -99,18 +99,47 @@ read-only dial, not a spine change. All builds default-off.
   Neutral→0 / Bearish-unaffected; slow-grind gate off-ignores-flag /
   on-blocks-fast-v / on-admits-slow-grind), all `List.count + equal_to N`.
 
+- **Build 2b — fast-V arming-speed dial** (READY_FOR_REVIEW, PR
+  feat/decline-character/fast-v-arm-speed). Closes the arming-LATENCY gap the
+  Build-2 fast-crash screen found: the `catastrophic_stop_pct` absolute stop
+  NEVER FIRED in 2020 because `Decline_character.Fast_v` cannot arm until the
+  index is below a *falling* MA (~mid-March 2020) — by then the structural
+  gap-down stop has already exited every long. The binding constraint is arming
+  speed, not stop width. New default-off classifier knob
+  `Decline_character.config.fast_v_ignores_ma_filter` (`[@sexp.default false]`):
+  when `true`, `classify` evaluates the fast-V-on-rate path even when no decline
+  is in progress by the MA test — returning `Fast_v` iff the trailing
+  rate-of-decline drawdown over `rate_lookback_weeks` exceeds
+  `fast_v_min_rate_pct` (and A-D not leading); else `Not_declining`. The
+  slow-grind path is never reached this way (it presupposes weeks-below-a-falling
+  -MA). Threaded from a new strategy flag
+  `Weinstein_strategy.config.fast_v_arm_on_rate_alone` (`[@sexp.default false]`,
+  mirrored in `weinstein_strategy_config.{ml,mli}` + `weinstein_strategy.mli`)
+  through a single `Decline_character_wiring.classifier_config
+  ~fast_v_arm_on_rate_alone` into BOTH classify sites
+  (`Decline_character_wiring.update_ref` — the load-bearing stop-arming seam —
+  and `weinstein_strategy_screening._decline_is_slow_grind`, inert for this flag
+  since it maps `Fast_v`→not-slow-grind). Variant_matrix-searchable per R2
+  (real `Weinstein_strategy.config` field → sexp-resolved by
+  `Overlay_validator`). Default `false` = bit-identical (no golden re-pin). 4 new
+  classifier unit tests (flag-off steep+rising-MA→Not_declining; flag-on
+  steep+rising-MA→Fast_v; flag-on shallow+rising-MA→Not_declining; flag-on
+  preserves already-declining Slow_grind / Fast_v). No core-module edits.
+
 ## In progress
 
 - None.
 
 ## Next steps
 
-1. Merge Build 2 (fast-crash absolute stop, PR feat/fast-crash-stop) + Build 3
-   (faithful short, PR feat/faithful-short).
+1. Merge Build 2 (fast-crash absolute stop, PR feat/fast-crash-stop), Build 2b
+   (fast-V arming-speed dial, PR feat/decline-character/fast-v-arm-speed) + Build
+   3 (faithful short, PR feat/faithful-short).
 2. **Build 0** — A/D data wiring (feat-data) `[non-blocking]` — makes the
    A/D-lead leg real (today the indicator is `Neutral` with `~ad_bars:[]`).
-3. Read-only screens (screen-rigor) on the `catastrophic_stop_pct` surface
-   (and the 2020 fast-crash scenario specifically) and the faithful-short knobs
+3. Read-only screens (screen-rigor) on the `catastrophic_stop_pct` surface with
+   `fast_v_arm_on_rate_alone=true` (the dial that lets the absolute stop actually
+   fire in the 2020 fast-crash) and the faithful-short knobs
    (`neutral_blocks_shorts` × `enable_slow_grind_short_gate`) → WF-CV if
    promising → promotion grid, before any default flip.
 

--- a/trading/analysis/weinstein/macro/lib/decline_character.ml
+++ b/trading/analysis/weinstein/macro/lib/decline_character.ml
@@ -10,6 +10,7 @@ type config = {
   fast_v_min_rate_pct : float;
   weeks_below_ma_slow_grind : int;
   trailing_high_lookback_weeks : int;
+  fast_v_ignores_ma_filter : bool; [@sexp.default false]
 }
 [@@deriving sexp]
 
@@ -21,6 +22,7 @@ let default_config =
     fast_v_min_rate_pct = 0.08;
     weeks_below_ma_slow_grind = 8;
     trailing_high_lookback_weeks = 52;
+    fast_v_ignores_ma_filter = false;
   }
 
 (* The most recent index close, or [None] when there are no bars. *)
@@ -126,21 +128,36 @@ let _is_fast_v (macro : Macro.result) (bars : Daily_price.t list)
   (not (_ad_line_is_leading macro bars ~config))
   && Float.( > ) rate_pct config.fast_v_min_rate_pct
 
+(* The trailing rate-of-decline drawdown as a positive fraction (0.0 when there
+   are too few bars). Shared by the decline-in-progress and pre-decline paths. *)
+let _rate_pct (bars : Daily_price.t list) ~(config : config) : float =
+  Option.value
+    (_trailing_drawdown_pct bars ~lookback:config.rate_lookback_weeks)
+    ~default:0.0
+
 (* Classify a decline already known to be in progress. Kept separate from
    {!classify} so neither function carries a nested [else]. *)
 let _classify_declining (macro : Macro.result) (bars : Daily_price.t list)
     ~(config : config) : t =
-  let rate_pct =
-    Option.value
-      (_trailing_drawdown_pct bars ~lookback:config.rate_lookback_weeks)
-      ~default:0.0
-  in
+  let rate_pct = _rate_pct bars ~config in
   match _is_slow_grind macro bars ~config ~rate_pct with
   | true -> Slow_grind
   | false ->
       if _is_fast_v macro bars ~config ~rate_pct then Fast_v else Not_declining
 
+(* The [fast_v_ignores_ma_filter] arming-speed path, evaluated only when no
+   decline is in progress by the MA test. Returns [Fast_v] on rate alone (the
+   gap-down the weekly-MA confirmation lags); never [Slow_grind] (a slow grind
+   presupposes weeks-below-a-falling-MA, i.e. a decline in progress). *)
+let _classify_pre_decline_fast_v (macro : Macro.result)
+    (bars : Daily_price.t list) ~(config : config) : t =
+  let rate_pct = _rate_pct bars ~config in
+  if _is_fast_v macro bars ~config ~rate_pct then Fast_v else Not_declining
+
 let classify ~(config : config) ~(macro : Macro.result)
     ~(index_bars : Daily_price.t list) : t =
-  if not (_is_declining macro index_bars) then Not_declining
-  else _classify_declining macro index_bars ~config
+  if _is_declining macro index_bars then
+    _classify_declining macro index_bars ~config
+  else if config.fast_v_ignores_ma_filter then
+    _classify_pre_decline_fast_v macro index_bars ~config
+  else Not_declining

--- a/trading/analysis/weinstein/macro/lib/decline_character.mli
+++ b/trading/analysis/weinstein/macro/lib/decline_character.mli
@@ -66,6 +66,35 @@ type config = {
   trailing_high_lookback_weeks : int;
       (** Window (weeks) over which the trailing index high is taken for the
           A-D-lead drawdown comparison. Default: 52 (~1 year). *)
+  fast_v_ignores_ma_filter : bool; [@sexp.default false]
+      (** {b Arming-speed dial} for the fast-V path (default [false] = exactly
+          today's behaviour). When [false], {!classify} returns [Not_declining]
+          for any tape that is not already in a decline by the MA test (MA
+          Rising/Flat, or the close not yet below a falling MA) — so the fast-V
+          path cannot arm until the weekly MA has rolled over and price has
+          fallen below it. In a fast V-crash that confirmation lags the crash by
+          weeks (the 2020 problem: the MA does not roll over until ~mid-March,
+          after the gap-down has already exited every long), so the
+          [Fast_v]-gated absolute stop never gets a chance to fire.
+
+          When [true], the fast-V-on-rate path is evaluated even when no decline
+          is in progress by the MA test: if the trailing rate-of-decline
+          drawdown over [rate_lookback_weeks] exceeds [fast_v_min_rate_pct] (and
+          the A-D line is not leading), {!classify} returns [Fast_v] on rate
+          alone — dropping the falling-MA precondition for the fast-V path only.
+          The slow-grind path is {b never} reached this way: a slow grind
+          legitimately requires weeks-below-a-falling-MA, which presupposes a
+          decline already in progress.
+
+          {b Faithfulness}: a fast crash gives no Advance-Decline breadth lead
+          and falls steeply before the weekly MA can roll over (book Ch. 8
+          distribution-lead doctrine — the MA confirmation is built for the slow
+          distribution top, not the V-crash). Arming the tail-RISK-insurance
+          absolute stop on rate captures the gap-down the weekly-MA confirmation
+          structurally misses. This changes no buy/sell rule — only {b when} the
+          [Fast_v]-gated absolute stop arms — so it is the sanctioned
+          tail-RISK-insurance exception ([weinstein-faithful-core.md]), not a
+          spine change. *)
 }
 [@@deriving sexp]
 (** Tunable thresholds for {!classify}. Every threshold is a config field (no
@@ -96,12 +125,19 @@ val classify :
       the weeks-below-falling-MA count.
 
     Classification rule (thresholds from [config]):
-    - {!Not_declining} when the MA is rising, or the current close is not below
-      a falling MA at all (no decline in progress).
-    - {!Slow_grind} when the A-D line is leading (A-D [`Bearish] while the index
-      is still within [ad_lead_max_drawdown_pct] of its trailing high), OR
-      (weeks-below-falling-MA ≥ [weeks_below_ma_slow_grind] AND the drawdown
-      magnitude over [rate_lookback_weeks] < [slow_grind_max_rate_pct]).
+    - When no decline is in progress (the MA is rising/flat, or the current
+      close is not below a falling MA): {!Not_declining}, {b unless}
+      [fast_v_ignores_ma_filter = true] — in which case the fast-V-on-rate path
+      is still evaluated and returns {!Fast_v} when the A-D line is not leading
+      AND the drawdown magnitude over [rate_lookback_weeks] >
+      [fast_v_min_rate_pct] (else {!Not_declining}). The slow-grind path is
+      never taken on this branch (a slow grind presupposes a decline in
+      progress).
+    - When a decline is in progress: {!Slow_grind} when the A-D line is leading
+      (A-D [`Bearish] while the index is still within [ad_lead_max_drawdown_pct]
+      of its trailing high), OR (weeks-below-falling-MA ≥
+      [weeks_below_ma_slow_grind] AND the drawdown magnitude over
+      [rate_lookback_weeks] < [slow_grind_max_rate_pct]).
     - {!Fast_v} when the A-D line is not leading AND the drawdown magnitude over
       [rate_lookback_weeks] > [fast_v_min_rate_pct].
     - {!Not_declining} otherwise (an ambiguous shallow dip with no qualifying

--- a/trading/analysis/weinstein/macro/test/test_decline_character.ml
+++ b/trading/analysis/weinstein/macro/test/test_decline_character.ml
@@ -136,6 +136,88 @@ let test_ambiguous_shallow_dip _ =
     (Decline_character.classify ~config:cfg ~macro ~index_bars)
     (equal_to Decline_character.Not_declining)
 
+(* ------------------------------------------------------------------ *)
+(* fast_v_ignores_ma_filter — arming-speed dial                        *)
+(* ------------------------------------------------------------------ *)
+
+(* Config with the fast-V arming-speed dial enabled. *)
+let cfg_arm_on_rate = { cfg with fast_v_ignores_ma_filter = true }
+
+(* A steep recent plunge while the weekly MA is still RISING (the 2020 lag: the
+   crash leads the MA roll-over). The close is still above the MA, so no decline
+   is "in progress" by the MA test, but the 4-week drawdown is ~25%. *)
+let steep_crash_with_rising_ma () =
+  let prices = List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 92.0; 84.0; 75.0 ] in
+  let index_bars = weekly_bars prices in
+  let macro =
+    macro_result ~ma_value:60.0 ~ma_direction:Weinstein_types.Rising
+      ~ad_signal:`Neutral
+  in
+  (index_bars, macro)
+
+(* Flag OFF (default): a steep crash with a rising MA is still Not_declining —
+   the fast-V path cannot arm until the MA rolls over. Pins backward-compat. *)
+let test_arm_off_rising_ma_steep_is_not_declining _ =
+  let index_bars, macro = steep_crash_with_rising_ma () in
+  assert_that
+    (Decline_character.classify ~config:cfg ~macro ~index_bars)
+    (equal_to Decline_character.Not_declining)
+
+(* Flag ON: the same steep-crash-with-rising-MA input now arms as Fast_v on rate
+   alone (drops the falling-MA precondition for the fast-V path). *)
+let test_arm_on_rising_ma_steep_is_fast_v _ =
+  let index_bars, macro = steep_crash_with_rising_ma () in
+  assert_that
+    (Decline_character.classify ~config:cfg_arm_on_rate ~macro ~index_bars)
+    (equal_to Decline_character.Fast_v)
+
+(* Flag ON but a SHALLOW pullback with a rising MA: the rate gate still applies,
+   so this stays Not_declining (a slow dip never arms the fast-V stop). *)
+let test_arm_on_rising_ma_shallow_is_not_declining _ =
+  (* ~2% drop over the last 4 weeks — below [fast_v_min_rate_pct] (8%). *)
+  let prices = List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 99.0; 98.5; 98.0 ] in
+  let index_bars = weekly_bars prices in
+  let macro =
+    macro_result ~ma_value:80.0 ~ma_direction:Weinstein_types.Rising
+      ~ad_signal:`Neutral
+  in
+  assert_that
+    (Decline_character.classify ~config:cfg_arm_on_rate ~macro ~index_bars)
+    (equal_to Decline_character.Not_declining)
+
+(* Flag ON must NOT change an already-declining classification: a real
+   falling-MA slow grind is still Slow_grind, and a falling-MA steep drop is
+   still Fast_v (the falling-MA branch is unchanged by the dial). *)
+let test_arm_on_preserves_declining_classification _ =
+  let slow_prices =
+    List.init 20 ~f:(fun i -> 100.0 -. (Float.of_int i *. 0.2))
+  in
+  let slow_bars = weekly_bars slow_prices in
+  let slow_macro =
+    macro_result ~ma_value:101.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Bearish
+  in
+  let fast_prices =
+    List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 92.0; 84.0; 75.0 ]
+  in
+  let fast_bars = weekly_bars fast_prices in
+  let fast_macro =
+    macro_result ~ma_value:98.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Bearish
+  in
+  assert_that
+    [
+      Decline_character.classify ~config:cfg_arm_on_rate ~macro:slow_macro
+        ~index_bars:slow_bars;
+      Decline_character.classify ~config:cfg_arm_on_rate ~macro:fast_macro
+        ~index_bars:fast_bars;
+    ]
+    (elements_are
+       [
+         equal_to Decline_character.Slow_grind;
+         equal_to Decline_character.Fast_v;
+       ])
+
 let suite =
   "decline_character"
   >::: [
@@ -145,6 +227,14 @@ let suite =
          "not_declining_above_ma" >:: test_not_declining_above_ma;
          "empty_bars" >:: test_empty_bars;
          "ambiguous_shallow_dip" >:: test_ambiguous_shallow_dip;
+         "arm_off_rising_ma_steep_is_not_declining"
+         >:: test_arm_off_rising_ma_steep_is_not_declining;
+         "arm_on_rising_ma_steep_is_fast_v"
+         >:: test_arm_on_rising_ma_steep_is_fast_v;
+         "arm_on_rising_ma_shallow_is_not_declining"
+         >:: test_arm_on_rising_ma_shallow_is_not_declining;
+         "arm_on_preserves_declining_classification"
+         >:: test_arm_on_preserves_declining_classification;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/decline_character_wiring.ml
+++ b/trading/trading/weinstein/strategy/lib/decline_character_wiring.ml
@@ -14,13 +14,24 @@ let _index_bars_of_weekly_view
         ~volume:(Float.to_int v.volumes.(i))
         ~adjusted_close:v.closes.(i) ())
 
+(* The decline-character classifier config built from the strategy-level
+   arming-speed flag: default config except [fast_v_ignores_ma_filter] is set
+   from [fast_v_arm_on_rate_alone], so one strategy flag controls both classify
+   sites consistently. [false] reproduces [default_config] exactly. *)
+let classifier_config ~fast_v_arm_on_rate_alone =
+  {
+    Decline_character.default_config with
+    fast_v_ignores_ma_filter = fast_v_arm_on_rate_alone;
+  }
+
 let classify ~config ~macro ~index_view =
   let index_bars = _index_bars_of_weekly_view index_view in
   Decline_character.classify ~config ~macro ~index_bars
 
-let update_ref ~prior_decline_character ~macro_result_opt ~index_view =
+let update_ref ~fast_v_arm_on_rate_alone ~prior_decline_character
+    ~macro_result_opt ~index_view =
   match macro_result_opt with
   | None -> ()
   | Some macro ->
-      prior_decline_character :=
-        classify ~config:Decline_character.default_config ~macro ~index_view
+      let config = classifier_config ~fast_v_arm_on_rate_alone in
+      prior_decline_character := classify ~config ~macro ~index_view

--- a/trading/trading/weinstein/strategy/lib/decline_character_wiring.mli
+++ b/trading/trading/weinstein/strategy/lib/decline_character_wiring.mli
@@ -11,6 +11,16 @@
     [weinstein.macro]), so the stops lib and stops runner stay macro-agnostic
     (A2): they receive a plain [~armed:bool], not a {!Decline_character.t}. *)
 
+val classifier_config :
+  fast_v_arm_on_rate_alone:bool -> Decline_character.config
+(** [classifier_config ~fast_v_arm_on_rate_alone] is
+    [Decline_character.default_config] with [fast_v_ignores_ma_filter] set from
+    the strategy-level [fast_v_arm_on_rate_alone] flag — a single source of the
+    classifier config so both classify sites (the stop-arming {!update_ref} and
+    the slow-grind-gate screen-time classify) stay consistent. With
+    [fast_v_arm_on_rate_alone = false] it reproduces [default_config] exactly
+    (bit-identical to the pre-flag behaviour). *)
+
 val classify :
   config:Decline_character.config ->
   macro:Macro.result ->
@@ -26,15 +36,19 @@ val classify :
     lookahead-free: every input is at the current week or earlier. *)
 
 val update_ref :
+  fast_v_arm_on_rate_alone:bool ->
   prior_decline_character:Decline_character.t ref ->
   macro_result_opt:Macro.result option ->
   index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
   unit
-(** [update_ref ~prior_decline_character ~macro_result_opt ~index_view] stores a
-    fresh {!classify} of the index into [prior_decline_character] when
-    [macro_result_opt] is [Some] (a screening day) — using
-    {!Decline_character.default_config}. On a non-screening day ([None]) it is a
-    no-op, so the ref retains the last classification: the strategy's stops pass
-    reads it on the NEXT tick (strictly prior, no lookahead — the Build 2
-    fast-crash absolute-stop arming seam). The searchable mechanism flag is
-    [stops_config.catastrophic_stop_pct]. *)
+(** [update_ref ~fast_v_arm_on_rate_alone ~prior_decline_character
+     ~macro_result_opt ~index_view] stores a fresh {!classify} of the index into
+    [prior_decline_character] when [macro_result_opt] is [Some] (a screening
+    day) — using {!classifier_config} built from the strategy-level
+    [fast_v_arm_on_rate_alone] arming-speed flag (default [false] reproduces
+    {!Decline_character.default_config} exactly). On a non-screening day
+    ([None]) it is a no-op, so the ref retains the last classification: the
+    strategy's stops pass reads it on the NEXT tick (strictly prior, no
+    lookahead — the Build 2 fast-crash absolute-stop arming seam). The
+    searchable mechanism flag is [stops_config.catastrophic_stop_pct]; the
+    arming-speed flag is [fast_v_arm_on_rate_alone]. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -297,8 +297,9 @@ let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
   in
   (* Re-classify the index's decline character (strictly-past read by the next
      tick's stops pass to arm the fast-crash absolute stop — Build 2). *)
-  Decline_character_wiring.update_ref ~prior_decline_character ~macro_result_opt
-    ~index_view;
+  Decline_character_wiring.update_ref
+    ~fast_v_arm_on_rate_alone:config.fast_v_arm_on_rate_alone
+    ~prior_decline_character ~macro_result_opt ~index_view;
   let skip_ids =
     Set.union_list
       (module String)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -421,6 +421,17 @@ type config = {
           [Screener.screen_with_cooldown ~decline_is_slow_grind] (the screener
           lib stays macro-agnostic). [Variant_matrix] flag axis. See
           [Weinstein_strategy_config] for full semantics. *)
+  fast_v_arm_on_rate_alone : bool; [@sexp.default false]
+      (** Arming-speed dial for the fast-crash absolute stop (default-off): when
+          [true], the primary-index [Decline_character.Fast_v] classification
+          may arm on the rate of decline alone, without waiting for the weekly
+          MA to roll over (the 2020 arming-latency fix — the binding constraint
+          is when the stop arms, not its width). Default [false] is a no-op
+          (bit-identical; the classifier is unchanged). Threaded into
+          [Decline_character.fast_v_ignores_ma_filter] at both classify sites.
+          The {b spine} is untouched — it changes no buy/sell rule, only when
+          the tail-RISK-insurance absolute stop arms. [Variant_matrix] flag
+          axis. See [Weinstein_strategy_config] for full semantics. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -97,6 +97,9 @@ type config = {
   enable_slow_grind_short_gate : bool; [@sexp.default false]
       (** Admit shorts only in a slow-grind decline; default [false] = no-op.
           See [.mli]. *)
+  fast_v_arm_on_rate_alone : bool; [@sexp.default false]
+      (** Fast-crash absolute-stop arming-speed dial; default [false] = no-op.
+          See [.mli]. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Master switch for the late-Stage-2 stop-tighten runner; see [.mli]. *)
   late_stage2_stop_buffer_pct : float; [@sexp.default 0.0]
@@ -162,6 +165,7 @@ let default_config ~universe ~index_symbol =
     neutral_blocks_longs = false;
     neutral_blocks_shorts = false;
     enable_slow_grind_short_gate = false;
+    fast_v_arm_on_rate_alone = false;
     enable_late_stage2_stop_tighten = false;
     late_stage2_stop_buffer_pct = 0.0;
     enable_macro_bearish_exposure_trim = false;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -200,6 +200,39 @@ type config = {
           ([((flag enable_slow_grind_short_gate) (values (true false)))]).
           Default-off until an experiment-ledger ACCEPT (per
           [.claude/rules/experiment-flag-discipline.md]). *)
+  fast_v_arm_on_rate_alone : bool; [@sexp.default false]
+      (** Arming-speed dial for the fast-crash absolute stop
+          ([stops_config.catastrophic_stop_pct]); default [false] is a no-op
+          (bit-identical to baseline — the decline classifier behaves exactly as
+          before). When [true], the primary-index [Decline_character.Fast_v]
+          classification may arm on the {b rate of decline alone}, without
+          waiting for the weekly MA to roll over and price to fall below it.
+
+          Motivation: in a fast V-crash (2020), the structural gap-down stop has
+          already exited every long before the weekly MA rolls over, so the
+          [Fast_v]-gated [catastrophic_stop_pct] absolute stop never fires — the
+          binding constraint is arming {b latency}, not stop width. This flag
+          drops the falling-MA precondition for the fast-V path only (the
+          slow-grind path is untouched, since it presupposes a decline already
+          in progress). It is threaded into
+          [Decline_character.fast_v_ignores_ma_filter] at the two classify sites
+          ([Decline_character_wiring.update_ref], the load-bearing stop-arming
+          seam, and the [enable_slow_grind_short_gate] screen-time classify,
+          inert here since it maps [Fast_v] -> not-slow-grind) so one config
+          builds the classifier config.
+
+          {b Faithfulness}: a fast crash gives no Advance-Decline breadth lead
+          and falls before the weekly MA can confirm
+          (weinstein-book-reference.md §Macro / Ch. 8 distribution-lead
+          doctrine). This changes no buy/sell rule — only {b when} the absolute
+          tail-RISK-insurance stop arms — so it is the sanctioned
+          tail-RISK-insurance exception
+          ([.claude/rules/weinstein-faithful-core.md]); the spine is intact.
+
+          Single-component [Variant_matrix] flag axis
+          ([((flag fast_v_arm_on_rate_alone) (values (true false)))]).
+          Default-off until an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md]). *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -379,8 +379,12 @@ let _sector_lookup_of ~sector_map symbol =
 let _decline_is_slow_grind ~config ~macro_result ~index_view =
   if not config.enable_slow_grind_short_gate then true
   else
+    let classifier_config =
+      Decline_character_wiring.classifier_config
+        ~fast_v_arm_on_rate_alone:config.fast_v_arm_on_rate_alone
+    in
     match
-      Decline_character_wiring.classify ~config:Decline_character.default_config
+      Decline_character_wiring.classify ~config:classifier_config
         ~macro:macro_result ~index_view
     with
     | Decline_character.Slow_grind -> true


### PR DESCRIPTION
## What it does

Adds a default-off **`fast_v_arm_on_rate_alone`** arming-speed dial for the
fast-crash absolute long stop (Build 2b on the decline-character track).

### Motivation
The Build-2 fast-crash absolute stop (`catastrophic_stop_pct`, #1695) **never
fired** in its 2020 screen because `Decline_character.Fast_v` cannot arm until
the index is below a *falling* MA (~mid-March 2020) — by then the structural
gap-down stop has already exited every long. The binding constraint is arming
**latency**, not stop width. This knob lets `Fast_v` arm on the **rate of
decline alone**, dropping the falling-MA precondition for the fast-V path only.
(`dev/backtest/fast-crash-stop-screen-2026-06-22/FINDINGS.md`.)

## Changes

1. **Classifier knob** (`analysis/weinstein/macro/lib/decline_character.{ml,mli}`):
   new `config.fast_v_ignores_ma_filter : bool [@sexp.default false]`. When
   `true`, `classify` evaluates the fast-V-on-rate path even when no decline is
   in progress by the MA test — returning `Fast_v` iff the trailing
   rate-of-decline drawdown over `rate_lookback_weeks` exceeds
   `fast_v_min_rate_pct` (and A-D not leading); else `Not_declining`. The
   slow-grind path is **never** reached this way (it presupposes
   weeks-below-a-falling-MA = a decline already in progress). Extracted a flat
   `_classify_pre_decline_fast_v` helper so `classify` stays under the
   fn-length cap.

2. **Screenable axis (R2)**: new strategy flag
   `Weinstein_strategy.config.fast_v_arm_on_rate_alone : bool [@sexp.default
   false]` (mirrored in `weinstein_strategy_config.{ml,mli}` +
   `weinstein_strategy.mli`), threaded through a single new
   `Decline_character_wiring.classifier_config ~fast_v_arm_on_rate_alone` into
   **both** classify sites: `Decline_character_wiring.update_ref` (the
   load-bearing fast-crash stop-arming seam) and
   `weinstein_strategy_screening._decline_is_slow_grind` (inert for this flag
   since it maps `Fast_v`→not-slow-grind). It is a real `Weinstein_strategy.config`
   field → sexp-resolved by `Overlay_validator.apply_overrides`, so
   `((flag fast_v_arm_on_rate_alone) (values (true false)))` expands.

3. **Tests** (`analysis/weinstein/macro/test/test_decline_character.ml`, +4):
   flag-off steep-crash+rising-MA → `Not_declining` (backward-compat pin);
   flag-on same input → `Fast_v` (arms early); flag-on shallow+rising-MA →
   `Not_declining` (rate gate still applies); flag-on preserves the
   already-declining classification (`Slow_grind` / `Fast_v` unchanged).

## Flag discipline / faithfulness

- **R1 default-off**: both new fields carry `[@sexp.default false]`; with `false`
  the classifier reproduces `default_config` exactly → **no golden re-pin**
  (verified: `dune build` + the decline_character/strategy suites pass
  bit-identical with the flag off).
- **R2 searchable**: it's a real config field, Variant_matrix-expressible.
- **Faithfulness** (`weinstein-faithful-core.md`): a fast crash gives no
  Advance-Decline breadth lead and falls before the weekly MA can confirm
  (book Ch. 8 distribution-lead doctrine). This changes **no buy/sell rule** —
  only *when* the absolute tail-RISK-insurance stop arms — so it is the
  sanctioned tail-RISK-insurance exception. The Weinstein spine is intact.

No core-module edits (Portfolio/Orders/Position/Engine untouched); stops + screener
libs stay macro-agnostic. ~281 LOC. Do not modify `dev/status/_index.md`.
