### PR TITLE
docs+fixtures: neutral_blocks_shorts promotion GRID — NO default flip (regime-dependent)

### DIFF
--- a/dev/backtest/neutral-blocks-shorts-grid-2026-06-22/FINDINGS.md
+++ b/dev/backtest/neutral-blocks-shorts-grid-2026-06-22/FINDINGS.md
@@ -1,0 +1,66 @@
+# `neutral_blocks_shorts` — promotion confirmation GRID (2026-06-22)
+
+The `promotion-confirmation.md` grid for the `neutral_blocks_shorts` mechanism,
+which earned a single-cell **ACCEPT** in
+`dev/backtest/neutral-blocks-shorts-wfcv-2026-06-22/` (cell 1). The grid re-runs
+the same flag axis in a **second, independent (period × universe) cell** before
+any default flip.
+
+| cell | universe | window | folds | base |
+|---|---|---|---|---|
+| 1 (ACCEPT) | sp500-as-of-2000 PIT | 2000-2026 (all-regime) | 26 | deep long-short |
+| 2 (this) | sp500-as-of-2010 PIT | 2010-2026 (bull-dominated) | 16 | sp500-2010-2026-longshort golden |
+
+## Cell-2 result — `true` does NOT beat baseline (dominated)
+
+| Variant | Sharpe | Calmar | MaxDD % | Pareto |
+|---|---|---|---|---|
+| baseline (≡ false) | 0.576 | 1.170 | 11.42 | **yes** |
+| neutral_blocks_shorts=true | 0.576 | 1.170 | **11.48** | **no (dominated)** |
+
+`true` is **identical to baseline in 15/16 folds** and marginally **worse** in one:
+- **fold-009 (2019):** return 0.42→0.39%, Sharpe 0.095→0.092, MaxDD **8.43→9.39%**,
+  Calmar 0.050→0.042. The gate removed a Neutral-tape short that would have
+  marginally helped in 2019. Aggregate: Sharpe tied, MaxDD fractionally worse →
+  `true` is off the frontier.
+
+## Grid verdict: NO DEFAULT FLIP — keep ACCEPT(mechanism), promote no value
+
+| cell | regime | `true` vs baseline |
+|---|---|---|
+| 1 (2000-2026) | all-regime incl. dot-com/GFC | **≥** (wins 2003 squeeze-avoidance +9pp, +0.02 Sharpe aggregate) |
+| 2 (2010-2026) | clean bull | **≤** (inert 15/16, fractionally worse in 2019; dominated on MaxDD) |
+
+Per the `promotion-confirmation.md` decision rule — *PROMOTE value V only if it
+beats baseline in a strong majority of cells AND is never badly dominated* — the
+grid **disagrees**: `true` helps in the bear-containing cell and is
+inert-or-fractionally-worse in the bull cell. No single value is robust across the
+grid, so:
+
+- **`neutral_blocks_shorts` stays default-off + an axis** (ACCEPT-mechanism, no
+  value promoted). It is faithful and helpful **in regimes with bad Neutral-tape
+  shorts** (post-bottom squeezes like 2003/2010), but in clean bulls it
+  occasionally removes a marginally-useful Neutral short. It is a **regime-dependent
+  trade, not a free win.**
+- This is the grid doing its job: cell 1 alone read as a clean ACCEPT; the second
+  cell reveals the regime-dependence and **prevents an over-promotion** — exactly
+  the failure mode (`promotion-confirmation.md`, the 2026-05-30 early-admission
+  episode) the grid exists to catch.
+
+## Why this is the right call (transferable)
+
+The short leg's value is **regime-governed** ([[project_factor_lens_regime_governs_edge]]):
+shorts (and short-gating) pay in sustained/recovering-bear regimes and are a
+low-stakes wash in clean bulls. A *static default flip* of a short-gate cannot be
+right for both regimes at once. The faithful resolution is to **keep the gate as an
+available axis** and, if anything, gate it on a macro-regime signal — not flip it
+globally. For now: no flip; the mechanism is recorded, faithful, and ready if a
+regime-aware wiring is built later.
+
+Recorded: `dev/experiments/_ledger/2026-06-22-neutral-blocks-shorts-grid.sexp`.
+
+## Caveats
+- Cell 2 uses the committed `sp500-2010-2026-longshort` golden base (sp500-as-of-2010,
+  16 annual folds) on the now-complete deep `data/` store. Both cells static-universe;
+  the qualitative cross-regime split (help-in-bear / wash-in-bull) is the robust
+  finding. Evidence: `cell2_walk_forward_report.md` + `cell2_ranking.md`.

