### PR TITLE
feat(decline-character): expose fast_v_min_rate_pct as strategy config axis (default-off no-op)

### DIFF
--- a/trading/analysis/weinstein/macro/test/test_decline_character.ml
+++ b/trading/analysis/weinstein/macro/test/test_decline_character.ml
@@ -218,6 +218,48 @@ let test_arm_on_preserves_declining_classification _ =
          equal_to Decline_character.Fast_v;
        ])
 
+(* ------------------------------------------------------------------ *)
+(* fast_v_min_rate_pct — arming rate threshold (whipsaw-suppression)   *)
+(* ------------------------------------------------------------------ *)
+
+(* A MODERATE 4-week drawdown of ~10% below a falling MA, A-D Neutral (not
+   leading). At the default threshold (8%) the 10% drop classifies as Fast_v;
+   raising the threshold to 16% requires a steeper drop, so the same input is
+   Not_declining. Both share this fixture. *)
+let moderate_drawdown_below_falling_ma () =
+  let prices = List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 97.0; 94.0; 90.0 ] in
+  let index_bars = weekly_bars prices in
+  let macro =
+    macro_result ~ma_value:98.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Neutral
+  in
+  (index_bars, macro)
+
+(* Default config (threshold 8%): a ~10% drawdown arms Fast_v. Also pins that
+   the default reproduces today's classification on the steep-drop fixture. *)
+let test_default_rate_threshold_arms_fast_v _ =
+  let index_bars, macro = moderate_drawdown_below_falling_ma () in
+  assert_that
+    [
+      Decline_character.classify ~config:cfg ~macro ~index_bars;
+      (let steep_bars, steep_macro = steep_crash_with_rising_ma () in
+       (* default 0.08 == today's classification on the steep fixture *)
+       Decline_character.classify ~config:cfg_arm_on_rate ~macro:steep_macro
+         ~index_bars:steep_bars);
+    ]
+    (elements_are
+       [ equal_to Decline_character.Fast_v; equal_to Decline_character.Fast_v ])
+
+(* Raising fast_v_min_rate_pct to 16%: the same ~10% drawdown no longer meets
+   the (steeper) rate bar, so it is Not_declining — the whipsaw-suppression
+   behaviour (a moderate dip that would have armed Fast_v at 8% no longer does). *)
+let test_higher_rate_threshold_suppresses_fast_v _ =
+  let index_bars, macro = moderate_drawdown_below_falling_ma () in
+  let cfg_high_rate = { cfg with fast_v_min_rate_pct = 0.16 } in
+  assert_that
+    (Decline_character.classify ~config:cfg_high_rate ~macro ~index_bars)
+    (equal_to Decline_character.Not_declining)
+
 let suite =
   "decline_character"
   >::: [
@@ -235,6 +277,10 @@ let suite =
          >:: test_arm_on_rising_ma_shallow_is_not_declining;
          "arm_on_preserves_declining_classification"
          >:: test_arm_on_preserves_declining_classification;
+         "default_rate_threshold_arms_fast_v"
+         >:: test_default_rate_threshold_arms_fast_v;
+         "higher_rate_threshold_suppresses_fast_v"
+         >:: test_higher_rate_threshold_suppresses_fast_v;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/decline_character_wiring.ml
+++ b/trading/trading/weinstein/strategy/lib/decline_character_wiring.ml
@@ -15,23 +15,29 @@ let _index_bars_of_weekly_view
         ~adjusted_close:v.closes.(i) ())
 
 (* The decline-character classifier config built from the strategy-level
-   arming-speed flag: default config except [fast_v_ignores_ma_filter] is set
-   from [fast_v_arm_on_rate_alone], so one strategy flag controls both classify
-   sites consistently. [false] reproduces [default_config] exactly. *)
-let classifier_config ~fast_v_arm_on_rate_alone =
+   arming-speed flag and arming rate threshold: default config except
+   [fast_v_ignores_ma_filter] is set from [fast_v_arm_on_rate_alone] and
+   [fast_v_min_rate_pct] from the strategy field, so the strategy controls both
+   classify sites consistently. [fast_v_arm_on_rate_alone = false] together with
+   [fast_v_min_rate_pct = default_config.fast_v_min_rate_pct] (0.08) reproduces
+   [default_config] exactly. *)
+let classifier_config ~fast_v_arm_on_rate_alone ~fast_v_min_rate_pct =
   {
     Decline_character.default_config with
     fast_v_ignores_ma_filter = fast_v_arm_on_rate_alone;
+    fast_v_min_rate_pct;
   }
 
 let classify ~config ~macro ~index_view =
   let index_bars = _index_bars_of_weekly_view index_view in
   Decline_character.classify ~config ~macro ~index_bars
 
-let update_ref ~fast_v_arm_on_rate_alone ~prior_decline_character
-    ~macro_result_opt ~index_view =
+let update_ref ~fast_v_arm_on_rate_alone ~fast_v_min_rate_pct
+    ~prior_decline_character ~macro_result_opt ~index_view =
   match macro_result_opt with
   | None -> ()
   | Some macro ->
-      let config = classifier_config ~fast_v_arm_on_rate_alone in
+      let config =
+        classifier_config ~fast_v_arm_on_rate_alone ~fast_v_min_rate_pct
+      in
       prior_decline_character := classify ~config ~macro ~index_view

--- a/trading/trading/weinstein/strategy/lib/decline_character_wiring.mli
+++ b/trading/trading/weinstein/strategy/lib/decline_character_wiring.mli
@@ -12,14 +12,19 @@
     (A2): they receive a plain [~armed:bool], not a {!Decline_character.t}. *)
 
 val classifier_config :
