### PR TITLE
docs+fixtures: slow_grind WF-CV on A-D-live basis — NO promote (regime-mixed)

### DIFF
--- a/dev/backtest/slow-grind-adlive-wfcv-2026-06-22/FINDINGS.md
+++ b/dev/backtest/slow-grind-adlive-wfcv-2026-06-22/FINDINGS.md
@@ -1,0 +1,60 @@
+# `slow_grind_gate` WF-CV — A-D-LIVE basis (2026-06-22)
+
+The Build-0 follow-up. The A-D-live deep screen
+(`dev/backtest/build0-ad-breadth-2026-06-22/`) showed `slow_grind_gate` flipping
+from "taxes the edge" to **best-Calmar / best-DD** on the single 2000-2010 window.
+This WF-CV asks whether that holds across rolling OOS folds, now that the
+A-D-lead leg is live (`data/breadth/` populated).
+
+- **Spec:** `test_data/walk_forward/slow-grind-gate-adlive-2000-2026.sexp`.
+- **Base:** `sp500-2000-2026-longshort` (deep long-short). A-D-live `data/`. Axis
+  `enable_slow_grind_short_gate ∈ {true, false}`. Rolling 2000-2026, 26 folds.
+
+## Result — does NOT hold per-fold; the single-window Calmar was a cumulative artifact
+
+| Variant | Sharpe | Calmar | MaxDD % | return mean |
+|---|---|---|---|---|
+| baseline (≡ false) | **0.661** | **1.152** | 10.93 | 10.12% |
+| slow_grind=true | 0.612 | 1.064 | **10.61** | 9.18% |
+
+Across 26 folds, `true` is **lower on Sharpe AND Calmar** and only marginally
+better on raw per-fold MaxDD (10.61 vs 10.93 — the weakest axis). The single-window
+"best Calmar 0.745" was driven by `slow_grind` avoiding one big **multi-year
+cumulative** drawdown over 2000-2010; per-fold (annual) that effect washes out and
+the per-fold return give-up dominates.
+
+## Per-fold — genuinely MIXED (regime-dependent), net slightly negative
+
+`true` differs in 22/26 folds (A-D-live makes the gate active in most declines):
+- **Wins:** 2020 (+5.1pp), 2003 (+6.6), 2014 (+4.9), 2006 (+2.6), 2001 (+2.2).
+- **Losses:** 2002 (−10.6), 2025 (−9.7), 2016 (−9.1), 2009 (−7.6), 2007 (−4.2),
+  2000 (−3.9).
+
+It **helps in some bears** (2020, 2003) and **hurts in others** (2002 & 2009 — the
+dot-com / GFC *bottoms*, where gated shorts admitted late in the decline get
+squeezed on the recovery, and the short-side capital draw hurts the long re-entry).
+Net mean −0.94pp return. This is the same **regime-dependence** every short
+mechanism this session has shown — not a robust edge.
+
+## Verdict: NO promote — A-D improved it but not to promotable
+
+`slow_grind_gate` A-D-live is **much better than A-D-inert** (the hard −108pp
+single-window tax shrank to a mixed near-wash) — the A-D-lead leg genuinely helped
+select better shorts. But it is **still sub-promotable**: per-fold Sharpe/Calmar
+are worse than baseline; the marginal MaxDD reduction does not compensate. Stays a
+default-off axis. (Recorded: `dev/experiments/_ledger/2026-06-22-slow-grind-adlive-wfcv.sexp`.)
+
+## The real Build-0 payoff is BROAD, not the short gate
+
+The headline from Build 0 is **not** a promotable short gate — it is that A-D-live
+**lifts the whole strategy** (long-only +92pp / −4pp DD / Sharpe 0.90→1.04 in the
+deep screen; the WF-CV baseline itself improved). That is the **macro entry gate**
+getting sharper, and it argues for making **A-D-live the default basis**
+(commit synthetic breadth to `test_data/breadth/` + re-pin goldens — attended)
+**independent of** any short-gate promotion. The short gates remain faithful
+default-off tail-tools.
+
+## Caveat
+Same long↔short capital-interaction confound on per-fold return attribution; the
+aggregate Sharpe/Calmar ordering (baseline > true) is clean. A-D-live, static
+sp500-as-of-2000, 26 annual folds.

