### PR TITLE
docs: P1 blocked — deep data/ store gone (arming-speed A-D-live needs re-fetch)

### DIFF
--- a/dev/notes/next-session-priorities-2026-06-24.md
+++ b/dev/notes/next-session-priorities-2026-06-24.md
@@ -59,11 +59,32 @@ Now that A-D is live by default, re-run the A-D-inert WF-CVs on the live basis:
 `neutral_blocks_shorts` (faithfulness flip still on the table), `fast_v_arm_on_rate_alone`
 (#1708) + `fast_v_min_rate_pct` (#1716) arming surface. See `project_decline_character_builds`.
 
+**⚠ BLOCKED (found 2026-06-24): the deep `data/` store is GONE.** The deep A-D-live
+WF-CVs read CSV `data/` (sp500-2000-2026 universe + `data/breadth/`). As of this
+session both `trading/data/` (731-name PIT bars) **and** `trading/data/breadth/` are
+empty on host+container — cleared since the prior handoff (disk pressure / sweep /
+container churn). Reconstituting needs an EODHD re-fetch of the deep sp500-2000
+universe (`fetch-historical-data` skill; needs API key + the user-GUI disk prep noted
+in `project_decline_character_builds`). The committed breadth (`test_data/breadth/
+synthetic_{advn,decln}.csv`, 1998–2026, 7159 rows) survives and can re-seed
+`data/breadth/`, but the **universe bars are the missing piece**. The warehouse
+snapshot `/tmp/snap_top3000_1998_2026` (2 GB, intact) is a *different* universe
+(top-3000) and carries the snapshot memory crash → not a drop-in substitute for the
+sp500-2000 CSV WF-CV baseline. **Scope status:** of P1, the short-gate half is
+effectively DONE (06-22 `slow-grind-adlive` WF-CV → NO-promote; `neutral_blocks_shorts`
+stays ≈ungated even A-D-live). The *only* not-yet-done, evidence-backed slice is the
+**fast_v arming-speed surface on A-D-live** (the 06-22 `fast_v_min_rate` REJECT named
+the A-D breadth lead as the unlock) — and it is the part this data gap blocks.
+**Next-session action:** re-provision the deep `data/` store (user disk prep + fetch),
+then run the arming-speed surface WF-CV on A-D-live via `experiment-gap-closing`.
+
 ## P2 — barbell weight cert (unchanged) — needs weight mandate.
 
 ## Operational notes
-- Local `data/` (gitignored) has the validated synthetic breadth 1998–2026 +
-  731-name PIT bars; `data/breadth/synthetic_*.csv` is the source copied into test_data.
+- ⚠ Local `data/` (gitignored) is **now EMPTY** (was: synthetic breadth 1998–2026 +
+  731-name PIT bars). Cleared since the prior handoff. The synthetic breadth survives
+  only in committed `test_data/breadth/synthetic_*.csv`; the PIT universe bars are gone
+  and need an EODHD re-fetch to restore (blocks all deep A-D-live CSV WF-CVs — see P1).
 - A second orchestrator run (#1724) advanced main this session; main green.
 - Scenario runner writes output under the dune-root `trading/dev/backtest/scenarios-*`
   (not repo-root) when cwd=trading — `find` accordingly.


### PR DESCRIPTION
Records the session finding: the deep gitignored `data/` store (731-name sp500-2000 PIT bars + `data/breadth/`) is empty as of 2026-06-24, blocking the one not-yet-done P1 slice (fast_v arming-speed surface on A-D-live). Committed breadth survives; universe bars need an EODHD re-fetch. Updates the P1 section + operational notes.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)