--- a/dev/backtest/neutral-blocks-shorts-grid-2026-06-22/cell2_ranking.md
+++ b/dev/backtest/neutral-blocks-shorts-grid-2026-06-22/cell2_ranking.md
@@ -1,0 +1,16 @@
+# Variant ranking
+
+Baseline: baseline
+
+## Pareto frontier (Sharpe up, Calmar up, MaxDD down)
+
+- baseline
+- neutral_blocks_shorts=false
+
+## Variants
+
+| Variant | Sharpe | Calmar | MaxDD % | Frontier | Deflated Sharpe |
+|---------|-------:|-------:|--------:|:--------:|----------------:|
+| baseline | 0.576 | 1.170 | 11.42 | yes | 0.9875 |
+| neutral_blocks_shorts=true | 0.576 | 1.170 | 11.48 | no | 0.9875 |
+| neutral_blocks_shorts=false | 0.576 | 1.170 | 11.42 | yes | 0.9875 |

--- a/dev/backtest/neutral-blocks-shorts-grid-2026-06-22/cell2_walk_forward_report.md
+++ b/dev/backtest/neutral-blocks-shorts-grid-2026-06-22/cell2_walk_forward_report.md
@@ -1,0 +1,78 @@
+# Walk-forward CV report
+
+## 1. Per-fold metrics
+
+| Fold | Variant | Return % | CAGR % | Sharpe | MaxDD % | Calmar |
+|------|---------|---------:|-------:|-------:|--------:|-------:|
+| fold-000 | baseline | 9.39 | 9.40 | 0.629 | 13.53 | 0.697 |
+| fold-001 | baseline | -11.40 | -11.41 | -1.059 | 14.55 | -0.786 |
+| fold-002 | baseline | 12.46 | 12.47 | 1.028 | 8.78 | 1.425 |
+| fold-003 | baseline | 36.94 | 36.97 | 2.523 | 6.90 | 5.376 |
+| fold-004 | baseline | 17.56 | 17.57 | 1.285 | 11.54 | 1.528 |
+| fold-005 | baseline | 0.93 | 0.93 | 0.137 | 10.39 | 0.090 |
+| fold-006 | baseline | 8.60 | 8.60 | 0.625 | 9.00 | 0.959 |
+| fold-007 | baseline | 36.20 | 36.22 | 2.083 | 6.81 | 5.336 |
+| fold-008 | baseline | 8.36 | 8.37 | 0.572 | 12.15 | 0.690 |
+| fold-009 | baseline | 0.42 | 0.42 | 0.095 | 8.43 | 0.050 |
+| fold-010 | baseline | 3.28 | 3.29 | 0.260 | 15.61 | 0.211 |
+| fold-011 | baseline | 8.98 | 8.99 | 0.647 | 12.60 | 0.715 |
+| fold-012 | baseline | -17.55 | -17.56 | -1.905 | 19.14 | -0.920 |
+| fold-013 | baseline | 17.91 | 17.92 | 1.213 | 10.99 | 1.635 |
+| fold-014 | baseline | 13.28 | 13.29 | 1.110 | 7.25 | 1.838 |
+| fold-015 | baseline | -1.79 | -1.79 | -0.031 | 15.05 | -0.119 |
+| fold-000 | neutral_blocks_shorts=true | 9.39 | 9.40 | 0.629 | 13.53 | 0.697 |
+| fold-001 | neutral_blocks_shorts=true | -11.40 | -11.41 | -1.059 | 14.55 | -0.786 |
+| fold-002 | neutral_blocks_shorts=true | 12.46 | 12.47 | 1.028 | 8.78 | 1.425 |
+| fold-003 | neutral_blocks_shorts=true | 36.94 | 36.97 | 2.523 | 6.90 | 5.376 |
+| fold-004 | neutral_blocks_shorts=true | 17.56 | 17.57 | 1.285 | 11.54 | 1.528 |
+| fold-005 | neutral_blocks_shorts=true | 0.93 | 0.93 | 0.137 | 10.39 | 0.090 |
+| fold-006 | neutral_blocks_shorts=true | 8.60 | 8.60 | 0.625 | 9.00 | 0.959 |
+| fold-007 | neutral_blocks_shorts=true | 36.20 | 36.22 | 2.083 | 6.81 | 5.336 |
+| fold-008 | neutral_blocks_shorts=true | 8.36 | 8.37 | 0.572 | 12.15 | 0.690 |
+| fold-009 | neutral_blocks_shorts=true | 0.39 | 0.39 | 0.092 | 9.39 | 0.042 |
+| fold-010 | neutral_blocks_shorts=true | 3.28 | 3.29 | 0.260 | 15.61 | 0.211 |
+| fold-011 | neutral_blocks_shorts=true | 8.98 | 8.99 | 0.647 | 12.60 | 0.715 |
+| fold-012 | neutral_blocks_shorts=true | -17.55 | -17.56 | -1.905 | 19.14 | -0.920 |
+| fold-013 | neutral_blocks_shorts=true | 17.91 | 17.92 | 1.213 | 10.99 | 1.635 |
+| fold-014 | neutral_blocks_shorts=true | 13.28 | 13.29 | 1.110 | 7.25 | 1.838 |
+| fold-015 | neutral_blocks_shorts=true | -1.79 | -1.79 | -0.031 | 15.05 | -0.119 |
+| fold-000 | neutral_blocks_shorts=false | 9.39 | 9.40 | 0.629 | 13.53 | 0.697 |
+| fold-001 | neutral_blocks_shorts=false | -11.40 | -11.41 | -1.059 | 14.55 | -0.786 |
+| fold-002 | neutral_blocks_shorts=false | 12.46 | 12.47 | 1.028 | 8.78 | 1.425 |
+| fold-003 | neutral_blocks_shorts=false | 36.94 | 36.97 | 2.523 | 6.90 | 5.376 |
+| fold-004 | neutral_blocks_shorts=false | 17.56 | 17.57 | 1.285 | 11.54 | 1.528 |
+| fold-005 | neutral_blocks_shorts=false | 0.93 | 0.93 | 0.137 | 10.39 | 0.090 |
+| fold-006 | neutral_blocks_shorts=false | 8.60 | 8.60 | 0.625 | 9.00 | 0.959 |
+| fold-007 | neutral_blocks_shorts=false | 36.20 | 36.22 | 2.083 | 6.81 | 5.336 |
+| fold-008 | neutral_blocks_shorts=false | 8.36 | 8.37 | 0.572 | 12.15 | 0.690 |
+| fold-009 | neutral_blocks_shorts=false | 0.42 | 0.42 | 0.095 | 8.43 | 0.050 |
+| fold-010 | neutral_blocks_shorts=false | 3.28 | 3.29 | 0.260 | 15.61 | 0.211 |
+| fold-011 | neutral_blocks_shorts=false | 8.98 | 8.99 | 0.647 | 12.60 | 0.715 |
+| fold-012 | neutral_blocks_shorts=false | -17.55 | -17.56 | -1.905 | 19.14 | -0.920 |
+| fold-013 | neutral_blocks_shorts=false | 17.91 | 17.92 | 1.213 | 10.99 | 1.635 |
+| fold-014 | neutral_blocks_shorts=false | 13.28 | 13.29 | 1.110 | 7.25 | 1.838 |
+| fold-015 | neutral_blocks_shorts=false | -1.79 | -1.79 | -0.031 | 15.05 | -0.119 |
+
+## 2. Stability (mean ± stdev across folds)
+
+| Variant | Return % (μ ± σ) | CAGR % (μ ± σ) | Sharpe (μ ± σ) | MaxDD % (μ ± σ) | Calmar (μ ± σ) |
+|---------|-----------------:|---------------:|---------------:|----------------:|--------------:|
+| baseline | 8.97 ± 14.41 | 8.98 ± 14.42 | 0.576 ± 1.071 | 11.42 ± 3.55 | 1.170 ± 1.822 |
+| neutral_blocks_shorts=true | 8.97 ± 14.41 | 8.98 ± 14.42 | 0.576 ± 1.071 | 11.48 ± 3.50 | 1.170 ± 1.822 |
+| neutral_blocks_shorts=false | 8.97 ± 14.41 | 8.98 ± 14.42 | 0.576 ± 1.071 | 11.42 ± 3.55 | 1.170 ± 1.822 |
+
+## 3. Cross-fold sensitivity
+
+Variant wins per fold on each metric (vs baseline `baseline`, 16 folds total; gate metric marked **\***):
+
+| Variant | Sharpe wins* | Calmar wins | Return wins | MaxDD wins | of |
+|---------|----------:|----------:|----------:|----------:|---:|
+| neutral_blocks_shorts=true | 0 | 0 | 0 | 0 | 16 |
+| neutral_blocks_shorts=false | 0 | 0 | 0 | 0 | 16 |
+
+## 4. Go/no-go verdict
+
+Gate: variant wins ≥9 of 16 folds on **Sharpe** vs baseline `baseline`, no fold worse by Δ>0.0000.
+
+- **neutral_blocks_shorts=true**: FAIL (0 / 16 wins; worst fold `fold-009` gap 0.0025). Reason: M-threshold miss: 0 wins < 9 required; worst fold fold-009 trails by 0.0025 > Δ=0.0000
+- **neutral_blocks_shorts=false**: FAIL (0 / 16 wins; worst fold `fold-000` gap 0.0000). Reason: M-threshold miss: 0 wins < 9 required

