### PR TITLE
perf(macro): precompute A-D cumulative+momentum cache (kill O(n²) A-D-live macro path)

### DIFF
--- a/dev/status/backtest-perf.md
+++ b/dev/status/backtest-perf.md
@@ -663,6 +663,24 @@ mechanics + release-gate procedure.
 
 ## Completed
 
+- [x] **P0a — kill O(n²) A-D-live macro path** (2026-06-22). PR #1722
+  (`feat/ad-macro-perf`). PURE PERF, bit-identical (no golden re-pin). When A-D
+  breadth is LIVE the per-tick macro step was O(n) (`ad_bars_at_or_before`
+  `List.filter` + `_build_cumulative_ad_array`/`_compute_momentum_ma_scalar`
+  refold every Friday) → O(n²) over the run, 3-5× slower than A-D-inert. Fix:
+  new `Ad_series_cache` (`trading/trading/weinstein/strategy/lib/ad_series_cache.{ml,mli}`)
+  precomputes the cumulative-A-D int/float arrays + momentum_period ONCE from the
+  fixed `weekly_ad_bars`; per tick it binary-searches the `as_of` cutoff (O(log n))
+  and slices the prefix. New `Panel_callbacks.macro_callbacks_of_weekly_views_cached`
+  twin reads the cached closures; `run_macro_only` migrates from `~ad_bars` to
+  `~ad_series` threaded through `_on_market_close`. Bit-identical: same
+  int-then-float boundary; momentum MA via telescoped `cum_int.(k-1) -
+  cum_int.(k-1-period)` (A-D nets « 2^53, no rounding); empty bars → k=0 → all-`None`,
+  so A-D-inert goldens untouched. Verify: `dune runtest weinstein/strategy/test/`
+  (parity test `test_ad_series_cache` = 3 tests pin NEW cache == OLD path across
+  cutoffs/periods/offsets + empty input + prefix-length). The bar-list
+  `macro_callbacks_of_weekly_views` / `_of_snapshot_views` path is preserved.
+
 - **15y memory-cliff resolution + perf hotspot fixes** (2026-05-08..13). Combined
   data-side + simulator-side + orders-side work brought 15y SP500 wall from ~5 h
   to ~13.6 min (~22×) and peak RSS from 11.4 GB to ~766 MB. MERGED:

--- a/trading/trading/weinstein/strategy/lib/ad_series_cache.ml
+++ b/trading/trading/weinstein/strategy/lib/ad_series_cache.ml
@@ -1,0 +1,63 @@
+open Core
+
+type t = {
+  dates : Date.t array;
+  cum_int : int array;
+  cum_float : float array;
+  momentum_period : int;
+}
+
+let of_weekly_ad_bars ~momentum_period (ad_bars : Macro.ad_bar list) : t =
+  let n = List.length ad_bars in
+  let dates = Array.create ~len:n Date.unix_epoch in
+  let cum_int = Array.create ~len:n 0 in
+  let running = ref 0 in
+  List.iteri ad_bars ~f:(fun j (bar : Macro.ad_bar) ->
+      running := !running + bar.advancing - bar.declining;
+      dates.(j) <- bar.date;
+      cum_int.(j) <- !running);
+  let cum_float = Array.map cum_int ~f:Float.of_int in
+  { dates; cum_int; cum_float; momentum_period }
+
+let length t = Array.length t.dates
+
+(* Count of bars with [date <= as_of]. [dates] is ascending, so this is an
+   upper-bound search — the exact prefix length
+   {!Macro_inputs.ad_bars_at_or_before} produces. Binary search keeps the
+   per-tick cost O(log n) instead of the O(n) list filter it replaces. *)
+let _count_at_or_before t ~as_of =
+  let lo = ref 0 and hi = ref (Array.length t.dates) in
+  while !lo < !hi do
+    let mid = !lo + ((!hi - !lo) / 2) in
+    if Date.( <= ) t.dates.(mid) as_of then lo := mid + 1 else hi := mid
+  done;
+  !lo
+
+(* [get_cumulative_ad] over the prefix [0, k). [week_offset:0] = newest in the
+   prefix (index [k-1]); reproduces the [_get_from_float_array] indexing of the
+   old [_build_cumulative_ad_array]-over-the-filtered-prefix path. *)
+let _get_cumulative_ad t ~k ~week_offset =
+  let idx = k - 1 - week_offset in
+  if idx >= 0 && idx < k then Some t.cum_float.(idx) else None
+
+(* [get_ad_momentum_ma] over the prefix [0, k). Only [week_offset:0] is
+   consumed; the int sum of the last [min momentum_period k] A-D nets is the
+   telescoped difference of cumulatives, divided by float [period] — the exact
+   int-then-float boundary of the old [_compute_momentum_ma_scalar]. *)
+let _get_ad_momentum_ma t ~k ~week_offset =
+  if week_offset <> 0 then None
+  else if k = 0 then None
+  else
+    let period = min t.momentum_period k in
+    let lo = k - 1 - period in
+    let sum = t.cum_int.(k - 1) - if lo >= 0 then t.cum_int.(lo) else 0 in
+    Some (Float.of_int sum /. Float.of_int period)
+
+let callbacks_at t ~as_of =
+  let k = _count_at_or_before t ~as_of in
+  ( _get_cumulative_ad t ~k,
+    fun ~week_offset -> _get_ad_momentum_ma t ~k ~week_offset )
+
+module Internal_for_test = struct
+  let count_at_or_before = _count_at_or_before
+end