-  fast_v_arm_on_rate_alone:bool -> Decline_character.config
-(** [classifier_config ~fast_v_arm_on_rate_alone] is
+  fast_v_arm_on_rate_alone:bool ->
+  fast_v_min_rate_pct:float ->
+  Decline_character.config
+(** [classifier_config ~fast_v_arm_on_rate_alone ~fast_v_min_rate_pct] is
     [Decline_character.default_config] with [fast_v_ignores_ma_filter] set from
-    the strategy-level [fast_v_arm_on_rate_alone] flag — a single source of the
+    the strategy-level [fast_v_arm_on_rate_alone] flag and [fast_v_min_rate_pct]
+    set from the strategy-level field of the same name — a single source of the
     classifier config so both classify sites (the stop-arming {!update_ref} and
     the slow-grind-gate screen-time classify) stay consistent. With
-    [fast_v_arm_on_rate_alone = false] it reproduces [default_config] exactly
-    (bit-identical to the pre-flag behaviour). *)
+    [fast_v_arm_on_rate_alone = false] and
+    [fast_v_min_rate_pct = Decline_character.default_config.fast_v_min_rate_pct]
+    (0.08) it reproduces [default_config] exactly (bit-identical to the pre-flag
+    behaviour). *)
 
 val classify :
   config:Decline_character.config ->
@@ -37,18 +42,21 @@ val classify :
 
 val update_ref :
   fast_v_arm_on_rate_alone:bool ->
+  fast_v_min_rate_pct:float ->
   prior_decline_character:Decline_character.t ref ->
   macro_result_opt:Macro.result option ->
   index_view:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
   unit