--- a/dev/backtest/slow-grind-adlive-wfcv-2026-06-22/ranking.md
+++ b/dev/backtest/slow-grind-adlive-wfcv-2026-06-22/ranking.md
@@ -1,0 +1,17 @@
+# Variant ranking
+
+Baseline: baseline
+
+## Pareto frontier (Sharpe up, Calmar up, MaxDD down)
+
+- baseline
+- enable_slow_grind_short_gate=true
+- enable_slow_grind_short_gate=false
+
+## Variants
+
+| Variant | Sharpe | Calmar | MaxDD % | Frontier | Deflated Sharpe |
+|---------|-------:|-------:|--------:|:--------:|----------------:|
+| baseline | 0.661 | 1.152 | 10.93 | yes | 0.9999 |
+| enable_slow_grind_short_gate=true | 0.612 | 1.064 | 10.61 | yes | 0.9999 |
+| enable_slow_grind_short_gate=false | 0.661 | 1.152 | 10.93 | yes | 0.9999 |

--- a/dev/backtest/slow-grind-adlive-wfcv-2026-06-22/walk_forward_report.md
+++ b/dev/backtest/slow-grind-adlive-wfcv-2026-06-22/walk_forward_report.md
@@ -1,0 +1,108 @@
+# Walk-forward CV report
+
+## 1. Per-fold metrics
+
+| Fold | Variant | Return % | CAGR % | Sharpe | MaxDD % | Calmar |
+|------|---------|---------:|-------:|-------:|--------:|-------:|
+| fold-000 | baseline | 55.99 | 56.03 | 1.910 | 9.60 | 5.856 |
+| fold-001 | baseline | -5.60 | -5.60 | -0.560 | 12.44 | -0.452 |
+| fold-002 | baseline | 5.00 | 5.00 | 0.514 | 10.41 | 0.482 |
+| fold-003 | baseline | 15.26 | 15.27 | 1.105 | 7.82 | 1.958 |
+| fold-004 | baseline | 25.23 | 25.25 | 1.750 | 7.45 | 3.401 |
+| fold-005 | baseline | 20.09 | 20.10 | 1.494 | 9.88 | 2.042 |
+| fold-006 | baseline | 8.39 | 8.39 | 0.716 | 10.49 | 0.802 |
+| fold-007 | baseline | 21.33 | 21.35 | 1.170 | 11.87 | 1.804 |
+| fold-008 | baseline | -4.48 | -4.49 | -0.242 | 14.32 | -0.314 |
+| fold-009 | baseline | 12.29 | 12.30 | 0.625 | 17.08 | 0.722 |
+| fold-010 | baseline | 11.75 | 11.76 | 0.749 | 11.72 | 1.006 |
+| fold-011 | baseline | -3.96 | -3.96 | -0.321 | 11.66 | -0.341 |
+| fold-012 | baseline | 10.06 | 10.07 | 0.961 | 7.96 | 1.268 |
+| fold-013 | baseline | 25.02 | 25.04 | 1.538 | 6.69 | 3.755 |
+| fold-014 | baseline | 2.27 | 2.27 | 0.234 | 11.46 | 0.198 |
+| fold-015 | baseline | 0.62 | 0.62 | 0.111 | 10.21 | 0.061 |
+| fold-016 | baseline | 12.89 | 12.90 | 0.891 | 10.04 | 1.289 |
+| fold-017 | baseline | 9.91 | 9.92 | 1.009 | 5.39 | 1.847 |
+| fold-018 | baseline | 9.61 | 9.61 | 0.664 | 8.67 | 1.112 |
+| fold-019 | baseline | 1.94 | 1.94 | 0.214 | 10.26 | 0.190 |
+| fold-020 | baseline | -3.29 | -3.29 | -0.063 | 17.72 | -0.186 |
+| fold-021 | baseline | 4.25 | 4.25 | 0.352 | 13.45 | 0.317 |
+| fold-022 | baseline | -13.35 | -13.36 | -0.719 | 17.62 | -0.760 |
+| fold-023 | baseline | 15.31 | 15.32 | 1.110 | 10.47 | 1.467 |
+| fold-024 | baseline | 4.25 | 4.25 | 0.414 | 7.25 | 0.588 |
+| fold-025 | baseline | 22.37 | 22.38 | 1.566 | 12.13 | 1.850 |
+| fold-000 | enable_slow_grind_short_gate=true | 52.07 | 52.11 | 1.878 | 9.53 | 5.485 |
+| fold-001 | enable_slow_grind_short_gate=true | -3.38 | -3.38 | -0.360 | 11.97 | -0.283 |
+| fold-002 | enable_slow_grind_short_gate=true | -5.59 | -5.59 | -0.837 | 8.57 | -0.655 |
+| fold-003 | enable_slow_grind_short_gate=true | 21.82 | 21.84 | 1.519 | 7.16 | 3.058 |
+| fold-004 | enable_slow_grind_short_gate=true | 27.12 | 27.15 | 1.885 | 6.82 | 3.992 |
+| fold-005 | enable_slow_grind_short_gate=true | 20.16 | 20.18 | 1.594 | 9.06 | 2.233 |
+| fold-006 | enable_slow_grind_short_gate=true | 10.96 | 10.97 | 0.962 | 9.61 | 1.144 |
+| fold-007 | enable_slow_grind_short_gate=true | 17.13 | 17.14 | 0.999 | 12.64 | 1.361 |
+| fold-008 | enable_slow_grind_short_gate=true | -3.96 | -3.96 | -0.432 | 14.37 | -0.277 |
+| fold-009 | enable_slow_grind_short_gate=true | 4.68 | 4.68 | 0.342 | 13.51 | 0.348 |
+| fold-010 | enable_slow_grind_short_gate=true | 12.26 | 12.27 | 0.837 | 12.45 | 0.988 |
+| fold-011 | enable_slow_grind_short_gate=true | -4.23 | -4.23 | -0.502 | 8.88 | -0.478 |
+| fold-012 | enable_slow_grind_short_gate=true | 8.45 | 8.45 | 0.836 | 7.96 | 1.064 |
+| fold-013 | enable_slow_grind_short_gate=true | 23.11 | 23.13 | 1.909 | 8.78 | 2.643 |
+| fold-014 | enable_slow_grind_short_gate=true | 7.15 | 7.15 | 0.623 | 10.99 | 0.653 |
+| fold-015 | enable_slow_grind_short_gate=true | -0.20 | -0.20 | 0.028 | 10.82 | -0.019 |
+| fold-016 | enable_slow_grind_short_gate=true | 3.84 | 3.85 | 0.364 | 11.41 | 0.338 |
+| fold-017 | enable_slow_grind_short_gate=true | 9.91 | 9.92 | 1.009 | 5.39 | 1.847 |
+| fold-018 | enable_slow_grind_short_gate=true | 9.61 | 9.61 | 0.664 | 8.67 | 1.112 |
+| fold-019 | enable_slow_grind_short_gate=true | 1.51 | 1.51 | 0.181 | 11.95 | 0.127 |
+| fold-020 | enable_slow_grind_short_gate=true | 1.79 | 1.79 | 0.187 | 15.55 | 0.115 |
+| fold-021 | enable_slow_grind_short_gate=true | 4.25 | 4.25 | 0.352 | 13.45 | 0.317 |
+| fold-022 | enable_slow_grind_short_gate=true | -12.42 | -12.43 | -0.671 | 17.66 | -0.706 |
+| fold-023 | enable_slow_grind_short_gate=true | 15.63 | 15.64 | 1.131 | 10.47 | 1.498 |
+| fold-024 | enable_slow_grind_short_gate=true | 4.25 | 4.25 | 0.414 | 7.25 | 0.588 |
+| fold-025 | enable_slow_grind_short_gate=true | 12.69 | 12.70 | 1.006 | 10.90 | 1.169 |
+| fold-000 | enable_slow_grind_short_gate=false | 55.99 | 56.03 | 1.910 | 9.60 | 5.856 |
+| fold-001 | enable_slow_grind_short_gate=false | -5.60 | -5.60 | -0.560 | 12.44 | -0.452 |
+| fold-002 | enable_slow_grind_short_gate=false | 5.00 | 5.00 | 0.514 | 10.41 | 0.482 |
+| fold-003 | enable_slow_grind_short_gate=false | 15.26 | 15.27 | 1.105 | 7.82 | 1.958 |
+| fold-004 | enable_slow_grind_short_gate=false | 25.23 | 25.25 | 1.750 | 7.45 | 3.401 |
+| fold-005 | enable_slow_grind_short_gate=false | 20.09 | 20.10 | 1.494 | 9.88 | 2.042 |
+| fold-006 | enable_slow_grind_short_gate=false | 8.39 | 8.39 | 0.716 | 10.49 | 0.802 |
+| fold-007 | enable_slow_grind_short_gate=false | 21.33 | 21.35 | 1.170 | 11.87 | 1.804 |
+| fold-008 | enable_slow_grind_short_gate=false | -4.48 | -4.49 | -0.242 | 14.32 | -0.314 |
+| fold-009 | enable_slow_grind_short_gate=false | 12.29 | 12.30 | 0.625 | 17.08 | 0.722 |
+| fold-010 | enable_slow_grind_short_gate=false | 11.75 | 11.76 | 0.749 | 11.72 | 1.006 |
+| fold-011 | enable_slow_grind_short_gate=false | -3.96 | -3.96 | -0.321 | 11.66 | -0.341 |
+| fold-012 | enable_slow_grind_short_gate=false | 10.06 | 10.07 | 0.961 | 7.96 | 1.268 |
+| fold-013 | enable_slow_grind_short_gate=false | 25.02 | 25.04 | 1.538 | 6.69 | 3.755 |
+| fold-014 | enable_slow_grind_short_gate=false | 2.27 | 2.27 | 0.234 | 11.46 | 0.198 |
+| fold-015 | enable_slow_grind_short_gate=false | 0.62 | 0.62 | 0.111 | 10.21 | 0.061 |
+| fold-016 | enable_slow_grind_short_gate=false | 12.89 | 12.90 | 0.891 | 10.04 | 1.289 |
+| fold-017 | enable_slow_grind_short_gate=false | 9.91 | 9.92 | 1.009 | 5.39 | 1.847 |
+| fold-018 | enable_slow_grind_short_gate=false | 9.61 | 9.61 | 0.664 | 8.67 | 1.112 |
+| fold-019 | enable_slow_grind_short_gate=false | 1.94 | 1.94 | 0.214 | 10.26 | 0.190 |
+| fold-020 | enable_slow_grind_short_gate=false | -3.29 | -3.29 | -0.063 | 17.72 | -0.186 |
+| fold-021 | enable_slow_grind_short_gate=false | 4.25 | 4.25 | 0.352 | 13.45 | 0.317 |
+| fold-022 | enable_slow_grind_short_gate=false | -13.35 | -13.36 | -0.719 | 17.62 | -0.760 |
+| fold-023 | enable_slow_grind_short_gate=false | 15.31 | 15.32 | 1.110 | 10.47 | 1.467 |
+| fold-024 | enable_slow_grind_short_gate=false | 4.25 | 4.25 | 0.414 | 7.25 | 0.588 |
+| fold-025 | enable_slow_grind_short_gate=false | 22.37 | 22.38 | 1.566 | 12.13 | 1.850 |
+
+## 2. Stability (mean ± stdev across folds)
+
+| Variant | Return % (μ ± σ) | CAGR % (μ ± σ) | Sharpe (μ ± σ) | MaxDD % (μ ± σ) | Calmar (μ ± σ) |
+|---------|-----------------:|---------------:|---------------:|----------------:|--------------:|
+| baseline | 10.12 ± 13.72 | 10.13 ± 13.73 | 0.661 ± 0.708 | 10.93 ± 3.20 | 1.152 ± 1.472 |
+| enable_slow_grind_short_gate=true | 9.18 ± 13.06 | 9.18 ± 13.07 | 0.612 ± 0.791 | 10.61 ± 2.88 | 1.064 ± 1.468 |
+| enable_slow_grind_short_gate=false | 10.12 ± 13.72 | 10.13 ± 13.73 | 0.661 ± 0.708 | 10.93 ± 3.20 | 1.152 ± 1.472 |
+
+## 3. Cross-fold sensitivity
+
+Variant wins per fold on each metric (vs baseline `baseline`, 26 folds total; gate metric marked **\***):
+
+| Variant | Sharpe wins | Calmar wins* | Return wins | MaxDD wins | of |
+|---------|----------:|----------:|----------:|----------:|---:|
+| enable_slow_grind_short_gate=true | 11 | 10 | 11 | 12 | 26 |
+| enable_slow_grind_short_gate=false | 0 | 0 | 0 | 0 | 26 |
+
+## 4. Go/no-go verdict
+
+Gate: variant wins ≥14 of 26 folds on **Calmar** vs baseline `baseline`, no fold worse by Δ>0.0000.
+
+- **enable_slow_grind_short_gate=true**: FAIL (10 / 26 wins; worst fold `fold-002` gap 1.1364). Reason: M-threshold miss: 10 wins < 14 required; worst fold fold-002 trails by 1.1364 > Δ=0.0000
+- **enable_slow_grind_short_gate=false**: FAIL (0 / 26 wins; worst fold `fold-000` gap 0.0000). Reason: M-threshold miss: 0 wins < 14 required

