### PR TITLE
docs+fixtures: faithful-short DEEP screen 2000-2010 (Build 3 verdict split)

### DIFF
--- a/dev/backtest/faithful-short-deep-screen-2026-06-22/FINDINGS.md
+++ b/dev/backtest/faithful-short-deep-screen-2026-06-22/FINDINGS.md
@@ -1,0 +1,113 @@
+# Faithful short (Build 3) — DEEP screen FINDINGS (2026-06-22)
+
+The deep-regime re-screen the shallow 2010-2026 screen
+(`dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md`) called for. Same 5
+arms, but on a **survivorship-correct PIT universe across two real sustained
+bears** — the dot-com bust (2000-02) and the GFC (2008) — the regimes where
+Weinstein's short doctrine is supposed to earn its keep and which 2010-2026
+(a secular bull) entirely lacked.
+
+- **Universe:** `sp500-2000-01-01` PIT membership (515 names, incl. delisted
+  LEH/BS/AIG etc.), **472/526 with bars fetched fresh from EODHD** (1998-2012,
+  90% coverage; delistings retained at real death dates — LEH→2008-09-17 etc.).
+- **Window:** 2000-01-01 → 2010-12-31, warmup from 1999-06-05. CSV mode, reads
+  the gitignored repo-root `data/` store.
+- **Arms:** identical overlay; only the two faithful-short flags vary (plus
+  `enable_short_side=false` for the long-only reference).
+
+## Headline — in real bears the short leg WORKS; the two gates split hard
+
+| arm | flags | return | trades | MaxDD | Sharpe | Calmar | shorts (net $) |
+|---|---|---|---|---|---|---|---|
+| 00 long-only ref | short off | 327.1% | 392 | 31.6% | 0.917 | 0.446 | — |
+| 01 baseline longshort | un-gated | **475.6%** | 401 | 27.6% | **1.066** | **0.624** | 18 (+$228.7K) |
+| 02 neutral_blocks_shorts | Bearish-only | **475.6%** | 401 | 27.6% | **1.066** | **0.624** | 18 (+$228.7K) |
+| 03 slow_grind_gate | slow-grind only | 367.1% | 397 | 26.7% | 0.962 | 0.563 | 5 (+$362.3K) |
+| 04 both | Bearish + slow-grind | 367.1% | 397 | 26.7% | 0.962 | 0.563 | 5 (+$362.3K) |
+
+Both long-short arms **beat long-only on return AND drawdown AND every
+risk-adjusted metric**. The un-gated short leg adds **+148pp return** and cuts
+**MaxDD 31.6→27.6** — Weinstein's short doctrine validated on a deep
+survivorship-correct universe. (This corrects the bull-only-window impression —
+2010-2026 and the #1678 NO-BUILD — that "shorts don't work": they work *in bear
+regimes*; bull regimes squeeze them.)
+
+## The two Build-3 flags have OPPOSITE verdicts
+
+### `neutral_blocks_shorts` (Bearish-tape-only) — KEEPER, promote candidate
+- **Bear regime (this screen): INERT.** 02 is identical to baseline (18 shorts,
+  +$228.7K, 475.6%, Sharpe 1.066) — **every un-gated short was already in a
+  Bearish tape**, so restricting to Bearish removes nothing.
+- **Bull regime (shallow screen): HELPS.** It removed exactly the 5 early-2010
+  Neutral-tape squeeze losses (−$33.7K) → +5.6pp, reverting to long-only.
+- **Net: strictly helpful-or-inert across both regimes.** It removes the
+  un-faithful (Neutral-tape) shorts and keeps every faithful (Bearish-tape) one.
+  This is the regime-adaptive faithful short. → **escalate to WF-CV + promotion
+  grid** (`experiment-gap-closing` → `promotion-confirmation.md`). Could be the
+  first short-side mechanism to clear.
+
+### `enable_slow_grind_short_gate` — TAXES the edge (reject-as-is / gate on Build 0)
+- **Bear regime: HURTS risk-adjusted return.** It cuts the short book 18→5,
+  dropping not just small losers but a profitable dot-com short (**JNS +$48.9K,
+  2001**). Total return falls **475.6→367.1**, Sharpe **1.066→0.962**, Calmar
+  **0.624→0.563** — for only a marginal MaxDD change (27.6→26.7). It does NOT
+  pay for itself.
+- **Bull regime: inert-equal-to-neutral** (removes all shorts, same as neutral).
+- **There is no regime where slow-grind beats neutral.** It is a **winner-touching
+  tax on the profitable short tail** — the short-side analog of
+  [[project_edge_is_the_fat_tail]]. → **do not prioritize promoting it.** Revisit
+  ONLY after Build 0 (A-D wiring): its over-restriction is the inert A-D-lead leg
+  (`~ad_bars:[]`) forcing reliance on the strict weeks-below-falling-MA≥8 leg,
+  which misses faster bear legs like much of 2008.
+
+## The WHY (transferable deliverable)
+
+1. **The short edge is itself a fat tail.** The un-gated short book's +$228.7K is
+   dominated by **ONE** position: **GENZ shorted 2008-08-30 → 2009-03-18 for
+   +$340.1K** (held through the GFC crash to near the bottom) — amid many small
+   losers. The let-the-short-run monster IS the edge, exactly mirroring the long
+   side ([[project_edge_is_the_fat_tail]]). Regime split of the 18: dot-com
+   (≤2003) +$27.4K, GFC-era +$201.3K.
+2. **Why slow-grind looks better per-trade but worse in total.** Its 5 kept
+   shorts net MORE ($362K > $228K) because it drops small losers — but it also
+   drops the JNS winner, and fewer shorts changes the long-book capital/exposure
+   deployment under the caps (`max_long_exposure 0.70` / `min_cash 0.30`), and
+   the un-gated config's long book captured more of the 2003-07 + 2009-10
+   recoveries. Net: total return and risk-adjusted metrics are *worse*. (The
+   long↔short capital interaction is a known attribution limit — shorts affect
+   cash/exposure → long sizing. The robust ordering un-gated ≥ grind holds on
+   every aggregate metric regardless.)
+3. **Regime is the governing variable for the short leg** — consistent with
+   [[project_factor_lens_regime_governs_edge]]. Shorts are additive in sustained
+   bears, a drag (squeezes) in bulls. The right lever is a **macro/tape gate**
+   (`neutral_blocks_shorts`) that turns the short leg off in non-bear tapes — NOT
+   a decline-shape gate (`slow_grind`) that second-guesses *which* bear shorts to
+   take and taxes the tail.
+
+## Verdict (screen-rigor calibrated)
+
+- **`neutral_blocks_shorts`: PROMISING — escalate to the real test.** Strictly
+  helpful-or-inert across a bull and a bear regime; risk-adjusted-best in the
+  bear regime; removes the loss-making bull shorts. This is a *promotion-track*
+  decision, not a promotion — WF-CV + the macro-regime-diverse confirmation grid
+  decide the default flip.
+- **`enable_slow_grind_short_gate`: NO-BUILD-PRIORITY decision (not a rigorous
+  rejection).** On this deep screen it taxes the bear short edge and never beats
+  `neutral`; combined with the fat-tail prior that's enough to deprioritize it.
+  Only a WF-CV surface can *reject* it; hold it as a default-off axis, gated on
+  Build 0 making its A-D leg live.
+
+## Caveats / infra
+
+- **Single deep window + survivor-leaning large-cap PIT** (sp500-as-of-2000, 90%
+  coverage). Conservative for short *profits* (survivors recovered), so the
+  measured +148pp short benefit is if anything understated. Still one window —
+  the promotion grid (`promotion-confirmation.md`) must add ≥1 more
+  (period × universe) cell before any default flip.
+- Long↔short capital-interaction confound on the *total*-return attribution
+  (point 2) — direct short P&L and the aggregate-metric ordering are both clean.
+- `all_eligible` diagnostic post-step errored on the universe path (looks under
+  `data/` not `test_data/` — the same fixtures-root bug noted in the shallow
+  screen); main `actual.sexp` metrics are valid.
+- Deep bars fetched into the gitignored `data/` store via
+  `dev/scripts/fetch_deep_2000.sh` — not committed (experiment input).