-(** [update_ref ~fast_v_arm_on_rate_alone ~prior_decline_character
-     ~macro_result_opt ~index_view] stores a fresh {!classify} of the index into
-    [prior_decline_character] when [macro_result_opt] is [Some] (a screening
-    day) — using {!classifier_config} built from the strategy-level
-    [fast_v_arm_on_rate_alone] arming-speed flag (default [false] reproduces
-    {!Decline_character.default_config} exactly). On a non-screening day
-    ([None]) it is a no-op, so the ref retains the last classification: the
+(** [update_ref ~fast_v_arm_on_rate_alone ~fast_v_min_rate_pct
+     ~prior_decline_character ~macro_result_opt ~index_view] stores a fresh
+    {!classify} of the index into [prior_decline_character] when
+    [macro_result_opt] is [Some] (a screening day) — using {!classifier_config}
+    built from the strategy-level [fast_v_arm_on_rate_alone] arming-speed flag
+    and [fast_v_min_rate_pct] arming rate threshold (defaults [false] / 0.08
+    reproduce {!Decline_character.default_config} exactly). On a non-screening
+    day ([None]) it is a no-op, so the ref retains the last classification: the
     strategy's stops pass reads it on the NEXT tick (strictly prior, no
     lookahead — the Build 2 fast-crash absolute-stop arming seam). The
     searchable mechanism flag is [stops_config.catastrophic_stop_pct]; the
-    arming-speed flag is [fast_v_arm_on_rate_alone]. *)
+    arming-speed flag is [fast_v_arm_on_rate_alone]; the arming rate threshold
+    is [fast_v_min_rate_pct]. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -299,7 +299,8 @@ let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
      tick's stops pass to arm the fast-crash absolute stop — Build 2). *)
   Decline_character_wiring.update_ref
     ~fast_v_arm_on_rate_alone:config.fast_v_arm_on_rate_alone
-    ~prior_decline_character ~macro_result_opt ~index_view;
+    ~fast_v_min_rate_pct:config.fast_v_min_rate_pct ~prior_decline_character
+    ~macro_result_opt ~index_view;
   let skip_ids =
     Set.union_list
       (module String)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -432,6 +432,18 @@ type config = {
           The {b spine} is untouched — it changes no buy/sell rule, only when
           the tail-RISK-insurance absolute stop arms. [Variant_matrix] flag
           axis. See [Weinstein_strategy_config] for full semantics. *)
+  fast_v_min_rate_pct : float; [@sexp.default 0.08]
+      (** Fast-V arming rate threshold (whipsaw-suppression dial): the minimum
+          trailing rate-of-decline drawdown at which the primary index is
+          classified [Decline_character.Fast_v]. Default [0.08] equals
+          [Decline_character.default_config.fast_v_min_rate_pct] — a no-op
+          (bit-identical classification). Raising it (e.g. to 0.16) requires a
+          steeper drawdown before [Fast_v] arms, suppressing the rate-alone
+          re-arm whipsaw in choppy corrections. Threaded into
+          [Decline_character.fast_v_min_rate_pct] at both classify sites. The
+          {b spine} is untouched — it changes only when the tail-RISK-insurance
+          absolute stop arms. [Variant_matrix] float axis. See
+          [Weinstein_strategy_config] for full semantics. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -4,6 +4,12 @@ open Core
    long-exposure cap, so the trim never bites until a spec sets a tighter value. *)
 let macro_bearish_no_op_cap = 0.70
 
+(* No-op default for [fast_v_min_rate_pct]: equals [Decline_character]'s own
+   [default_config.fast_v_min_rate_pct], so threading this value into the
+   classifier config reproduces [default_config] exactly (bit-identical
+   classification) until a spec sets a different fast-V arming rate threshold. *)
+let fast_v_min_rate_no_op = 0.08
+
 type index_config = { primary : string; global : (string * string) list }
 [@@deriving sexp]
 
