### PR TITLE
docs+fixtures: A-D-default flip teed up for next session (+ perf fix first)

### DIFF
--- a/dev/backtest/ad-default-fullwindow-2026-06-22/FINDINGS.md
+++ b/dev/backtest/ad-default-fullwindow-2026-06-22/FINDINGS.md
@@ -1,0 +1,96 @@
+# A-D-default flip — full-window 1999-2026 evidence (2026-06-22)
+
+Decides whether to make **A-D-live the default basis** (Build 0). The 2000-2010
+deep-screen showed A-D-live lifting long-only +92pp — but that was a bear-heavy
+window. This is the full 1999-2026 (~27y) A-D-live vs A-D-inert comparison, both
+long-only and long-short, to see the real-regime tradeoff before the
+behavior-changing golden re-pin.
+
+- Same config; only `skip_ad_breadth` toggles (false = A-D live via generated
+  `data/breadth/`, true = inert/degraded). sp500-as-of-2000 PIT, CSV mode.
+- Scenarios: `experiments/adlive-{longonly,longshort}-fullwindow-2026-06-22/`.
+
+## The 2×2
+
+| config | A-D | Return | MaxDD | Sharpe | Calmar | Sortino | Ulcer |
+|---|---|---|---|---|---|---|---|
+| long-only | inert | **1787.6%** | 32.5% | 0.785 | 0.349 | 1.274 | 11.46 |
+| long-only | live | 1575.8% | 28.9% | 0.791 | 0.376 | 1.299 | 10.43 |
+| long-short | inert | **3408.6%** | 27.3% | 0.884 | 0.509 | 1.481 | 9.71 |
+| long-short | live | 3077.4% | **25.6%** | **0.933** | **0.528** | **1.583** | **8.80** |
+
+## Read
+
+1. **A-D-live consistently trades ~10% raw return for better risk** — lower return
+   (it makes the macro gate more conservative → fewer trades, less bull upside)
+   but lower MaxDD, better Sortino/Ulcer, higher win rate, in both configs.
+2. **The +92pp "broad lift" was a 2000-2010 bear-window artifact.** Over the full
+   27y, A-D-live *reduces* raw return (−212pp long-only, −331pp long-short).
+3. **With shorts (the real strategy) the risk-adjusted edge is MEANINGFUL, not
+   marginal.** Long-only A-D-live: Sharpe basically tied (+0.006). Long-short
+   A-D-live: **Sharpe +0.049, Sortino +0.102, Calmar +0.019, MaxDD −1.7pp, Ulcer
+   better** — every risk metric clearly better. A-D's breadth reads make the
+   **shorts land better** (the A-D-lead identifies genuine distribution → better
+   short timing).
+
+## Recommendation: FLIP (make A-D-live the default)
+
+In the *actual* long-short config A-D-live is **clearly better risk-adjusted on
+every metric** at a ~10% raw-return cost, and it is the **doctrinally faithful**
+default (the A-D line is Weinstein's primary breadth gauge; running without it is
+unfaithful). For a risk-managed Weinstein strategy this is the correct default —
+the raw-return give-up is the price of the more conservative, better-risk-adjusted,
+faithful gate. **Decision: flip** (user-confirmed direction; execute next session).
+
+## ⚡ Do FIRST: optimize the A-D macro perf (the 3-5× slowdown is O(n²))
+
+A-D-live runs are 3-5× slower because the macro **recomputes the cumulative A-D
+array from the full breadth history on every weekly tick** instead of caching it:
+- `macro.ml:_build_cumulative_ad_array` `List.fold`s the entire `ad_bars` list
+  (O(n)); `_compute_momentum_ma_scalar` likewise folds the full list.
+- `Macro.analyze` → `callbacks_from_bars ~ad_bars` rebuilds those each call, and the
+  strategy calls macro analysis **every weekly tick** → O(n²) over the run
+  (~1400 weekly ticks × ~1400-bar rebuild for a 27y window).
+- The **MA path is already cached** (`ma_cache` threaded via
+  `Panel_callbacks.macro_callbacks_of_weekly_views ?ma_cache`); the **A-D path is
+  not** — that asymmetry is the 3-5× cost.
+
+**Fix (do BEFORE the re-pin):** precompute the cumulative-A-D prefix-sum (and the
+momentum-MA scalar series) ONCE and index by date — an `ad_cache` mirroring the
+existing `ma_cache`, or hoist `_build_cumulative_ad_array` out of the per-tick
+path. The cumulative A-D is a monotonic prefix sum, trivially incremental. This is
+a pure perf change (no behavior change → no golden re-pin) and it makes every
+A-D-live backtest — including the golden re-pin runs below — cheap. Verify
+bit-identical output before/after. **This is the first next-session task; it
+de-risks and speeds the whole flip.**
+
+## Execution plan (next session) + ETA ~2-4h (much less once A-D perf is fixed)
+
+**Gating unknown first (~20 min):** determine which data dir the committed goldens
+read in CI — `data/` (no breadth → A-D-inert today) vs `test_data/` (Unicorn
+breadth present 1965-2020, no synthetic tail → maybe already partly A-D-live). This
+sets the blast radius (re-pin ~4 vs ~30 goldens). Check `default_data_dir`
+(`/workspaces/trading-1/data`), the CI data setup, and whether goldens currently
+load Unicorn breadth.
+
+Then:
+1. Generate synthetic ADL into **committed** `test_data/breadth/`
+   (`compute_synthetic_adl.exe -data-dir <test_data>`); commit `synthetic_advn/
+   decln.csv` (~100KB each). test_data/breadth currently has only Unicorn nyse_*.
+2. **Re-pin affected goldens** — the dominant cost. ~30 committed golden scenarios
+   across `goldens-sp500-historical` (~4 core; 3 of the 7 there are this session's
+   research bases, not pins), `goldens-broad` (7), `goldens-small` (3),
+   `goldens-sp500` (4), `panel_goldens` (2), etc. Each: re-run → read new metrics →
+   update expected bands. **A-D-live is 3-5× slower** — the 27y long-short goldens
+   are ~15 min *each* live.
+3. Verify the full golden suite passes with new pins (docker, in-container).
+4. Behavior-change PR → full CI + QC (changes backtest behavior).
+
+ETA: ~2h if only a handful shift; ~4h if the whole suite does. Biggest variables:
+the data-path blast radius + A-D-live slowness on the long-window goldens.
+
+## Caveats
+- sp500-as-of-2000 static universe (survivorship-stale late); the A-D-live-vs-inert
+  *comparison* is internally valid (same universe both arms). Synthetic breadth
+  0.92-0.93 corr vs official NYSE. Single universe — the flip should also spot-check
+  a different universe golden during the re-pin.

