### PR TITLE
fix(goldens): re-pin runnable broad/custom cells to complete-universe warehouse numbers (#1729)

### DIFF
--- a/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
@@ -16,6 +16,23 @@
 ;;
 ;; Measured 2026-06-05 (Cell E, PIT top-1000-2015). Tolerances ±20%
 ;; (return/DD/sharpe/trades/holding), win_rate ±5pp — first PIT pin.
+;;
+;; RE-PINNED 2026-06-24 (#1729 decision C): complete-universe warehouse run
+;; (top-1000-2015, 1000/1000 symbols loaded; 1015 incl. ^GSPC + sector ETFs).
+;; The prior band (49.3-73.9%) was measured against an incomplete
+;; (survivor-subset, ~462/1000) test_data store — the runner silently skipped
+;; the missing symbols, inflating return. Re-measured against the
+;; delisting-complete warehouse snapshot /tmp/snap_top3000_1998_2026 (3015 syms);
+;; the complete top-1000-2015 universe drops the return from 49-74% to ~38%.
+;; Determinism established on the sibling decade cell (bit-identical across two
+;; runs). This cell will (correctly) keep FAILING in GHA perf-tier4 against the
+;; incomplete committed test_data — that failure is the intentional missing-data
+;; signal; a local snapshot run reproduces the band below.
+;;
+;; Measured 2026-06-24 (complete-universe warehouse, top-1000-2015):
+;;   total_return_pct 37.91   total_trades 259   win_rate 34.75
+;;   sharpe_ratio 0.47   max_drawdown 17.44   avg_holding_days 43.80   calmar 0.32
+;; Tolerances ±20% (return/DD/sharpe/trades/holding), win_rate ±5pp.
 ((name "bull-crash-2015-2020")
  (description "Strong bull market through the 2020 crash (PIT top-1000-2015)")
  (period ((start_date 2015-01-02) (end_date 2020-12-31)))
@@ -31,9 +48,9 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min 49.3) (max 73.9)))
-   (total_trades       ((min 157) (max 235)))
-   (win_rate           ((min 27.7) (max 37.7)))
-   (sharpe_ratio       ((min 0.54) (max 0.82)))
-   (max_drawdown_pct   ((min 11.3) (max 17.0)))
-   (avg_holding_days   ((min 46.4) (max 69.6))))))
+  ((total_return_pct   ((min 30.3) (max 45.5)))
+   (total_trades       ((min 207) (max 311)))
+   (win_rate           ((min 29.7) (max 39.7)))
+   (sharpe_ratio       ((min 0.38) (max 0.57)))
+   (max_drawdown_pct   ((min 14.0) (max 20.9)))
+   (avg_holding_days   ((min 35.0) (max 52.6))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
@@ -19,6 +19,23 @@
 ;;   total_return_pct 41.3   total_trades 272   win_rate 33.1
 ;;   sharpe_ratio 0.46   max_drawdown 36.1   avg_holding_days 38.7   calmar 0.20
 ;; Tolerances ±20% (return/DD/sharpe/trades/holding), win_rate ±5pp — first PIT pin.
+;;
+;; RE-PINNED 2026-06-24 (#1729 decision C): complete-universe warehouse run
+;; (top-1000-2020, 1000/1000 symbols loaded; 1015 incl. ^GSPC + sector ETFs).
+;; The prior band was measured against an incomplete (survivor-subset) test_data
+;; store. Re-measured against the delisting-complete warehouse snapshot
+;; /tmp/snap_top3000_1998_2026 (3015 syms). The complete-universe number (35.31%)
+;; is close to the prior band (which happened to overlap), but the band is now
+;; re-centred on the honest warehouse point. Determinism established on the
+;; sibling decade cell (bit-identical across two runs). This cell will (correctly)
+;; keep FAILING in GHA perf-tier4 against the incomplete committed test_data —
+;; that failure is the intentional missing-data signal; a local snapshot run
+;; reproduces the band below.
+;;
+;; Measured 2026-06-24 (complete-universe warehouse, top-1000-2020):
+;;   total_return_pct 35.31   total_trades 277   win_rate 35.74
+;;   sharpe_ratio 0.47   max_drawdown 29.78   avg_holding_days 39.09   calmar 0.21
+;; Tolerances ±20% (return/DD/sharpe/trades/holding), win_rate ±5pp.
 ((name "covid-recovery-2020-2024")
  (description "COVID crash and recovery through 2024 (PIT top-1000-2020)")
  (period ((start_date 2020-01-02) (end_date 2024-12-31)))
@@ -34,9 +51,9 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min  33.1)  (max  49.6)))
-   (total_trades       ((min 218)    (max 326)))
-   (win_rate           ((min  28.1)  (max  38.1)))
-   (sharpe_ratio       ((min   0.37) (max   0.55)))
-   (max_drawdown_pct   ((min  28.9)  (max  43.4)))
-   (avg_holding_days   ((min  31.0)  (max  46.5))))))
+  ((total_return_pct   ((min  28.2)  (max  42.4)))
+   (total_trades       ((min 222)    (max 332)))
+   (win_rate           ((min  30.7)  (max  40.7)))
+   (sharpe_ratio       ((min   0.38) (max   0.56)))
+   (max_drawdown_pct   ((min  23.8)  (max  35.7)))
+   (avg_holding_days   ((min  31.3)  (max  46.9))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
@@ -16,6 +16,22 @@
 ;;
 ;; Measured 2026-06-05 (Cell E, PIT top-1000-2014). Tolerances ±20%
 ;; (return/DD/sharpe/trades/holding), win_rate ±5pp — first PIT pin.
+;;
+;; RE-PINNED 2026-06-24 (#1729 decision C): complete-universe warehouse run
+;; (top-1000-2014, 1000/1000 symbols loaded; 1015 incl. ^GSPC + sector ETFs).
+;; The prior band (105.3-157.9%) was measured against an incomplete
+;; (survivor-subset, ~462/1000) test_data store — the runner silently skipped
+;; the missing symbols, inflating return. Re-measured against the
+;; delisting-complete warehouse snapshot /tmp/snap_top3000_1998_2026 (3015 syms).
+;; Deterministic: two independent warehouse runs produced bit-identical metrics.
+;; This cell will (correctly) keep FAILING in GHA perf-tier4 against the
+;; incomplete committed test_data — that failure is the intentional missing-data
+;; signal; a local snapshot run reproduces the band below.
+;;
+;; Measured 2026-06-24 (complete-universe warehouse, top-1000-2014):
+;;   total_return_pct 95.28   total_trades 462   win_rate 32.25
+;;   sharpe_ratio 0.50   max_drawdown 37.07   avg_holding_days 45.20   calmar 0.19
+;; Tolerances ±20% (return/DD/sharpe/trades/holding), win_rate ±5pp.
 ((name "decade-2014-2023")
  (description "10-year decade run spanning multiple regimes (PIT top-1000-2014)")
  (period ((start_date 2014-01-02) (end_date 2023-12-29)))
@@ -31,9 +47,9 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min 105.3) (max 157.9)))
-   (total_trades       ((min 291) (max 437)))
-   (win_rate           ((min 26.3) (max 36.3)))
-   (sharpe_ratio       ((min 0.56) (max 0.84)))
-   (max_drawdown_pct   ((min 21.3) (max 32.0)))
-   (avg_holding_days   ((min 38.8) (max 58.2))))))
+  ((total_return_pct   ((min 76.2) (max 114.3)))
+   (total_trades       ((min 370) (max 554)))
+   (win_rate           ((min 27.3) (max 37.3)))
+   (sharpe_ratio       ((min 0.40) (max 0.60)))
+   (max_drawdown_pct   ((min 29.7) (max 44.5)))
+   (avg_holding_days   ((min 36.2) (max 54.2))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
@@ -16,6 +16,24 @@
 ;;
 ;; Measured 2026-06-05 (Cell E, PIT top-1000-2018). Tolerances ±20%
 ;; (return/DD/sharpe/trades/holding), win_rate ±5pp — first PIT pin.
+;;
+;; RE-PINNED 2026-06-24 (#1729 decision C): complete-universe warehouse run
+;; (top-1000-2018, 1000/1000 symbols loaded; 1015 incl. ^GSPC + sector ETFs).
+;; The prior band (70.9-106.3%) was measured against an incomplete
+;; (survivor-subset, ~462/1000) test_data store — the runner silently skipped
+;; the missing symbols, badly inflating return. Re-measured against the
+;; delisting-complete warehouse snapshot /tmp/snap_top3000_1998_2026 (3015 syms);
+;; the complete top-1000-2018 universe (with COVID-era delistings) collapses the
+;; return from the survivor-inflated 70-106% to ~19%, and the MaxDD falls too
+;; (less concentrated). Determinism established on the sibling decade cell
+;; (bit-identical across two runs). This cell will (correctly) keep FAILING in
+;; GHA perf-tier4 against the incomplete committed test_data — that failure is
+;; the intentional missing-data signal; a local snapshot run reproduces the band.
+;;
+;; Measured 2026-06-24 (complete-universe warehouse, top-1000-2018):
+;;   total_return_pct 19.45   total_trades 280   win_rate 35.71
+;;   sharpe_ratio 0.28   max_drawdown 21.79   avg_holding_days 39.68   calmar 0.14
+;; Tolerances ±20% (return/DD/sharpe/trades/holding), win_rate ±5pp.
 ((name "six-year-2018-2023")
  (description "6-year run covering COVID crash and recovery (PIT top-1000-2018)")
  (period ((start_date 2018-01-02) (end_date 2023-12-29)))
@@ -31,9 +49,9 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min 70.9) (max 106.3)))
-   (total_trades       ((min 254) (max 382)))
-   (win_rate           ((min 25.5) (max 35.5)))
-   (sharpe_ratio       ((min 0.35) (max 0.52)))
-   (max_drawdown_pct   ((min 46.4) (max 69.5)))
-   (avg_holding_days   ((min 29.1) (max 43.7))))))
+  ((total_return_pct   ((min 15.6) (max 23.3)))
+   (total_trades       ((min 224) (max 336)))
+   (win_rate           ((min 30.7) (max 40.7)))
+   (sharpe_ratio       ((min 0.23) (max 0.34)))
+   (max_drawdown_pct   ((min 17.4) (max 26.1)))
+   (avg_holding_days   ((min 31.7) (max 47.6))))))