--- a/dev/experiments/_ledger/2026-06-22-slow-grind-adlive-wfcv.sexp
+++ b/dev/experiments/_ledger/2026-06-22-slow-grind-adlive-wfcv.sexp
@@ -1,0 +1,15 @@
+((date 2026-06-22)
+ (slug slow-grind-adlive-wfcv)
+ (hypothesis
+  "enable_slow_grind_short_gate=true holds the A-D-live deep-screen best-Calmar/best-DD result across rolling OOS folds (now that Build 0 made the decline-character A-D-lead leg live)")
+ (base_scenario "goldens-sp500-historical/sp500-2000-2026-longshort.sexp")
+ (window_id wfcv-adlive-deep-2000-2026-26fold)
+ (baseline_label baseline)
+ (variants
+  (((label enable_slow_grind_short_gate=true)
+    (config_hash slowgrind-true-adlive-deep-2000-2026)
+    (aggregate ((sharpe_mean 0.612) (calmar_mean 1.064) (maxdd_mean 10.61) (return_mean 9.18) (pareto_frontier yes) (deflated_sharpe 0.9999))))))
+ (verdict Reject)
+ (notes
+  "NO promote (A-D-live basis). See dev/backtest/slow-grind-adlive-wfcv-2026-06-22/. Across 26 folds true is LOWER on Sharpe (0.612 vs 0.661) AND Calmar (1.064 vs 1.152), only marginally better on raw per-fold MaxDD (10.61 vs 10.93). The single-window deep-screen best-Calmar (0.745) was a CUMULATIVE multi-year-drawdown artifact that washes out per-fold. Per-fold genuinely MIXED (22/26 differ): wins 2020 +5.1/2003 +6.6/2014 +4.9, losses 2002 -10.6/2025 -9.7/2016 -9.1/2009 -7.6 (gated shorts admitted late in a decline get squeezed at the 2002/2009 BOTTOMS). Net -0.94pp return = regime-dependent, same pattern as every short mechanism this session. A-D-live MUCH improved it vs A-D-inert (-108pp tax -> near-wash) but not to promotable. Stays default-off axis. THE REAL Build-0 payoff is BROAD: A-D-live lifts the whole strategy (long-only +92pp, macro entry gate sharper) -> argues for A-D-live as DEFAULT BASIS independent of any short gate. Third time WF-CV corrected a single-window screen (cf arming-speed, neutral-grid).")
+ )