--- a/dev/notes/next-session-priorities-2026-06-23.md
+++ b/dev/notes/next-session-priorities-2026-06-23.md
@@ -1,0 +1,79 @@
+# Next-session priorities — 2026-06-23 (handoff)
+
+**Supersedes** `next-session-priorities-2026-06-22-EOD.md`. Continues the
+decline-character / Build-0 work. Main green; this session merged **14 PRs**
+(#1707-1720) + the Build-0 A-D work. The headline carry-forward is the
+**A-D-default flip**, decided but deliberately left to execute next session, with
+a **perf fix to do first**.
+
+## P0 — the A-D-default flip (decided; execute this session, in two steps)
+
+Build 0 made A-D breadth live (synthetic ADL 1998-2026 into gitignored
+`data/breadth/`, 0.92-0.93 corr vs official NYSE). Full-window 1999-2026 evidence
+(`dev/backtest/ad-default-fullwindow-2026-06-22/FINDINGS.md`) shows A-D-live is
+**clearly better risk-adjusted in the real long-short config** (Sharpe
+0.884→0.933, Sortino 1.481→1.583, Calmar 0.509→0.528, MaxDD 27.3→25.6%) at a ~10%
+raw-return cost — and it is the **doctrinally faithful** default. **User confirmed
+the direction: flip it.** (Note: the 2000-2010 "+92pp long-only lift" was a
+bear-window artifact; full-window it's a return-for-risk trade, meaningful only
+*with shorts*.)
+
+### P0a (do FIRST) — fix the A-D macro O(n²) perf
+A-D-live is 3-5× slower because the macro **rebuilds the cumulative-A-D array from
+the full breadth history every weekly tick** (`macro.ml:_build_cumulative_ad_array`
++ `_compute_momentum_ma_scalar` fold the whole `ad_bars` list; `callbacks_from_bars`
+rebuilds per call; the MA path is cached via `ma_cache` but the A-D path is not).
+**Fix:** precompute the cumulative-A-D prefix-sum + momentum-MA series ONCE
+(an `ad_cache` mirroring `ma_cache`, or hoist the build out of the per-tick path).
+Pure perf change → **bit-identical output, no golden re-pin** → verify with a
+before/after diff. This makes every A-D-live run (incl. the P0b re-pin runs) cheap,
+so it de-risks the whole flip. Proper TDD + a perf-tier check.
+
+### P0b — make A-D-live the default basis + re-pin goldens (ETA ~2-4h, less after P0a)
+1. **Resolve the gating unknown (~20 min):** which data dir do committed goldens
+   read in CI — `data/` (A-D-inert today) or `test_data/` (Unicorn breadth present
+   1965-2020, no synthetic tail → maybe already partly A-D-live)? Sets blast radius
+   (~4 vs ~30 goldens). `default_data_dir` = `/workspaces/trading-1/data`.
+2. Generate synthetic ADL into **committed** `test_data/breadth/` + commit
+   `synthetic_advn/decln.csv` (test_data/breadth has only Unicorn nyse_* today).
+3. **Re-pin affected goldens** (the dominant cost): ~30 golden scenarios across
+   `goldens-sp500-historical` (~4 core), `goldens-broad` (7), `goldens-small` (3),
+   `goldens-sp500` (4), `panel_goldens` (2), etc. Re-run → update expected bands.
+4. Verify full golden suite in-container; behavior-change PR → full CI + QC.
+
+Evidence scenarios committed: `experiments/adlive-{longonly,longshort}-fullwindow-2026-06-22/`.
+
+## P1 — decline-character mechanisms: re-run A-D-inert WF-CVs on the A-D-live basis
+Every WF-CV this session was A-D-inert (the old degraded basis). With A-D live:
+- `slow_grind_gate`: A-D-live WF-CV already done (#1720) → still **NO promote**
+  (regime-mixed; single-window best-Calmar was a cumulative artifact). Stays axis.
+- `neutral_blocks_shorts`: re-run cell-1/grid A-D-live (likely holds — still inert,
+  all shorts Bearish-tape even live). The **faithfulness/asymmetry default-on flip**
+  (user's "sideline-in-Neutral is OK") is still on the table — decide post-A-D.
+- `fast_v_arm_on_rate_alone` (#1708) + `fast_v_min_rate_pct` (#1716): re-run the
+  arming WF-CV + threshold surface A-D-live — the A-D-lead may finally separate the
+  2020 catch from the 2010/2011 whipsaw (the rate signal alone couldn't;
+  `fast-v-min-rate-surface` proved it). This is the arming-speed unlock.
+
+## P2 — barbell weight cert (unchanged) — needs your weight mandate.
+
+## Session ledger (this session, on main)
+4 ledger entries (`2026-06-22-{neutral-blocks-shorts-wfcv,neutral-blocks-shorts-grid,
+arming-speed-wfcv,fast-v-min-rate-surface,slow-grind-adlive-wfcv}`). Meta-pattern:
+the short/crash gates are **faithful tail-tools with regime-specific niches, not
+robust standalone alpha**; WF-CV corrected the single-window screen **three times**
+(arming-speed, neutral-grid, slow-grind). The durable wins are the **deep-data
+infra (1998-2026)** + **A-D breadth as a real risk-adjusted lever**.
+
+## Local data state (IMPORTANT)
+- Runner reads gitignored repo-root `data/` (`default_data_dir`; `TRADING_DATA_DIR`
+  override). This session fetched the union sp500-2000/2010/2015/2020 PIT universes
+  + ETFs + ^GSPC, **1998-2026 (731 names)**, AND generated synthetic+unicorn breadth
+  into `data/breadth/`. Both gitignored — a fresh checkout / cleaned `data/` must
+  re-fetch + re-generate breadth (`compute_synthetic_adl.exe -data-dir data`).
+
+## State
+Main green. 0 feature PRs open. Code on main: #1708 (`fast_v_arm_on_rate_alone`) +
+#1716 (`fast_v_min_rate_pct`) — both default-off no-op axes. No behavior change
+landed; the A-D-default flip (P0) is the first behavior change, queued for next
+session.

--- a/trading/test_data/backtest_scenarios/experiments/adlive-longonly-fullwindow-2026-06-22/longonly-adinert.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/adlive-longonly-fullwindow-2026-06-22/longonly-adinert.sexp
@@ -1,0 +1,23 @@
+;; longonly A-D-inert full window 1999-2026 (sp500-2000 PIT). skip_ad_breadth=true,
+;; enable_short_side=false. Build-0 A-D-default-flip evidence (see
+;; dev/backtest/ad-default-fullwindow-2026-06-22/FINDINGS.md). Reads data/ breadth.
+((name "longonly-adinert")
+ (description "longonly A-D-inert (skip_ad_breadth=true enable_short_side=false), sp500-2000 PIT, 1999-2026.")
+ (period ((start_date 1999-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((skip_ad_breadth true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected ((total_return_pct ((min -90.0) (max 90000.0))) (total_trades ((min 1) (max 99000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/adlive-longonly-fullwindow-2026-06-22/longonly-adlive.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/adlive-longonly-fullwindow-2026-06-22/longonly-adlive.sexp
@@ -1,0 +1,23 @@
+;; longonly A-D-live full window 1999-2026 (sp500-2000 PIT). skip_ad_breadth=false,
+;; enable_short_side=false. Build-0 A-D-default-flip evidence (see
+;; dev/backtest/ad-default-fullwindow-2026-06-22/FINDINGS.md). Reads data/ breadth.
+((name "longonly-adlive")
+ (description "longonly A-D-live (skip_ad_breadth=false enable_short_side=false), sp500-2000 PIT, 1999-2026.")
+ (period ((start_date 1999-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((skip_ad_breadth false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected ((total_return_pct ((min -90.0) (max 90000.0))) (total_trades ((min 1) (max 99000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/adlive-longshort-fullwindow-2026-06-22/longshort-adinert.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/adlive-longshort-fullwindow-2026-06-22/longshort-adinert.sexp
@@ -1,0 +1,23 @@
+;; longshort A-D-inert full window 1999-2026 (sp500-2000 PIT). skip_ad_breadth=true,
+;; enable_short_side=true. Build-0 A-D-default-flip evidence (see
+;; dev/backtest/ad-default-fullwindow-2026-06-22/FINDINGS.md). Reads data/ breadth.
+((name "longshort-adinert")
+ (description "longshort A-D-inert (skip_ad_breadth=true enable_short_side=true), sp500-2000 PIT, 1999-2026.")
+ (period ((start_date 1999-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side true))
+   ((skip_ad_breadth true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected ((total_return_pct ((min -90.0) (max 90000.0))) (total_trades ((min 1) (max 99000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/adlive-longshort-fullwindow-2026-06-22/longshort-adlive.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/adlive-longshort-fullwindow-2026-06-22/longshort-adlive.sexp
@@ -1,0 +1,23 @@
+;; longshort A-D-live full window 1999-2026 (sp500-2000 PIT). skip_ad_breadth=false,
+;; enable_short_side=true. Build-0 A-D-default-flip evidence (see
+;; dev/backtest/ad-default-fullwindow-2026-06-22/FINDINGS.md). Reads data/ breadth.
+((name "longshort-adlive")
+ (description "longshort A-D-live (skip_ad_breadth=false enable_short_side=true), sp500-2000 PIT, 1999-2026.")
+ (period ((start_date 1999-01-01) (end_date 2026-04-30)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side true))
+   ((skip_ad_breadth false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected ((total_return_pct ((min -90.0) (max 90000.0))) (total_trades ((min 1) (max 99000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))


### PR DESCRIPTION
Full-window 1999-2026 A-D-live vs inert evidence (2×2 long-only + long-short) + next-session P0.

**A-D-live in the real long-short config:** Sharpe 0.884→0.933, Sortino 1.481→1.583, Calmar 0.509→0.528, MaxDD 27.3→25.6% — clearly better risk-adjusted at a ~10% raw-return cost, and doctrinally faithful → **decision: flip** (next session). The +92pp long-only lift was a 2000-2010 bear-window artifact.

**P0a (do first): fix the A-D macro O(n²) perf.** A-D-live is 3-5× slower because the cumulative-A-D array is rebuilt from the full history every weekly tick (MA path cached, A-D path not). Precompute/cache it (bit-identical, no re-pin) → makes the golden re-pin cheap.
**P0b:** generate committed breadth + re-pin goldens.

Docs + 4 evidence scenarios. Breadth CSVs stay gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)