--- a/dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md
+++ b/dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md
@@ -1,5 +1,21 @@
 # Faithful short (Build 3) — screen FINDINGS (2026-06-22)
 
+> **SUPERSEDED on the benefit question** by the deep re-screen
+> `dev/backtest/faithful-short-deep-screen-2026-06-22/FINDINGS.md` (2000-2010,
+> survivorship-correct 472-name PIT). The deep screen shows the short leg DOES
+> work in real bears (+148pp, lower DD), splits the two Build-3 flags
+> (`neutral_blocks_shorts` = keeper/promote-track; `slow_grind_gate` = taxes the
+> edge), and supplies the "keep half" this bull-only window could not.
+>
+> **Correction (2026-06-22):** the universe-coverage caveat below originally said
+> "309/510 names have committed bars" — that counted the wrong store
+> (`trading/test_data/`). The runner reads the gitignored repo-root `data/`,
+> which at run time held deep history for only **~25 mega-cap survivors**, so the
+> effective universe here was **25 mega-caps** (AAPL…XOM), not 309. This makes
+> the screen even *less* able to surface Stage-4 shorts (mega-caps rarely top out)
+> — which is exactly why only 5 shorts occurred. The verdict (NEEDS-DEEP-DATA) is
+> unchanged and strengthened.
+
 Read-only screen of the Build-3 mechanism (`Weinstein_strategy.config`
 `neutral_blocks_shorts` + `enable_slow_grind_short_gate`; merged #1696,
 both default-off). Question: does tightening shorts to confirmed bears

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/00-longonly-reference.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/00-longonly-reference.sexp
@@ -1,0 +1,38 @@
+;; Faithful-short DEEP screen (Build 3) — LONG-ONLY REFERENCE FLOOR.
+;;
+;; enable_short_side=false: the short leg is dropped entirely. This is the
+;; reference the gated-short arms must beat for the short leg to be additive.
+;; If a faithful-short arm's risk-adjusted result rises toward / above this
+;; floor, the gate has turned the short leg from a drag into a contributor.
+;; Identical overlay to the long-short arms (only enable_short_side differs).
+((name "faithful-short-deep-00-longonly-reference")
+ (description
+   "Faithful-short DEEP screen reference: LONG-ONLY (short leg off). SP500 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/01-baseline-longshort.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/01-baseline-longshort.sexp
@@ -1,0 +1,44 @@
+;; Faithful-short DEEP screen (Build 3) — BASELINE: long-short, faithful flags OFF.
+;;
+;; Reproduces current un-gated short behavior (neutral_blocks_shorts=false,
+;; enable_slow_grind_short_gate=false): both Bearish AND Neutral tapes admit
+;; shorts, and shorts are admitted in fast-V crashes as well as slow grinds.
+;; This is the arm the night's screen flagged as net-negative (squeezed on
+;; the 2020 fast-V bounce). Overlay config copied verbatim from the
+;; sp500-2000-2010-longshort golden so the ONLY difference across the screen
+;; arms is the two faithful-short flags.
+;;
+;; Window 2000-2010 spans 2018-Q4, the 2020 fast-V, and the 2022 grind on
+;; committed data. Deep slow-bear (2000-02/2008) confirmation is a follow-up
+;; needing an EODHD fetch. CSV mode. Research-tier; sentinel bands only.
+((name "faithful-short-deep-01-baseline-longshort")
+ (description
+   "Faithful-short DEEP screen baseline: long-short, faithful flags OFF (un-gated short). SP500 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/02-neutral-only.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/02-neutral-only.sexp
@@ -1,0 +1,38 @@
+;; Faithful-short DEEP screen (Build 3) — ARM: neutral_blocks_shorts ONLY.
+;;
+;; neutral_blocks_shorts=true: only a Bearish tape admits shorts (Neutral no
+;; longer does). Tightens the short side to Weinstein's confirmed-bear rule.
+;; Isolates the macro-gate leg of the faithful short. Overlay identical to
+;; baseline; the slow-grind gate stays OFF here.
+((name "faithful-short-deep-02-neutral-only")
+ (description
+   "Faithful-short DEEP screen: neutral_blocks_shorts=true only (Bearish-tape-only shorts). SP500 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side true))
+   ((neutral_blocks_shorts true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/03-grind-only.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/03-grind-only.sexp
@@ -1,0 +1,40 @@
+;; Faithful-short DEEP screen (Build 3) — ARM: enable_slow_grind_short_gate ONLY.
+;;
+;; enable_slow_grind_short_gate=true: shorts admitted only when the current
+;; index decline is a Decline_character.Slow_grind (fast-V crashes and
+;; non-declines excluded). This is THE arm that targets the 2020 fast-V
+;; squeeze — it should block short entries during the V so the bounce cannot
+;; squeeze them. neutral_blocks_shorts stays OFF here. Overlay identical to
+;; baseline.
+((name "faithful-short-deep-03-grind-only")
+ (description
+   "Faithful-short DEEP screen: enable_slow_grind_short_gate=true only (slow-grind-only shorts). SP500 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side true))
+   ((enable_slow_grind_short_gate true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/04-both.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/faithful-short-deep-screen-2026-06-22/04-both.sexp
@@ -1,0 +1,39 @@
+;; Faithful-short DEEP screen (Build 3) — ARM: BOTH faithful flags ON.
+;;
+;; neutral_blocks_shorts=true AND enable_slow_grind_short_gate=true: the full
+;; Build-3 faithful short — shorts admitted only on a Bearish tape AND only
+;; when the index decline is a slow grind (no Neutral-tape shorts, no fast-V
+;; shorts). The most restrictive arm. Overlay identical to baseline.
+((name "faithful-short-deep-04-both")
+ (description
+   "Faithful-short DEEP screen: BOTH faithful flags ON (Bearish + slow-grind only shorts). SP500 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side true))
+   ((neutral_blocks_shorts true))
+   ((enable_slow_grind_short_gate true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (cost_model
+  ((per_trade_commission 0.0)
+   (per_share_commission 0.0)
+   (bid_ask_spread_bps 5.0)
+   (market_impact_bps_per_pct_adv 0.0)))
+ (expected
+  ((total_return_pct        ((min -90.0)  (max 5000.0)))
+   (total_trades            ((min   1)    (max 5000)))
+   (win_rate                ((min   0.0)  (max 100.0)))
+   (sharpe_ratio            ((min  -3.0)  (max   5.0)))
+   (max_drawdown_pct        ((min   0.0)  (max  90.0)))
+   (avg_holding_days        ((min   0.0)  (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0)  (max  10.0)))
+   (calmar_ratio            ((min  -3.0)  (max   5.0)))
+   (ulcer_index             ((min   0.0)  (max  60.0)))
+   (open_positions_value    ((min -1.0e12) (max 1.0e12))))))


### PR DESCRIPTION
Deep-regime re-screen of **Build 3** the shallow 2010-2026 screen (#1707) called for — on a **survivorship-correct 472-name PIT universe** (sp500-as-of-2000, 1998-2012 EODHD fetch incl. delisted LEH/BS/AIG) across the **dot-com bust + GFC**, the bears a secular-bull window lacked.

## Result — in real bears the short leg WORKS; the two flags split hard

| arm | return | trades | MaxDD | Sharpe | Calmar | shorts (net $) |
|---|---|---|---|---|---|---|
| long-only ref | 327.1% | 392 | 31.6% | 0.917 | 0.446 | — |
| un-gated longshort | **475.6%** | 401 | 27.6% | **1.066** | **0.624** | 18 (+$228.7K) |
| +neutral_blocks_shorts | **475.6%** | 401 | 27.6% | **1.066** | **0.624** | 18 (+$228.7K) |
| +slow_grind_gate | 367.1% | 397 | 26.7% | 0.962 | 0.563 | 5 (+$362.3K) |
| both | 367.1% | 397 | 26.7% | 0.962 | 0.563 | 5 |

Both long-short arms beat long-only on **return AND drawdown AND every risk-adjusted metric** — Weinstein's short doctrine validated deep (corrects the bull-only "shorts don't work" impression).

## The two Build-3 flags have OPPOSITE verdicts
- **`neutral_blocks_shorts` → KEEPER / promote-track.** Inert in bears (all 18 shorts already Bearish; 02≡01) + removes the bad bull-regime Neutral squeeze shorts (shallow screen) → strictly helpful-or-inert. Escalate to WF-CV + grid.
- **`enable_slow_grind_short_gate` → taxes the edge.** Cuts shorts 18→5, drops the JNS +$49K dot-com winner, return 475→367, Sharpe 1.07→0.96 — never beats neutral. Winner-touching tax on the short tail; reject-as-is / gate on Build 0 (A-D wiring). 

**Short edge is itself a fat tail:** GENZ shorted through the GFC = +$340K dominates the whole short book.

Full writeup: `dev/backtest/faithful-short-deep-screen-2026-06-22/FINDINGS.md`. Also **corrects** the merged shallow FINDINGS (effective universe was 25 mega-caps, not 309/510 — runner reads gitignored `data/`).

## Contents (docs + test fixtures only — no code)
- `dev/backtest/faithful-short-deep-screen-2026-06-22/FINDINGS.md` (new)
- `dev/backtest/faithful-short-screen-2026-06-22/FINDINGS.md` (correction + supersession note)
- 5 deep-window scenarios (`experiments/faithful-short-deep-screen-2026-06-22/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)