--- a/trading/trading/weinstein/strategy/lib/ad_series_cache.mli
+++ b/trading/trading/weinstein/strategy/lib/ad_series_cache.mli
@@ -1,0 +1,54 @@
+(** Precomputed A-D (advance/decline) breadth series for the strategy's per-tick
+    macro path.
+
+    The weekly A-D bar list threaded through the strategy is FIXED across the
+    whole run (built once in {!Weinstein_strategy.make} from the daily A-D
+    bars). The old per-tick macro path rebuilt the cumulative-A-D array and the
+    momentum-MA scalar from scratch on every Friday tick — O(t) work over T
+    ticks = O(n²). This cache precomputes the cumulative series ONCE and answers
+    each tick's A-D queries in O(log n) (a binary search for the [as_of] cutoff
+    plus O(1) array reads).
+
+    The cache reproduces the OLD path bit-identically: the cumulative running
+    sum is an [int] accumulator converted to [float] at the array boundary, and
+    the momentum MA is an [int] sum of the last [min momentum_period k] A-D nets
+    divided by a [float] period. A-D nets are small ints far below 2^53, so the
+    telescoped int subtraction used here equals the old per-prefix int sum
+    exactly. See {!Panel_callbacks._build_cumulative_ad_array} /
+    {!Panel_callbacks._compute_momentum_ma_scalar} for the originals and
+    [Test_ad_series_cache] for the parity proof. *)
+
+type t
+
+val of_weekly_ad_bars : momentum_period:int -> Macro.ad_bar list -> t
+(** [of_weekly_ad_bars ~momentum_period ad_bars] precomputes the cumulative
+    series from [ad_bars] (must be ascending by [date], as
+    {!Ad_bars_aggregation.daily_to_weekly} produces). [momentum_period] is the
+    momentum-MA window
+    ([config.macro_config.indicator_thresholds.momentum_period]). An empty
+    [ad_bars] yields an empty cache whose [callbacks_at] closures always return
+    [None] — identical to the A-D-inert (empty-bars) behaviour. *)
+
+val length : t -> int
+(** Number of A-D bars held in the cache. *)
+
+val callbacks_at :
+  t ->
+  as_of:Core.Date.t ->
+  (week_offset:int -> float option) * (week_offset:int -> float option)
+(** [callbacks_at t ~as_of] returns the
+    [(get_cumulative_ad, get_ad_momentum_ma)] pair the macro callback bundle
+    needs, computed over the prefix of bars with [date <= as_of].
+
+    - [get_cumulative_ad ~week_offset]: cumulative A-D line value [week_offset]
+      weeks back from the newest in-prefix bar (offset 0 = newest); [None] when
+      the offset falls outside the prefix.
+    - [get_ad_momentum_ma ~week_offset]: A-D momentum MA; only [week_offset:0]
+      is meaningful (returns [None] otherwise, and [None] for an empty prefix).
+*)
+
+module Internal_for_test : sig
+  val count_at_or_before : t -> as_of:Core.Date.t -> int
+  (** Prefix length: count of bars with [date <= as_of]. Exposed for the parity
+      test that pins it against {!Macro_inputs.ad_bars_at_or_before}. *)
+end

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.ml
@@ -334,6 +334,32 @@ let macro_callbacks_of_weekly_views ?ma_cache ?index_symbol
       List.map globals ~f:(_named_global_stage ?ma_cache config);
   }
 
+(** Cache-backed twin of {!macro_callbacks_of_weekly_views}. Instead of
+    rebuilding the cumulative-A-D array and momentum-MA scalar from an [ad_bars]
+    list on every call (the O(n²) hot-loop cost), it reads the
+    [get_cumulative_ad] / [get_ad_momentum_ma] closures from a precomputed
+    {!Ad_series_cache.t} sliced to [as_of]. Output is bit-identical to
+    {!macro_callbacks_of_weekly_views} on the same underlying A-D series (parity
+    test: [Test_ad_series_cache]). Only the two A-D closures change; the index
+    stage / close / global-stage construction is identical. *)
+let macro_callbacks_of_weekly_views_cached ?ma_cache ?index_symbol
+    ~(config : Macro.config) ~(index : Snapshot_bar_views.weekly_view)
+    ~(globals : (string * Snapshot_bar_views.weekly_view) list)
+    ~(ad_series : Ad_series_cache.t) ~as_of () : Macro.callbacks =
+  let get_cumulative_ad, get_ad_momentum_ma =
+    Ad_series_cache.callbacks_at ad_series ~as_of
+  in
+  {
+    index_stage =
+      stage_callbacks_of_weekly_view ?ma_cache ?symbol:index_symbol
+        ~config:config.stage_config ~weekly:index ();
+    get_index_close = _get_from_float_array index.closes;
+    get_cumulative_ad;
+    get_ad_momentum_ma;
+    global_index_stages =
+      List.map globals ~f:(_named_global_stage ?ma_cache config);
+  }
+
 (* ------------------------------------------------------------------ *)
 (* Support floor — daily view with day_offset:0 = NEWEST                *)
 (* ------------------------------------------------------------------ *)