--- a/trading/test_data/backtest_scenarios/goldens-custom-universe-scenarios/weinstein-2019-top-500.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-custom-universe-scenarios/weinstein-2019-top-500.sexp
@@ -109,17 +109,37 @@
  ;; Tolerances ±20% across the board, EXCEPT max_drawdown_pct +
  ;; win_rate + avg_holding_days at ±15% (those have lower per-run
  ;; variance per the #1180 random-sample distribution).
+ ;;
+ ;; **RE-PINNED 2026-06-24 (#1729 decision C): complete-universe warehouse run
+ ;; (top-500-2019, 500/500 symbols loaded; 515 incl. ^GSPC + sector ETFs).**
+ ;; The 2026-05-18 band was measured against a test_data store that covered only
+ ;; a survivor subset (~337/500) of this delisting-aware composition universe —
+ ;; the runner silently skipped the missing names. Re-measured against the
+ ;; delisting-complete warehouse snapshot /tmp/snap_top3000_1998_2026 (3015 syms).
+ ;; Return (72.77%) lands close to the prior band (which was already
+ ;; delisted-aware), but the full universe is less risky: MaxDD/ulcer fall and
+ ;; calmar rises. Determinism established on the sibling decade cell (bit-identical
+ ;; across two runs). This cell will (correctly) keep FAILING in GHA perf-tier3 /
+ ;; golden-runs-custom-universe against the incomplete committed test_data — that
+ ;; failure is the intentional missing-data signal; a local snapshot run
+ ;; reproduces the band below. Tolerances unchanged (±20%, EXCEPT DD/win/holding
+ ;; at ±15%); wall_seconds band kept (perf guard, not data-dependent).
+ ;;
+ ;; Measured 2026-06-24 (complete-universe warehouse, top-500-2019):
+ ;;   total_return_pct  72.77  total_trades 262  win_rate 36.64
+ ;;   sharpe_ratio 0.77  max_drawdown 27.31  avg_holding_days 39.39
+ ;;   open_positions_value 1,472,159  sortino 1.13  calmar 0.42  ulcer 12.57
  (expected
-  ((total_return_pct   ((min  62.7)         (max  94.0)))
-   (total_trades       ((min 210)           (max 316)))
-   (win_rate           ((min  27.1)         (max  36.7)))
-   (sharpe_ratio       ((min   0.55)        (max   0.83)))
-   (max_drawdown_pct   ((min  35.8)         (max  48.5)))
-   (avg_holding_days   ((min  35.7)         (max  48.3)))
-   (open_positions_value ((min 1139000.0)   (max 1710000.0)))
-   (sortino_ratio_annualized ((min  0.77)   (max   1.15)))
-   (calmar_ratio       ((min   0.23)        (max   0.35)))
-   (ulcer_index        ((min  15.2)         (max  22.8)))
+  ((total_return_pct   ((min  58.2)         (max  87.3)))
+   (total_trades       ((min 210)           (max 314)))
+   (win_rate           ((min  31.1)         (max  42.1)))
+   (sharpe_ratio       ((min   0.61)        (max   0.92)))
+   (max_drawdown_pct   ((min  23.2)         (max  31.4)))
+   (avg_holding_days   ((min  33.5)         (max  45.3)))
+   (open_positions_value ((min 1177727.0)   (max 1766591.0)))
+   (sortino_ratio_annualized ((min  0.90)   (max   1.36)))
+   (calmar_ratio       ((min   0.34)        (max   0.51)))
+   (ulcer_index        ((min  10.1)         (max  15.1)))
    ;; wall_seconds wide (CI ~5x local, local ~190s) — catches only
    ;; catastrophic 2x slowdowns per design intent.
    (wall_seconds       ((min 100.0)         (max 1800.0))))))


### PR DESCRIPTION
## What

Re-pin the 5 runnable broad/custom regression goldens (top-1000 / top-500) to their **true complete-universe** numbers, measured against the delisting-complete warehouse snapshot `/tmp/snap_top3000_1998_2026` (3015 symbols). Implements **decision C** of #1729 (`dev/plans/broad-golden-complete-data-2026-06-24.md`).

## Why

These goldens use delisting-aware PIT universes (top-1000/3000, top-500) but their prior bands were measured against an **incomplete** committed `test_data` store (a survivor-scoped sp500 subset, ~462/1000 of top-1000-2014). The runner **silently skips symbols with no bars**, so a broad-golden run traded only the survivor subset → survivorship-inflated, data-path-dependent numbers. The only complete store is the warehouse snapshot. Decision C re-pins these cells to the honest complete-universe values.

## Per-cell: old band → measured complete-universe point → new band (±20%, win_rate ±5pp)

| cell (universe) | metric | old band | measured (warehouse) | new band |
|---|---|---|---|---|
| **decade-2014-2023** (top-1000-2014) | return % | 105.3–157.9 | **95.28** | 76.2–114.3 |
| | trades / win% / sharpe / DD% / hold | | 462 / 32.25 / 0.50 / 37.07 / 45.20 | 370–554 / 27.3–37.3 / 0.40–0.60 / 29.7–44.5 / 36.2–54.2 |
| **six-year-2018-2023** (top-1000-2018) | return % | 70.9–106.3 | **19.45** | 15.6–23.3 |
| | trades / win% / sharpe / DD% / hold | | 280 / 35.71 / 0.28 / 21.79 / 39.68 | 224–336 / 30.7–40.7 / 0.23–0.34 / 17.4–26.1 / 31.7–47.6 |
| **bull-crash-2015-2020** (top-1000-2015) | return % | 49.3–73.9 | **37.91** | 30.3–45.5 |
| | trades / win% / sharpe / DD% / hold | | 259 / 34.75 / 0.47 / 17.44 / 43.80 | 207–311 / 29.7–39.7 / 0.38–0.57 / 14.0–20.9 / 35.0–52.6 |
| **covid-recovery-2020-2024** (top-1000-2020) | return % | 33.1–49.6 | **35.31** | 28.2–42.4 |
| | trades / win% / sharpe / DD% / hold | | 277 / 35.74 / 0.47 / 29.78 / 39.09 | 222–332 / 30.7–40.7 / 0.38–0.56 / 23.8–35.7 / 31.3–46.9 |
| **weinstein-2019-top-500** (top-500-2019) | return % | 62.7–94.0 | **72.77** | 58.2–87.3 |
| | trades / win% / sharpe / DD% / hold / sortino / calmar / ulcer | | 262 / 36.64 / 0.77 / 27.31 / 39.39 / 1.13 / 0.42 / 12.57 | 210–314 / 31.1–42.1 / 0.61–0.92 / 23.2–31.4 / 33.5–45.3 / 0.90–1.36 / 0.34–0.51 / 10.1–15.1 |

The two top-1000 cells whose prior bands were measured against the most-incomplete data (decade, six-year, bull-crash) drop the hardest; the two whose prior bands were already delisted-aware (covid, top-500) land close to / inside the prior band but are re-centred on the honest warehouse point. Notably the complete universes are **less concentrated** → MaxDD/ulcer fall.

## Determinism

Two independent warehouse runs of the decade cell produced **bit-identical** metrics (95.280677749999882, 462 trades, …). The engine RNG is per-call/deterministic, so a single warehouse run per remaining cell is a stable point. All bands are the measured point ± the file's existing tolerance scheme.

## These cells stay GHA-fail-on-missing by design (decision C)

They will (correctly) **keep failing** in GHA perf-tier3/4 + golden-runs-custom-universe against the incomplete committed `test_data` — that failure is the **intentional missing-data signal** (the plan and `perf_tier3_weekly.sh` header call this out). They are runnable + verifiable **locally** by rebuilding/using the warehouse (`--snapshot-dir`). The pinned band is the locally-reproducible-against-warehouse truth. The top-3000 / full-pool cells are explicitly **out of scope** (blocked on the snapshot memory crash — sub-task 2).

## Local repro

```
TRADING_DATA_DIR=test_data dune exec trading/backtest/scenarios/scenario_runner.exe -- \
  --dir <staged-single-scenario-dir> --snapshot-dir /tmp/snap_top3000_1998_2026 \
  --fixtures-root test_data/backtest_scenarios --no-emit-all-eligible --parallel 1
```

## Test

Data/fixture-only change (no `.ml`/`.mli`). `dune build @fmt` and `dune build` both pass (exit 0) — sexp files parse via `Scenario.load`, proven by the scenario_runner runs that produced the metrics above.
