### PR TITLE
docs+fixtures: top-3000 broad goldens verified runnable — memory ceiling retired (#1729 sub-task 2)

### DIFF
--- a/dev/backtest/broad-golden-top3000-verify-2026-06-24/FINDINGS.md
+++ b/dev/backtest/broad-golden-top3000-verify-2026-06-24/FINDINGS.md
@@ -1,0 +1,71 @@
+# Broad-golden sub-task 2 — top-3000 verification (issue #1729, 2026-06-24)
+
+Sub-task 2 of the broad-golden complete-data work (`dev/plans/broad-golden-complete-data-2026-06-24.md`).
+Sub-task 1 (#1733) re-pinned the runnable top-1000/500 cells; the top-3000 / full-pool
+cells were deferred as **"blocked on the snapshot memory crash"**
+(`project_panel_runner_memory_ceiling`). This verifies that framing.
+
+## Headline: the memory ceiling is RETIRED — top-3000 snapshot runs clean
+
+`tier4-broad-1y` (PIT `top-3000-2022`, full N=3000, 2022 calendar) **completed PASS**
+in snapshot mode against `/tmp/snap_top3000_1998_2026`:
+
+```
+n_symbols=3015  snapshot cache cap=4096 MB  cache evictions=0
+tier4-broad-1y   Return -10.4%  Trades 16  WinRate 6.2%  MaxDD 19.6%  PASS
+```
+
+Full metrics (`actual.sexp`): total_return_pct −10.41, total_trades 16, win_rate 6.25,
+sharpe −0.855, max_drawdown 19.64, avg_holding_days 40.19, open_positions_value
+865,873, sortino −0.971, calmar −0.536, ulcer 10.37. (Low trade count is correct: 2022
+was a bear tape, so the Weinstein macro gate suppressed most entries.)
+
+**`evictions=0` at the 4 GB cache cap with all 3015 symbols loaded** — no memory
+pressure. The snapshot-format-v2 columnar mmap work (#1631) did what its memory claimed
+("top-3000 runs clean, memory ceiling GONE"); the broad goldens inherit it.
+
+`sp500-30y-capacity-1996` (N=1000 survivorship sentinel, 30-year) also runs clean and
+**deterministic** — two independent runs bit-identical at **1453.6% / 1210 trades /
+38.8% WR / 34.9% MaxDD**.
+
+## The real sub-task-2 obstacles were NOT memory
+
+1. **A fixtures-root path bug in the invocation.** Running `scenario_runner` from the
+   dune root (`/workspaces/trading-1/trading`) with `--fixtures-root
+   trading/test_data/backtest_scenarios` **doubles** the `trading/` prefix, so the
+   `../goldens-custom-universe/composition/top-3000-YYYY.sexp` universe path resolves to
+   a non-existent file → `Sys_error "… No such file or directory"` (looks like a crash,
+   is a path error). Correct form from the dune root: `--fixtures-root
+   test_data/backtest_scenarios` (no leading `trading/`). The composition fixtures all
+   exist (`top-3000-1998 … top-3000-2025`).
+2. **Wall-time, not memory.** `tier4-broad-10y` (top-3000 × 10y) and
+   `weinstein-2019-full-pool` (top-3000 × 5y) are multi-hour at N=3000 (~2.4 h / 5y per
+   `project_deep_1998_2026_contiguous`); they run within the memory budget but exceed a
+   convenient inline window. Deferred, not blocked.
+
+## What this means for the cells
+
+`tier4-broad-1y`, `tier4-broad-10y`, and `sp500-30y-capacity-1996` are **SCALE /
+scaffolding cells** — their own headers say *"expected ranges are intentionally
+permissive … leave ranges wide."* Their purpose is to validate the runtime path at
+scale, **not** to pin a return regression (unlike sub-task-1's regression cells, which
+were survivor-inflated and needed tight complete-universe re-pins). So the correct
+action here is to **record verified complete-universe provenance, keeping the wide
+ranges** — not to tighten them. `tier4-broad-1y` carries a dated provenance comment
+recording this N=3000 PASS.
+
+`weinstein-2019-full-pool` (top-3000-2019, 5y) is a **research baseline** with an
+existing measured comment (32.37%, 2026-05-23); refreshing it to a current
+complete-universe number is a multi-hour run, deferred.
+
+## Verdict
+
+Sub-task 2's blocking premise (memory crash) is **retired**. Top-3000 broad goldens are
+runnable in snapshot mode against the warehouse; the scaffolding cells keep their
+intentionally-wide ranges with verified provenance, and the two multi-hour cells
+(top-3000 × 5y/10y) are runnable-when-wanted, not blocked. Issue #1729 can close the
+"memory crash" sub-task.
+
+Warehouse: `/tmp/snap_top3000_1998_2026` (old .snap, format-detecting reader handles it)
+and a columnar `/tmp/snap_top3000_1998_2026_v2` (3016 syms) both present locally
+(ephemeral; rebuild per the plan's recipe if lost).

--- a/trading/test_data/backtest_scenarios/goldens-broad/tier4-broad-1y.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/tier4-broad-1y.sexp
@@ -40,6 +40,18 @@
 ;;
 ;; PINNED_AFTER_FIRST_RUN — leave `expected` ranges wide; first local run
 ;; populates them.
+;;
+;; VERIFIED 2026-06-24 (#1729 sub-task 2): ran clean at FULL N=3000 in snapshot
+;; mode against /tmp/snap_top3000_1998_2026 (PIT top-3000-2022, 3015 syms incl.
+;; index+ETFs) — snapshot cache evictions=0 at the 4 GB cap, NO memory ceiling
+;; (confirms the snapshot-format-v2 #1631 fix; retires project_panel_runner_memory_ceiling
+;; for the broad goldens). Measured: total_return_pct -10.41, total_trades 16,
+;; win_rate 6.25, sharpe -0.855, max_drawdown 19.64, avg_holding_days 40.19,
+;; calmar -0.536, ulcer 10.37, open_positions_value 865,873 (low trade count =
+;; 2022 bear tape, macro gate suppressed entries — expected). Ranges intentionally
+;; LEFT WIDE per the SCAFFOLDING/scale-validation purpose of this cell (it probes the
+;; runtime path at scale, not a return regression). See
+;; dev/backtest/broad-golden-top3000-verify-2026-06-24/FINDINGS.md.
 ((name "tier4-broad-1y")
  (description "Tier-4 release-gate SCALE — full broad universe × 1y mechanic validation (snapshot-mode only)")
  (period ((start_date 2022-01-03) (end_date 2022-12-30)))


### PR DESCRIPTION
Sub-task 2 of #1729. **Finding: the top-3000 'memory crash' blocker is retired.**

- `tier4-broad-1y` (PIT top-3000-2022, full N=3000) runs clean in snapshot mode: **cache evictions=0 at 4 GB cap, PASS** (−10.41% / 16 trades / 19.64% MaxDD; low trades = 2022 bear macro gate). Confirms the snapshot-format-v2 #1631 fix.
- `sp500-30y` (N=1000, 30y) runs deterministic (1453.6%, bit-identical twice).
- The real obstacles were a **fixtures-root path bug** (doubled `trading/` prefix → Sys_error that looks like a crash) and **wall-time** (top-3000 × 5y/10y are multi-hour, not memory-bound) — both documented.

Action: tier4/30y are SCALE/scaffolding cells whose headers say keep ranges wide — so this records **verified complete-universe provenance** (a dated comment on tier4-broad-1y) rather than tightening them (unlike sub-task-1's regression cells). FINDINGS doc included.

No code/contract/domain change → QC N/A; CI required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)