--- a/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
+++ b/trading/trading/weinstein/strategy/lib/panel_callbacks.mli
@@ -120,6 +120,25 @@ val macro_callbacks_of_weekly_views :
       0 only.
     - [global_index_stages] = each (name, view) -> Stage.callbacks. *)
 
+val macro_callbacks_of_weekly_views_cached :
+  ?ma_cache:Weekly_ma_cache.t ->
+  ?index_symbol:string ->
+  config:Macro.config ->
+  index:Snapshot_runtime.Snapshot_bar_views.weekly_view ->
+  globals:(string * Snapshot_runtime.Snapshot_bar_views.weekly_view) list ->
+  ad_series:Ad_series_cache.t ->
+  as_of:Core.Date.t ->
+  unit ->
+  Macro.callbacks
+(** [macro_callbacks_of_weekly_views_cached ~ad_series ~as_of …] is the hot-path
+    twin of {!macro_callbacks_of_weekly_views}. It produces a bit-identical
+    {!Macro.callbacks} bundle but sources [get_cumulative_ad] /
+    [get_ad_momentum_ma] from a precomputed {!Ad_series_cache.t} sliced to
+    [as_of], avoiding the per-tick rebuild of the cumulative-A-D array and
+    momentum-MA scalar (the O(n²) A-D-live macro cost). The [index_stage],
+    [get_index_close] and [global_index_stages] are constructed identically to
+    {!macro_callbacks_of_weekly_views}. *)
+
 val support_floor_callbacks_of_daily_view :
   Snapshot_runtime.Snapshot_bar_views.daily_view -> Weinstein_stops.callbacks
 (** [support_floor_callbacks_of_daily_view view] builds a

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -20,6 +20,7 @@ module Laggard_rotation_runner = Laggard_rotation_runner
 module Stage3_force_exit = Stage3_force_exit
 module Laggard_rotation = Laggard_rotation
 module Ad_bars = Ad_bars
+module Ad_series_cache = Ad_series_cache
 module Macro_inputs = Macro_inputs
 module Panel_callbacks = Panel_callbacks
 module Weekly_ma_cache = Weekly_ma_cache
@@ -252,13 +253,13 @@ let _run_held_position_dials ~config ~positions ~get_price ~prior_stages
     {!_run_macro_and_entries} so the macro trend is available to the
     macro-bearish trim pass (which runs before the entry walk) without computing
     the macro result twice. *)
-let _run_macro ~config ~ad_bars ~prior_macro ~prior_macro_result ~peak_tracker
+let _run_macro ~config ~ad_series ~prior_macro ~prior_macro_result ~peak_tracker
     ~bar_reader ~prior_stages ~current_date ~index_view ~is_screening_day =
   if not is_screening_day then None
   else
     let prev = !prior_macro in
     let r =
-      Weinstein_strategy_macro.run_macro_only ~config ~ad_bars ~prior_macro
+      Weinstein_strategy_macro.run_macro_only ~config ~ad_series ~prior_macro
         ~prior_macro_result ~bar_reader ~prior_stages ~current_date ~index_view
     in
     _maybe_reset_halt ~peak_tracker ~prior_macro:prev ~current_macro:r.trend;
@@ -286,13 +287,13 @@ let _run_entries ~fold_start_date ~config ~stop_states ~last_stop_out_dates
     {!_process_market_day} so that function stays within the length / nesting
     limits; the skip-id union (stop / Stage-3 / laggard / force-liq exits) is
     assembled here. *)
-let _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
+let _run_macro_and_trim ~config ~ad_series ~positions ~portfolio ~prior_macro
     ~prior_macro_result ~prior_decline_character ~peak_tracker ~bar_reader
     ~prior_stages ~get_price ~current_date ~index_view ~is_screening_day
     ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
     ~force_exit_transitions =
   let macro_result_opt =