--- a/trading/test_data/walk_forward/slow-grind-gate-adlive-2000-2026.sexp
+++ b/trading/test_data/walk_forward/slow-grind-gate-adlive-2000-2026.sexp
@@ -1,0 +1,13 @@
+;; enable_slow_grind_short_gate WF-CV — A-D-LIVE basis (Build 0).
+;; data/ now has generated synthetic+unicorn breadth (build0-ad-breadth-2026-06-22),
+;; so the decline-character A-D-lead leg is live. The A-D-inert deep screen had
+;; slow_grind TAXING the edge; with A-D live it flipped to best-Calmar / best-DD on
+;; higher-quality shorts (6 net +$432K vs ungated 25 net +$203K). This WF-CV asks:
+;; does that best-Calmar result hold across rolling OOS folds? Deep long-short base.
+;; Rolling 2000-2026 test 365 step 365 => 26 folds.
+((base_scenario "test_data/backtest_scenarios/goldens-sp500-historical/sp500-2000-2026-longshort.sexp")
+ (window_spec
+  (Rolling ((start_date 2000-01-01) (end_date 2026-04-30) (train_days 0) (test_days 365) (step_days 365))))
+ (baseline_label baseline)
+ (gate ((metric Calmar) (m 14) (n 26) (worst_delta 0.0)))
+ (axes ((axes (((flag enable_slow_grind_short_gate) (values (true false))))) (expansion Cartesian))))


### PR DESCRIPTION
Build-0 follow-up. `enable_slow_grind_short_gate` WF-CV on the deep long-short base, **A-D-live**.

| Variant | Sharpe | Calmar | MaxDD% |
|---|---|---|---|
| baseline | **0.661** | **1.152** | 10.93 |
| slow_grind=true | 0.612 | 1.064 | **10.61** |

Across 26 folds `true` is **lower on Sharpe AND Calmar**, only marginally lower per-fold MaxDD. The single-window deep-screen "best-Calmar 0.745" was a **cumulative** multi-year-drawdown artifact that washes out per-fold. Per-fold genuinely mixed (wins 2020 +5.1/2003 +6.6; losses 2002 −10.6/2009 −7.6 at the bottoms). **A-D-live MUCH improved it** vs A-D-inert (−108pp tax → near-wash) **but not to promotable** — stays default-off.

**The real Build-0 payoff is BROAD** (whole-strategy lift; long-only +92pp), not the short gate → A-D should be the default basis independent of any short promotion. Third time WF-CV corrected a single-window screen this session. Ledger added. Docs+fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)