--- a/dev/experiments/_ledger/2026-06-22-neutral-blocks-shorts-grid.sexp
+++ b/dev/experiments/_ledger/2026-06-22-neutral-blocks-shorts-grid.sexp
@@ -1,0 +1,17 @@
+((date 2026-06-22)
+ (slug neutral-blocks-shorts-grid)
+ (hypothesis
+  "neutral_blocks_shorts=true is robust across the promotion-confirmation grid (a 2nd period x universe cell) and therefore eligible for a default flip")
+ (base_scenario "goldens-sp500-historical/sp500-2010-2026-longshort.sexp")
+ (window_id wfcv-cell2-2010-2026-16fold)
+ (baseline_label baseline)
+ (variants
+  (((label neutral_blocks_shorts=true)
+    (config_hash nbs-true-sp500-2010-2026-16fold)
+    (aggregate
+     ((sharpe_mean 0.576) (calmar_mean 1.170) (maxdd_mean 11.48)
+      (pareto_frontier no) (deflated_sharpe 0.9875))))))
+ (verdict Reject)
+ (notes
+  "GRID DISAGREEMENT -> NO DEFAULT FLIP (keep ACCEPT-mechanism, promote no value). See dev/backtest/neutral-blocks-shorts-grid-2026-06-22/. Cell 1 (2000-2026 all-regime, 2026-06-22-neutral-blocks-shorts-wfcv) had true >= baseline (won 2003 squeeze +0.02 Sharpe). Cell 2 (this, 2010-2026 bull, sp500-2010 golden): true identical in 15/16 folds, marginally WORSE in fold-009 2019 (MaxDD 8.43->9.39), dominated on MaxDD / off frontier. So neutral_blocks_shorts helps in bear-containing regimes (post-bottom squeeze avoidance) but is inert-or-fractionally-worse in clean bulls (removes occasionally-useful Neutral shorts) = regime-dependent trade, NOT a free win. Per promotion-confirmation.md no single value robust across grid -> mechanism stays default-off axis. The grid PREVENTED an over-promotion cell-1 alone suggested (the methodology working as designed). Short-leg value is regime-governed (project_factor_lens_regime_governs_edge); a static global flip can't be right for both regimes. This Reject verdict is on the PROMOTION (the flip), not the mechanism (which keeps its cell-1 ACCEPT as an axis).")
+ )