-    _run_macro ~config ~ad_bars ~prior_macro ~prior_macro_result ~peak_tracker
+    _run_macro ~config ~ad_series ~prior_macro ~prior_macro_result ~peak_tracker
       ~bar_reader ~prior_stages ~current_date ~index_view ~is_screening_day
   in
   (* Re-classify the index's decline character (strictly-past read by the next
@@ -338,7 +339,7 @@ let _run_dials_and_entries ~fold_start_date ~config ~stop_states
   in
   (late_tighten_transitions, harvest_rotate_transitions, entry_transitions)
 
-let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
+let _process_market_day ~fold_start_date ~config ~ad_series ~stop_states
     ~last_stop_out_dates ~prior_macro ~prior_macro_result
     ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
     ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors ~stage3_streaks
@@ -369,7 +370,7 @@ let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
     Weinstein_strategy_screening.is_screening_day_view index_view
   in
   let macro_result_opt, macro_trim_transitions =
-    _run_macro_and_trim ~config ~ad_bars ~positions ~portfolio ~prior_macro
+    _run_macro_and_trim ~config ~ad_series ~positions ~portfolio ~prior_macro
       ~prior_macro_result ~prior_decline_character ~peak_tracker ~bar_reader
       ~prior_stages ~get_price ~current_date ~index_view ~is_screening_day
       ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
@@ -388,7 +389,7 @@ let _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
     ~adjust_transitions:(adjust_transitions @ late_tighten_transitions)
     ~entry_transitions ~stop_exited_ids ~stage3_exited_ids ~laggard_exited_ids
 
-let _on_market_close ~fold_start_date ~config ~ad_bars ~stop_states
+let _on_market_close ~fold_start_date ~config ~ad_series ~stop_states
     ~last_stop_out_dates ~prior_macro ~prior_macro_result
     ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
     ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors ~stage3_streaks
@@ -398,7 +399,7 @@ let _on_market_close ~fold_start_date ~config ~ad_bars ~stop_states
   | None -> Ok { Strategy_interface.transitions = [] }
   | Some primary_bar ->
       let current_date = primary_bar.Types.Daily_price.date in
-      _process_market_day ~fold_start_date ~config ~ad_bars ~stop_states
+      _process_market_day ~fold_start_date ~config ~ad_series ~stop_states
         ~last_stop_out_dates ~prior_macro ~prior_macro_result
         ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
         ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors
@@ -463,12 +464,20 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
         weekly_ad_bars ) =
     _init_strategy_state ~initial_stop_states ~ad_bars
   in
+  (* Precompute the A-D cumulative + momentum series ONCE; the weekly A-D bars
+     are fixed for the whole run, so per-tick macro work reads from this cache
+     in O(log n) instead of re-folding the full list every Friday. *)
+  let ad_series =
+    Ad_series_cache.of_weekly_ad_bars
+      ~momentum_period:config.macro_config.indicator_thresholds.momentum_period
+      weekly_ad_bars
+  in
   let module M = struct
     let name = name
 
     let on_market_close =
-      _on_market_close ~fold_start_date ~config ~ad_bars:weekly_ad_bars
-        ~stop_states ~last_stop_out_dates ~prior_macro ~prior_macro_result
+      _on_market_close ~fold_start_date ~config ~ad_series ~stop_states
+        ~last_stop_out_dates ~prior_macro ~prior_macro_result
         ~prior_decline_character ~peak_tracker ~bar_reader ~prior_stages
         ~prior_stage_ma_values ~sector_prior_stages ~ticker_sectors
         ~stage3_streaks ~laggard_streaks ~audit_recorder
@@ -476,7 +485,17 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
   (module M : Strategy_interface.STRATEGY)
 
 module Internal_for_test = struct
-  let on_market_close = _on_market_close
+  (* Tests pass the weekly A-D bar list directly; build the per-run cache from
+     it here so the test seam keeps its [~ad_bars] signature while the strategy
+     hot path consumes the precomputed [Ad_series_cache.t]. *)
+  let on_market_close ~fold_start_date ~config ~ad_bars =
+    let ad_series =
+      Ad_series_cache.of_weekly_ad_bars
+        ~momentum_period:
+          config.macro_config.indicator_thresholds.momentum_period ad_bars
+    in
+    _on_market_close ~fold_start_date ~config ~ad_series
+
   let maybe_reset_halt = _maybe_reset_halt
   let positions_minus_exited = _positions_minus_exited
   let record_force_exit = _record_force_exit

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -406,44 +406,6 @@ let _on_market_close ~fold_start_date ~config ~ad_series ~stop_states
         ~stage3_streaks ~laggard_streaks ~audit_recorder ~get_price ~portfolio
         ~current_date
 
-let _init_strategy_state ~initial_stop_states ~ad_bars =
-  let stop_states = ref initial_stop_states in
-  let last_stop_out_dates : Date.t Hashtbl.M(String).t =
-    Hashtbl.create (module String)
-  in
-  let prior_macro = ref Weinstein_types.Neutral in
-  let peak_tracker = Portfolio_risk.Force_liquidation.Peak_tracker.create () in
-  let prior_macro_result : Macro.result option ref = ref None in
-  (* Most recent index decline-character; updated at the macro step, read
-     strictly-prior by the next tick's stops pass to arm the fast-crash stop. *)
-  let prior_decline_character = ref Decline_character.Not_declining in
-  let prior_stages = Hashtbl.create (module String) in
-  let prior_stage_ma_values : float Hashtbl.M(String).t =
-    Hashtbl.create (module String)
-  in
-  let sector_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
-    Hashtbl.create (module String)
-  in
-  let stage3_streaks : int Hashtbl.M(String).t =
-    Hashtbl.create (module String)
-  in
-  let laggard_streaks : int Hashtbl.M(String).t =
-    Hashtbl.create (module String)
-  in
-  let weekly_ad_bars = Ad_bars_aggregation.daily_to_weekly ad_bars in
-  ( stop_states,
-    last_stop_out_dates,
-    prior_macro,
-    peak_tracker,
-    prior_macro_result,
-    prior_decline_character,
-    prior_stages,
-    prior_stage_ma_values,
-    sector_prior_stages,
-    stage3_streaks,
-    laggard_streaks,
-    weekly_ad_bars )
-
 let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
     ?(ticker_sectors = Hashtbl.create (module String)) ?bar_reader
     ?(audit_recorder = Audit_recorder.noop) ?fold_start_date config =
@@ -462,7 +424,7 @@ let make ?(initial_stop_states = String.Map.empty) ?(ad_bars = [])
         stage3_streaks,
         laggard_streaks,
         weekly_ad_bars ) =