@@ -100,6 +106,10 @@ type config = {
   fast_v_arm_on_rate_alone : bool; [@sexp.default false]
       (** Fast-crash absolute-stop arming-speed dial; default [false] = no-op.
           See [.mli]. *)
+  fast_v_min_rate_pct : float; [@sexp.default fast_v_min_rate_no_op]
+      (** Fast-V arming rate threshold (whipsaw-suppression dial); default
+          [fast_v_min_rate_no_op] (0.08) reproduces the classifier default. See
+          [.mli]. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Master switch for the late-Stage-2 stop-tighten runner; see [.mli]. *)
   late_stage2_stop_buffer_pct : float; [@sexp.default 0.0]
@@ -166,6 +176,7 @@ let default_config ~universe ~index_symbol =
     neutral_blocks_shorts = false;
     enable_slow_grind_short_gate = false;
     fast_v_arm_on_rate_alone = false;
+    fast_v_min_rate_pct = fast_v_min_rate_no_op;
     enable_late_stage2_stop_tighten = false;
     late_stage2_stop_buffer_pct = 0.0;
     enable_macro_bearish_exposure_trim = false;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -233,6 +233,29 @@ type config = {
           ([((flag fast_v_arm_on_rate_alone) (values (true false)))]).
           Default-off until an experiment-ledger ACCEPT (per
           [.claude/rules/experiment-flag-discipline.md]). *)
+  fast_v_min_rate_pct : float; [@sexp.default 0.08]
+      (** Fast-V arming rate threshold: the minimum trailing rate-of-decline
+          drawdown (positive fraction over [rate_lookback_weeks]) at which the
+          primary index is classified [Decline_character.Fast_v]. Threaded into
+          [Decline_character.fast_v_min_rate_pct] at the two classify sites via
+          {!Decline_character_wiring.classifier_config}. Default [0.08] equals
+          [Decline_character.default_config.fast_v_min_rate_pct], so it is a
+          no-op (bit-identical classification to the pre-flag behaviour).
+
+          Whipsaw-suppression dial: in choppy corrections (e.g. 2010/2011) the
+          [fast_v_arm_on_rate_alone] path arms the fast-crash absolute stop on
+          rate alone, and a low rate threshold lets shallow rallies-into-decline
+          re-arm/dis-arm repeatedly. Raising the threshold (e.g. to 0.16)
+          requires a steeper drawdown before [Fast_v] is declared, suppressing
+          that whipsaw — at the cost of arming later in a genuine crash. A
+          higher value never widens the [Fast_v] band, so the spine is untouched
+          (it changes only when the tail-RISK-insurance stop arms, never a
+          buy/sell rule — see [.claude/rules/weinstein-faithful-core.md]).
+
+          Single-component [Variant_matrix] float axis (e.g.
+          [((flag fast_v_min_rate_pct) (values (0.08 0.12 0.16)))]). Default
+          no-op until an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md]). *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -382,6 +382,7 @@ let _decline_is_slow_grind ~config ~macro_result ~index_view =
     let classifier_config =
       Decline_character_wiring.classifier_config
         ~fast_v_arm_on_rate_alone:config.fast_v_arm_on_rate_alone
+        ~fast_v_min_rate_pct:config.fast_v_min_rate_pct
     in
     match
       Decline_character_wiring.classify ~config:classifier_config


### PR DESCRIPTION
Mirrors the #1708 `fast_v_arm_on_rate_alone` plumbing for the `Fast_v` arming **rate threshold**. New `Weinstein_strategy.config.fast_v_min_rate_pct` (default = the classifier default 0.08, bound as a named `fast_v_min_rate_no_op` constant) threaded via `Decline_character_wiring.classifier_config` into both classify sites.

- **R1 default-off:** default == 0.08 == `Decline_character.default_config.fast_v_min_rate_pct` → bit-identical, **no golden re-pin**.
- **R2 searchable axis:** real `Weinstein_strategy.config` field → `((flag fast_v_min_rate_pct) (values …))` expands.
- **Why:** the arming-speed WF-CV (`dev/backtest/arming-speed-wfcv-2026-06-22/`) found `fast_v_arm_on_rate_alone` whipsaws in choppy corrections (2010/2011). This exposes the arming threshold so a `{0.08, 0.12, 0.16}` surface can suppress the whipsaw — the WF-CV's stated next step.

Tests: default-reproduces-today + a higher threshold reclassifies a moderate drawdown `Fast_v`→`Not_declining`. 8 files, +129/−21. `dune build @fmt && dune build && dune runtest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)