--- a/trading/test_data/walk_forward/neutral-blocks-shorts-cell2-2010-2026.sexp
+++ b/trading/test_data/walk_forward/neutral-blocks-shorts-cell2-2010-2026.sexp
@@ -1,0 +1,12 @@
+;; neutral_blocks_shorts WF-CV — CONFIRMATION GRID cell 2 (promotion-confirmation.md).
+;; Cell 1 was sp500-as-of-2000 / 2000-2026 (all-regime). This cell is a DIFFERENT
+;; universe (sp500-as-of-2010) and a DIFFERENT, bull-dominated period (2010-2026),
+;; on the existing long-short golden base. If neutral_blocks_shorts=true >= baseline
+;; here too, the mechanism is robust across the (period x universe) grid and eligible
+;; for a default flip. Rolling 2010-2026 test 365 step 365 => ~16 folds. CSV on data/.
+((base_scenario "test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026-longshort.sexp")
+ (window_spec
+  (Rolling ((start_date 2010-01-01) (end_date 2026-04-30) (train_days 0) (test_days 365) (step_days 365))))
+ (baseline_label baseline)
+ (gate ((metric Sharpe) (m 9) (n 16) (worst_delta 0.0)))
+ (axes ((axes (((flag neutral_blocks_shorts) (values (true false))))) (expansion Cartesian))))


### PR DESCRIPTION
Confirmation-grid **cell 2** for `neutral_blocks_shorts` (cell 1 = 2000-2026 all-regime ACCEPT, #1713). Cell 2 = a different universe + period (sp500-as-of-2010 / 2010-2026 bull, 16 folds).

## Cell-2 result — `true` does NOT beat baseline
| Variant | Sharpe | Calmar | MaxDD% | Pareto |
|---|---|---|---|---|
| baseline | 0.576 | 1.170 | 11.42 | yes |
| neutral=true | 0.576 | 1.170 | 11.48 | **no (dominated)** |

Identical in 15/16 folds; marginally **worse** in fold-009 (2019: MaxDD 8.43→9.39%).

## Grid verdict: NO default flip
- Cell 1 (all-regime): `true` ≥ baseline (won 2003 squeeze-avoidance)
- Cell 2 (clean bull): `true` ≤ baseline (inert-or-fractionally-worse)

Per `promotion-confirmation.md` (PROMOTE only if robust across cells) → **grid disagrees → no flip**. `neutral_blocks_shorts` stays default-off + an axis (keeps its cell-1 ACCEPT-mechanism; no value promoted). The short leg's value is **regime-governed** — a static global flip can't be right for both regimes. The grid prevented an over-promotion cell-1 alone suggested (methodology working as designed). Ledger entry added. Docs+fixtures only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)