-    _init_strategy_state ~initial_stop_states ~ad_bars
+    Weinstein_strategy_state.init ~initial_stop_states ~ad_bars
   in
   (* Precompute the A-D cumulative + momentum series ONCE; the weekly A-D bars
      are fixed for the whole run, so per-tick macro work reads from this cache

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -36,6 +36,10 @@ open Core
 module Ad_bars = Ad_bars
 (** NYSE advance/decline breadth data loader. See {!Ad_bars}. *)
 
+module Ad_series_cache = Ad_series_cache
+(** Precomputed cumulative-A-D + momentum series for the per-tick macro path.
+    See {!Ad_series_cache}. *)
+
 module Bar_reader = Bar_reader
 (** Panel-backed bar source. See {!Bar_reader}. *)
 

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.ml
@@ -7,8 +7,8 @@ open Weinstein_strategy_config
     Friday (including when the halt is active) so [_maybe_reset_halt] can
     consult the freshest macro trend even when the universe screen is gated off.
 *)
-let run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result ~bar_reader
-    ~prior_stages ~current_date ~index_view =
+let run_macro_only ~config ~ad_series ~prior_macro ~prior_macro_result
+    ~bar_reader ~prior_stages ~current_date ~index_view =
   let index_prior_stage = Hashtbl.find prior_stages config.indices.primary in
   (* Phase F.3.d-2 caller migration: the global-index view assembly reads
      through {!Snapshot_runtime.Snapshot_callbacks} directly via the
@@ -23,13 +23,16 @@ let run_macro_only ~config ~ad_bars ~prior_macro ~prior_macro_result ~bar_reader
       ~global_index_symbols:config.indices.global ~cb ~as_of:current_date
   in
   let ma_cache = Bar_reader.ma_cache bar_reader in
-  let ad_bars =
-    Macro_inputs.ad_bars_at_or_before ~ad_bars ~as_of:current_date
-  in
+  (* The weekly A-D series is FIXED across the run; [ad_series] precomputes its
+     cumulative + momentum-MA scalars once, so this per-tick step is O(log n)
+     (binary search for the [current_date] cutoff) instead of the O(n) refold
+     the old [ad_bars_at_or_before] + [_build_cumulative_ad_array] path incurred.
+     Output is bit-identical (parity test: [Test_ad_series_cache]). *)
   let macro_callbacks =
-    Panel_callbacks.macro_callbacks_of_weekly_views ?ma_cache
+    Panel_callbacks.macro_callbacks_of_weekly_views_cached ?ma_cache
       ~index_symbol:config.indices.primary ~config:config.macro_config
-      ~index:index_view ~globals:global_index_views ~ad_bars ()
+      ~index:index_view ~globals:global_index_views ~ad_series
+      ~as_of:current_date ()
   in
   let macro_result =
     Macro.analyze_with_callbacks ~config:config.macro_config

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_macro.mli
@@ -7,7 +7,7 @@ open Core
 
 val run_macro_only :
   config:Weinstein_strategy_config.config ->
-  ad_bars:Macro.ad_bar list ->
+  ad_series:Ad_series_cache.t ->
   prior_macro:Weinstein_types.market_trend ref ->
   prior_macro_result:Macro.result option ref ->
   bar_reader:Bar_reader.t ->

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_state.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_state.ml
@@ -1,0 +1,53 @@
+open Core
+
+type t =
+  Weinstein_stops.stop_state String.Map.t ref
+  * Date.t Hashtbl.M(String).t
+  * Weinstein_types.market_trend ref
+  * Portfolio_risk.Force_liquidation.Peak_tracker.t
+  * Macro.result option ref
+  * Decline_character.t ref
+  * Weinstein_types.stage Hashtbl.M(String).t
+  * float Hashtbl.M(String).t
+  * Weinstein_types.stage Hashtbl.M(String).t
+  * int Hashtbl.M(String).t
+  * int Hashtbl.M(String).t
+  * Macro.ad_bar list
+
+let init ~initial_stop_states ~ad_bars =
+  let stop_states = ref initial_stop_states in
+  let last_stop_out_dates : Date.t Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let prior_macro = ref Weinstein_types.Neutral in
+  let peak_tracker = Portfolio_risk.Force_liquidation.Peak_tracker.create () in
+  let prior_macro_result : Macro.result option ref = ref None in
+  (* Most recent index decline-character; updated at the macro step, read
+     strictly-prior by the next tick's stops pass to arm the fast-crash stop. *)
+  let prior_decline_character = ref Decline_character.Not_declining in
+  let prior_stages = Hashtbl.create (module String) in
+  let prior_stage_ma_values : float Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let sector_prior_stages : Weinstein_types.stage Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let stage3_streaks : int Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let laggard_streaks : int Hashtbl.M(String).t =
+    Hashtbl.create (module String)
+  in
+  let weekly_ad_bars = Ad_bars_aggregation.daily_to_weekly ad_bars in
+  ( stop_states,
+    last_stop_out_dates,
+    prior_macro,
+    peak_tracker,
+    prior_macro_result,
+    prior_decline_character,
+    prior_stages,
+    prior_stage_ma_values,
+    sector_prior_stages,
+    stage3_streaks,
+    laggard_streaks,
+    weekly_ad_bars )

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_state.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_state.mli
@@ -1,0 +1,38 @@
+open Core
+
+(** Per-run mutable state bootstrap for {!Weinstein_strategy.make}.
+
+    Factored out of [Weinstein_strategy] to keep that coordinator file within
+    the declared-large file-length limit. The single function below builds the
+    closure-scoped refs/hashtables the [on_market_close] hot path threads
+    through every tick, plus the weekly A-D bar list (aggregated once per run).
+    Not intended for external callers. *)
+
+type t =
+  Weinstein_stops.stop_state String.Map.t ref
+  * Date.t Hashtbl.M(String).t
+  * Weinstein_types.market_trend ref
+  * Portfolio_risk.Force_liquidation.Peak_tracker.t
+  * Macro.result option ref
+  * Decline_character.t ref
+  * Weinstein_types.stage Hashtbl.M(String).t
+  * float Hashtbl.M(String).t
+  * Weinstein_types.stage Hashtbl.M(String).t
+  * int Hashtbl.M(String).t
+  * int Hashtbl.M(String).t
+  * Macro.ad_bar list
+(** The bundle of per-run mutable state returned by {!init}, in the field order
+    consumed by [Weinstein_strategy.make]:
+    [(stop_states, last_stop_out_dates, prior_macro, peak_tracker,
+     prior_macro_result, prior_decline_character, prior_stages,
+     prior_stage_ma_values, sector_prior_stages, stage3_streaks,
+     laggard_streaks, weekly_ad_bars)]. *)
+
+val init :
+  initial_stop_states:Weinstein_stops.stop_state String.Map.t ->
+  ad_bars:Macro.ad_bar list ->
+  t
+(** [init ~initial_stop_states ~ad_bars] allocates a fresh per-run state bundle:
+    each ref/hashtable starts empty (or at its neutral seed value), and
+    [ad_bars] is aggregated to the run-fixed weekly A-D bar list. Pure
+    allocation — no I/O, no shared state. *)

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -1,5 +1,6 @@
 (tests
  (names
+  test_ad_series_cache
   test_ad_bars_unicorn
   test_ad_bars_compose
   test_ad_bars_weekly_e2e

--- a/trading/trading/weinstein/strategy/test/test_ad_series_cache.ml
+++ b/trading/trading/weinstein/strategy/test/test_ad_series_cache.ml
@@ -1,0 +1,160 @@
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+module Snapshot_bar_views = Snapshot_runtime.Snapshot_bar_views
+
+(* ------------------------------------------------------------------ *)
+(* Parity: Ad_series_cache must reproduce the OLD per-tick macro A-D path *)
+(* bit-for-bit. The OLD path is exactly                                  *)
+(*   Macro_inputs.ad_bars_at_or_before                                   *)
+(*     |> Panel_callbacks.macro_callbacks_of_weekly_views ~ad_bars       *)
+(* which internally folds _build_cumulative_ad_array /                   *)
+(* _compute_momentum_ma_scalar and wraps them in _get_from_float_array / *)
+(* _get_ad_momentum_ma. The NEW path is                                  *)
+(*   Ad_series_cache.of_weekly_ad_bars |> callbacks_at ~as_of            *)
+(* (equivalently macro_callbacks_of_weekly_views_cached). We compare the *)
+(* two A-D closures' outputs across many week_offsets and as_of cutoffs. *)
+(* ------------------------------------------------------------------ *)
+
+let make_ad_bar ~year ~month ~day ~advancing ~declining : Macro.ad_bar =
+  {
+    date = Date.create_exn ~y:year ~m:(Month.of_int_exn month) ~d:day;
+    advancing;
+    declining;
+  }
+
+(* Ascending-by-date weekly A-D bars with varied (incl. negative) nets. *)
+let sample_ad_bars : Macro.ad_bar list =
+  [
+    make_ad_bar ~year:2020 ~month:1 ~day:3 ~advancing:300 ~declining:100;
+    make_ad_bar ~year:2020 ~month:1 ~day:10 ~advancing:120 ~declining:380;
+    make_ad_bar ~year:2020 ~month:1 ~day:17 ~advancing:250 ~declining:250;
+    make_ad_bar ~year:2020 ~month:1 ~day:24 ~advancing:90 ~declining:410;
+    make_ad_bar ~year:2020 ~month:1 ~day:31 ~advancing:420 ~declining:80;
+    make_ad_bar ~year:2020 ~month:2 ~day:7 ~advancing:200 ~declining:300;
+  ]
+
+let empty_weekly_view : Snapshot_bar_views.weekly_view =
+  {
+    closes = [||];
+    raw_closes = [||];
+    highs = [||];
+    lows = [||];
+    volumes = [||];
+    dates = [||];
+    n = 0;
+  }
+
+(* Build a Macro.config whose momentum_period we control, so cutoffs exercise
+   both k < momentum_period and k >= momentum_period. *)
+let macro_config ~momentum_period : Macro.config =
+  {
+    Macro.default_config with
+    indicator_thresholds =
+      { Macro.default_config.indicator_thresholds with momentum_period };
+  }
+
+(* The OLD A-D closures: filter to [as_of], then build the legacy callbacks. *)
+let old_callbacks ~momentum_period ~as_of =
+  let ad_bars =
+    Macro_inputs.ad_bars_at_or_before ~ad_bars:sample_ad_bars ~as_of
+  in
+  let cbs =
+    Panel_callbacks.macro_callbacks_of_weekly_views
+      ~config:(macro_config ~momentum_period)
+      ~index:empty_weekly_view ~globals:[] ~ad_bars ()
+  in
+  (cbs.Macro.get_cumulative_ad, cbs.Macro.get_ad_momentum_ma)
+
+(* The NEW A-D closures from the precomputed cache. *)
+let new_callbacks ~momentum_period ~as_of =
+  let cache =
+    Ad_series_cache.of_weekly_ad_bars ~momentum_period sample_ad_bars
+  in
+  Ad_series_cache.callbacks_at cache ~as_of
+
+(* Offsets spanning in-range, the boundary, and well out of range. *)
+let week_offsets = List.range (-1) 9
+
+(* For one (momentum_period, as_of) cell, assert every cumulative-A-D offset and
+   the offset-0 momentum MA from the NEW closures equal the OLD closures. The
+   expected values are produced by the OLD path, so this is a true parity pin. *)
+let assert_cell ~momentum_period ~as_of =
+  let old_cum, old_ma = old_callbacks ~momentum_period ~as_of in
+  let new_cum, new_ma = new_callbacks ~momentum_period ~as_of in
+  let cum_matchers =
+    List.map week_offsets ~f:(fun week_offset ->
+        match old_cum ~week_offset with
+        | None -> is_none
+        | Some v -> is_some_and (float_equal v))
+  in
+  assert_that
+    (List.map week_offsets ~f:(fun week_offset -> new_cum ~week_offset))
+    (elements_are cum_matchers);
+  let expected_ma_matcher =
+    match old_ma ~week_offset:0 with
+    | None -> is_none
+    | Some v -> is_some_and (float_equal v)
+  in
+  assert_that (new_ma ~week_offset:0) expected_ma_matcher
+
+(* Cutoffs: before all (k=0), each exact boundary date, an off-boundary mid date,
+   and after all (k=n). *)
+let cutoffs =
+  [
+    Date.create_exn ~y:2019 ~m:Month.Dec ~d:31 (* before all *);
+    Date.create_exn ~y:2020 ~m:Month.Jan ~d:3 (* boundary, k=1 *);
+    Date.create_exn ~y:2020 ~m:Month.Jan ~d:14 (* mid, k=2 *);
+    Date.create_exn ~y:2020 ~m:Month.Jan ~d:17 (* boundary, k=3 *);
+    Date.create_exn ~y:2020 ~m:Month.Jan ~d:31 (* boundary, k=5 *);
+    Date.create_exn ~y:2020 ~m:Month.Feb ~d:7 (* boundary, k=6=n *);
+    Date.create_exn ~y:2020 ~m:Month.Mar ~d:1 (* after all, k=n *);
+  ]
+
+(* momentum_period 3 puts several cutoffs in k < period; period 200 keeps every
+   cutoff in k < period; period 1 keeps every non-empty cutoff in k >= period. *)
+let momentum_periods = [ 1; 3; 200 ]
+
+let test_parity_across_cutoffs _ =
+  List.iter momentum_periods ~f:(fun momentum_period ->
+      List.iter cutoffs ~f:(fun as_of -> assert_cell ~momentum_period ~as_of))
+
+(* Empty input: cache is empty, k is always 0, both closures always None. *)
+let test_empty_input _ =
+  let cache = Ad_series_cache.of_weekly_ad_bars ~momentum_period:3 [] in
+  assert_that (Ad_series_cache.length cache) (equal_to 0);
+  let get_cum, get_ma =
+    Ad_series_cache.callbacks_at cache
+      ~as_of:(Date.create_exn ~y:2020 ~m:Month.Jan ~d:15)
+  in
+  assert_that (get_cum ~week_offset:0) is_none;
+  assert_that (get_ma ~week_offset:0) is_none
+
+(* count_at_or_before must equal the OLD filter's prefix length at every cutoff. *)
+let test_prefix_length_matches_filter _ =
+  let cache =
+    Ad_series_cache.of_weekly_ad_bars ~momentum_period:3 sample_ad_bars
+  in
+  let actual =
+    List.map cutoffs ~f:(fun as_of ->
+        Ad_series_cache.Internal_for_test.count_at_or_before cache ~as_of)
+  in
+  let expected =
+    List.map cutoffs ~f:(fun as_of ->
+        List.length
+          (Macro_inputs.ad_bars_at_or_before ~ad_bars:sample_ad_bars ~as_of))
+  in
+  assert_that actual (elements_are (List.map expected ~f:(fun n -> equal_to n)))
+
+let suite =
+  "Ad_series_cache parity"
+  >::: [
+         "parity across cutoffs and momentum periods"
+         >:: test_parity_across_cutoffs;
+         "empty input yields all-None closures" >:: test_empty_input;
+         "prefix length matches ad_bars_at_or_before"
+         >:: test_prefix_length_matches_filter;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What this does (PURE PERF — bit-identical, no golden re-pin)

Eliminates the O(n²) in the A-D-live macro path. When A-D breadth is LIVE
(non-empty `ad_bars`), each weekly macro tick was O(n) and over T ticks the
run was O(n²) — 3-5× slower than A-D-inert. Inert was already O(1)/tick
(empty `ad_bars` → passthrough fast-path).

## Root cause

Per-tick hot path `Weinstein_strategy_macro.run_macro_only`:
1. `Macro_inputs.ad_bars_at_or_before` — O(n) `List.filter` over the FULL
   weekly history every tick (passthrough fails because the last bar's date
   is after `as_of` for every non-final tick).
2. `Panel_callbacks.macro_callbacks_of_weekly_views ~ad_bars` rebuilt
   `_build_cumulative_ad_array` (O(t) fold) + `_compute_momentum_ma_scalar`
   (O(t)) from scratch every tick.

The `weekly_ad_bars` list is FIXED across the whole run (built once in
`_init_strategy_state` from `Ad_bars_aggregation.daily_to_weekly`, ascending
by date), so all per-tick A-D work is recomputable from a single precomputed
structure.

## The fix

New `Ad_series_cache` module precomputes ONCE from `weekly_ad_bars`:
- `dates : Date.t array` (ascending), `cum_int : int array` (running A-D net
  sum), `cum_float = Array.map ~f:Float.of_int cum_int`, `momentum_period`.

Per tick, given `as_of`, `k` = number of bars with `date <= as_of` via binary
search (O(log n)), then the two A-D closures over the prefix `[0,k)`:
- `get_cumulative_ad ~week_offset`: `idx = k-1-week_offset`; `Some cum_float.(idx)`
  if in range else `None`.
- `get_ad_momentum_ma ~week_offset`: `week_offset<>0 → None`; else int sum of
  the last `min momentum_period k` nets via telescoping
  `cum_int.(k-1) - cum_int.(k-1-period)`, divided by float `period`.

The strategy hot loop migrates from `~ad_bars:weekly_ad_bars` to `~ad_series`
threaded through `_on_market_close → _process_market_day → _run_macro_and_trim
→ _run_macro → run_macro_only`. The cache is built once in `make`. The
`macro_callbacks_of_weekly_views_cached` twin reads the closures from the cache
instead of rebuilding.

`Macro_inputs.ad_bars_at_or_before`, `macro_callbacks_of_weekly_views`,
`_build_cumulative_ad_array`, `_compute_momentum_ma_scalar`, and
`macro_callbacks_of_snapshot_views` are all KEPT — used by the bar-list
`Macro.analyze` path and other callers. Only the strategy hot loop migrates.

## Why this is bit-identical

- `get_cumulative_ad`: the old path built the cumulative array over the
  FILTERED prefix `[0..k-1]` with the identical int-running-sum-then-`Float.of_int`
  boundary. The global prefix's first `k` entries ARE that prefix. The
  newest=offset-0 convention is reproduced by `idx = k-1-week_offset`.
- `get_ad_momentum_ma`: old path int-summed the last `period = min(momentum_period, k)`
  nets and divided by float `period`. `cum_int.(k-1) - cum_int.(k-1-period)` is
  the EXACT same int sum (telescoping; A-D nets are small ints far below 2^53,
  no float rounding). Same float division. `week_offset=0`-only behaviour matches.
- Inert path: empty `weekly_ad_bars` → empty arrays → `k` always 0 → both
  closures always `None`, identical to today's empty-`ad_bars` behaviour. ALL
  committed (A-D-inert) goldens are untouched.

## Test plan

TDD — the parity unit test `test_ad_series_cache.ml` is the centerpiece. It
pins bit-identical equivalence between the OLD path
(`ad_bars_at_or_before` → `macro_callbacks_of_weekly_views`) and the NEW cache
across many `as_of` cutoffs (before-all k=0, exact boundaries, mid-history,
after-all k=n) × momentum_periods `{1,3,200}` (covering k<period and k>=period)
× week_offsets `[-1..8]` (incl. out-of-range → `is_none`), plus empty input and
a `count_at_or_before` ↔ `ad_bars_at_or_before` prefix-length pin. 3 tests, all
green.

`dune build @fmt`, `dune build`, and the full strategy test dir
(`dune runtest weinstein/strategy/test/`) pass with zero warnings. No
end-to-end A-D-live backtest was run (live breadth data lives in the gitignored
repo-root `data/` dir, absent in CI/isolated worktree); the parity test +
unchanged inert goldens are the correctness proof. The only `dune runtest`
failures in this worktree are pre-existing data-floor `Sys_error: No such file`
errors on missing `data/backtest_scenarios/` + `data/breadth/` fixtures —
verified identical on clean `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
