### PR TITLE
feat(backtest): snapshot-dir mode for optimal + all-eligible runners

### DIFF
--- a/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
@@ -152,6 +152,7 @@ let _make_args ~scenario_path ~out_dir : Runner.cli_args =
     min_grade = None;
     grade_sweep = false;
     config_overrides = [];
+    warehouse_dir = None;
   }
 
 (** Default-mode runs land artefacts under [out_dir/grade-C/] (the default
@@ -348,6 +349,23 @@ let test_parse_argv_grade_sweep _ =
          field (fun a -> a.Runner.min_grade) is_none;
        ])
 
+let test_parse_argv_snapshot_dir _ =
+  let argv =
+    [|
+      "all_eligible_runner.exe";
+      "--scenario";
+      "/tmp/foo.sexp";
+      "--snapshot-dir";
+      "/tmp/snap_top3000";
+    |]
+  in
+  assert_that (Runner.parse_argv argv).Runner.warehouse_dir
+    (is_some_and (equal_to "/tmp/snap_top3000"))
+
+let test_parse_argv_snapshot_dir_absent_is_none _ =
+  let argv = [| "all_eligible_runner.exe"; "--scenario"; "/tmp/foo.sexp" |] in
+  assert_that (Runner.parse_argv argv).Runner.warehouse_dir is_none
+
 let test_parse_argv_invalid_min_grade_raises _ =
   let argv =
     [|
@@ -409,6 +427,7 @@ let test_resolve_out_dir_default _ =
       min_grade = None;
       grade_sweep = false;
       config_overrides = [];
+      warehouse_dir = None;
     }
   in
   let resolved = Runner.resolve_out_dir ~scenario_name:"sp500-2019-2023" args in
@@ -431,6 +450,7 @@ let test_resolve_out_dir_explicit _ =
       min_grade = None;
       grade_sweep = false;
       config_overrides = [];
+      warehouse_dir = None;
     }
   in
   assert_that
@@ -590,6 +610,9 @@ let suite =
          "parse_argv all flags populated" >:: test_parse_argv_all_flags;
          "parse_argv --min-grade variants" >:: test_parse_argv_min_grade;
          "parse_argv --grade-sweep" >:: test_parse_argv_grade_sweep;
+         "parse_argv --snapshot-dir" >:: test_parse_argv_snapshot_dir;
+         "parse_argv --snapshot-dir absent is None"
+         >:: test_parse_argv_snapshot_dir_absent_is_none;
          "parse_argv invalid --min-grade raises Failure"
          >:: test_parse_argv_invalid_min_grade_raises;
          "parse_argv missing --scenario raises Failure"

--- a/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_scenario_post_step.ml
@@ -130,7 +130,8 @@ let test_emit_enabled_writes_four_artefacts _ =
   let data_dir, scenario_dir = _mk_tmpdirs "post_step_on" in
   let scenario_path = _stage_fixture ~data_dir in
   _with_data_dir ~data_dir (fun () ->
-      Post_step.emit ~enabled:true ~scenario_path ~scenario_dir);
+      Post_step.emit ~enabled:true ~scenario_path ~scenario_dir
+        ~warehouse_dir:None);
   let cell =
     Filename.concat (Filename.concat scenario_dir "all_eligible") "grade-C"
   in
@@ -160,7 +161,8 @@ let test_emit_disabled_creates_no_subdir _ =
   let data_dir, scenario_dir = _mk_tmpdirs "post_step_off" in
   let scenario_path = _stage_fixture ~data_dir in
   _with_data_dir ~data_dir (fun () ->
-      Post_step.emit ~enabled:false ~scenario_path ~scenario_dir);
+      Post_step.emit ~enabled:false ~scenario_path ~scenario_dir
+        ~warehouse_dir:None);
   let all_eligible_dir = Filename.concat scenario_dir "all_eligible" in
   assert_that (Sys_unix.file_exists_exn all_eligible_dir) (equal_to false)
 
@@ -176,7 +178,7 @@ let test_emit_swallows_runner_failure _ =
   let raised =
     try
       Post_step.emit ~enabled:true ~scenario_path:bogus_scenario_path
-        ~scenario_dir;
+        ~scenario_dir ~warehouse_dir:None;
       false
     with _ -> true
   in

--- a/trading/trading/backtest/all_eligible/lib/all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible_runner.ml
@@ -23,7 +23,7 @@ module OT = Backtest_optimal.Optimal_types
 let _index_symbol = "GSPC.INDX"
 let _warmup_days = 210
 let _bar_lookback_weeks = 90
-let _snapshot_cache_mb = 256
+let _snapshot_cache_mb = Backtest.Snapshot_world.default_cache_mb ()
 
 (* ---------------------------------------------------------------- *)
 (* CLI args                                                           *)
@@ -37,6 +37,7 @@ type cli_args = {
   min_grade : Weinstein_types.grade option;
   grade_sweep : bool;
   config_overrides : Sexp.t list;
+  warehouse_dir : string option;
 }
 
 let _usage () =
@@ -52,6 +53,9 @@ let _usage () =
       "  --min-grade <F|D|C|B|A|A+>   Cascade grade floor (default: C).";
       "  --grade-sweep                Run F/D/C/B/A as a sweep; emit one \
        subdir per grade plus a top-level cross-grade summary.";
+      "  --snapshot-dir <warehouse>   Read bars from a pre-built snapshot \
+       warehouse (its manifest.sexp) instead of building from CSV data/. Use \
+       for broad universes (e.g. top-3000) the CSV store doesn't hold.";
       "  --config-overrides <sexp>    Extra config overrides (sexp list, \
        passthrough).";
     ]
@@ -94,6 +98,7 @@ let parse_argv argv =
       min_grade = None;
       grade_sweep = false;
       config_overrides = [];
+      warehouse_dir = None;
     }
   in
   let rec loop acc = function
@@ -107,6 +112,8 @@ let parse_argv argv =
     | "--min-grade" :: v :: rest ->
         loop { acc with min_grade = Some (_parse_grade v) } rest
     | "--grade-sweep" :: rest -> loop { acc with grade_sweep = true } rest
+    | "--snapshot-dir" :: v :: rest ->
+        loop { acc with warehouse_dir = Some v } rest
     | "--config-overrides" :: v :: rest ->
         loop { acc with config_overrides = _parse_overrides v } rest
     | flag :: _ -> _fail_usage (Printf.sprintf "Unknown flag: %s" flag)
@@ -146,31 +153,6 @@ let resolve_config (args : cli_args) : All_eligible.config =
   in
   let min_grade = Option.value args.min_grade ~default:base.min_grade in
   { entry_dollars; return_buckets; min_grade }
-
-(* ---------------------------------------------------------------- *)
-(* Snapshot construction (mirror of optimal-strategy runner's                *)
-(* private helper)                                                            *)
-(* ---------------------------------------------------------------- *)
-
-let _build_snapshot_callbacks ~data_dir_fpath ~universe ~start ~end_ :
-    Snapshot_callbacks.t =
-  let symbols =
-    _index_symbol :: universe |> List.dedup_and_sort ~compare:String.compare
-  in
-  let snapshot_dir, manifest =
-    Backtest.Csv_snapshot_builder.build ~data_dir:data_dir_fpath
-      ~universe:symbols ~start_date:start ~end_date:end_
-  in
-  let panels =
-    match
-      Daily_panels.create ~snapshot_dir ~manifest
-        ~max_cache_mb:_snapshot_cache_mb
-    with
-    | Ok p -> p
-    | Error err ->
-        failwithf "Daily_panels.create failed: %s" (Status.show err) ()
-  in
-  Snapshot_callbacks.of_daily_panels panels
 
 (* ---------------------------------------------------------------- *)
 (* Friday calendar                                                    *)
@@ -421,7 +403,8 @@ let format_summary_md ~scenario_name ~start_date ~end_date
     / [sectors_tbl]. Mirrors the optimal-strategy runner's private
     [_build_world] but without the macro-trend table (this diagnostic doesn't
     consume one — every Friday treats macro as [Neutral]). *)
-let _build_world ~(scenario : Scenario_lib.Scenario.t) ~universe ~sectors_tbl :
+let _build_world ~warehouse_dir ~(scenario : Scenario_lib.Scenario.t) ~universe
+    ~sectors_tbl :
     Snapshot_callbacks.t
     * (string, Screener.sector_context) Hashtbl.t
     * Date.t list =
@@ -432,8 +415,10 @@ let _build_world ~(scenario : Scenario_lib.Scenario.t) ~universe ~sectors_tbl :
     (Date.to_string warmup_start)
     (Date.to_string scenario.period.end_date);
   let snapshot_callbacks =
-    _build_snapshot_callbacks ~data_dir_fpath ~universe ~start:warmup_start
-      ~end_:scenario.period.end_date
+    Backtest.Snapshot_world.build_callbacks ~warehouse_dir
+      ~data_dir:data_dir_fpath ~index_symbol:_index_symbol ~universe
+      ~start:warmup_start ~end_:scenario.period.end_date
+      ~max_cache_mb:_snapshot_cache_mb
   in
   let sector_ctx_map = _build_sector_context_map sectors_tbl in
   let fridays =
@@ -483,7 +468,8 @@ let run_with_args (args : cli_args) : unit =
   Core_unix.mkdir_p out_dir;
   let base_config = resolve_config args in
   let snapshot_callbacks, sector_ctx_map, fridays =
-    _build_world ~scenario ~universe ~sectors_tbl
+    _build_world ~warehouse_dir:args.warehouse_dir ~scenario ~universe
+      ~sectors_tbl
   in
   let scored =
     _scan_and_score ~snapshot_callbacks ~sector_ctx_map ~fridays ~universe

--- a/trading/trading/backtest/all_eligible/lib/all_eligible_runner.mli
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible_runner.mli
@@ -96,6 +96,12 @@ type cli_args = {
           forward-compatibility but not yet threaded into the scanner config.
           Documented as inert in the public surface so callers don't expect
           behavioural change. *)
+  warehouse_dir : string option;
+      (** When [Some dir], the bar-panel world is opened over the pre-built
+          snapshot warehouse at [dir] (its [manifest.sexp]) instead of being
+          built from CSV bars under [Data_path.default_data_dir ()]. Use for
+          broad universes (e.g. top-3000) the CSV [data/] store doesn't hold.
+          [None] keeps the build-from-CSV path. Set by [--snapshot-dir]. *)
 }
 (** Parsed CLI arguments. Exposed for unit testing the parser; the binary
     consumes this through {!run_with_args}. *)

--- a/trading/trading/backtest/all_eligible/lib/scenario_post_step.ml
+++ b/trading/trading/backtest/all_eligible/lib/scenario_post_step.ml
@@ -15,7 +15,7 @@ let _all_eligible_subdir = "all_eligible"
     library defaults so the per-scenario emission is reproducible across runs
     (the host scenario_runner doesn't accept all-eligible-specific tuning
     flags). *)
-let _make_runner_args ~scenario_path ~all_eligible_dir :
+let _make_runner_args ~scenario_path ~all_eligible_dir ~warehouse_dir :
     All_eligible_runner.cli_args =
   {
     scenario_path;
@@ -25,14 +25,17 @@ let _make_runner_args ~scenario_path ~all_eligible_dir :
     min_grade = None;
     grade_sweep = false;
     config_overrides = [];
+    warehouse_dir;
   }
 
-let emit ~enabled ~scenario_path ~scenario_dir =
+let emit ~enabled ~scenario_path ~scenario_dir ~warehouse_dir =
   if not enabled then ()
   else
     let all_eligible_dir = Filename.concat scenario_dir _all_eligible_subdir in
     Core_unix.mkdir_p all_eligible_dir;
-    let args = _make_runner_args ~scenario_path ~all_eligible_dir in
+    let args =
+      _make_runner_args ~scenario_path ~all_eligible_dir ~warehouse_dir
+    in
     try All_eligible_runner.run_with_args args
     with e ->
       eprintf "all_eligible post-step: scenario:%s failed: %s\n%!" scenario_path

--- a/trading/trading/backtest/all_eligible/lib/scenario_post_step.mli
+++ b/trading/trading/backtest/all_eligible/lib/scenario_post_step.mli
@@ -36,9 +36,15 @@
     runner is invoked. This is the toggle the
     [scenario_runner.exe --no-emit-all-eligible] flag flips. *)
 
-val emit : enabled:bool -> scenario_path:string -> scenario_dir:string -> unit
-(** [emit ~enabled ~scenario_path ~scenario_dir] writes the all-eligible
-    diagnostic under [scenario_dir/all_eligible/] when [enabled = true].
+val emit :
+  enabled:bool ->
+  scenario_path:string ->
+  scenario_dir:string ->
+  warehouse_dir:string option ->
+  unit
+(** [emit ~enabled ~scenario_path ~scenario_dir ~warehouse_dir] writes the
+    all-eligible diagnostic under [scenario_dir/all_eligible/] when
+    [enabled = true].
 
     Parameters:
     - [enabled] — gate flag. When [false], the function returns immediately
@@ -47,6 +53,10 @@ val emit : enabled:bool -> scenario_path:string -> scenario_dir:string -> unit
       re-loads it (cheap; sexp-only).
     - [scenario_dir] — the per-scenario output directory the host scenario
       runner already populated with [actual.sexp] / [summary.sexp].
+    - [warehouse_dir] — when [Some dir], the diagnostic's bar world is opened
+      over that pre-built snapshot warehouse (matching the host backtest's
+      snapshot mode) instead of being built from CSV [data/]. Required for broad
+      universes the CSV store doesn't hold; [None] = build-from-CSV.
 
     Side effects (when [enabled = true]):
     - Creates [scenario_dir/all_eligible/].

--- a/trading/trading/backtest/lib/snapshot_world.ml
+++ b/trading/trading/backtest/lib/snapshot_world.ml
@@ -1,0 +1,49 @@
+open Core
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+
+(** Fallback LRU cache cap (MB) when [SNAPSHOT_CACHE_MB] is unset — sized for a
+    ~500-symbol sp500 working set. *)
+let _fallback_cache_mb = 256
+
+let default_cache_mb () =
+  match Sys.getenv "SNAPSHOT_CACHE_MB" with
+  | Some s -> (
+      try Int.of_string (String.strip s) with _ -> _fallback_cache_mb)
+  | None -> _fallback_cache_mb
+
+(** Read a pre-built warehouse's [manifest.sexp] (same convention as
+    [Bar_source_resolver]) and return [(dir, manifest)] for
+    [Daily_panels.create]. *)
+let _load_warehouse ~warehouse_dir =
+  let manifest_path = Filename.concat warehouse_dir "manifest.sexp" in
+  match Snapshot_pipeline.Snapshot_manifest.read ~path:manifest_path with
+  | Ok manifest ->
+      eprintf "snapshot_world: using snapshot warehouse %s (%d entries)\n%!"
+        warehouse_dir
+        (List.length manifest.entries);
+      (warehouse_dir, manifest)
+  | Error err ->
+      failwithf "snapshot_world: manifest read failed at %s: %s" manifest_path
+        (Status.show err) ()
+
+let build_callbacks ~warehouse_dir ~data_dir ~index_symbol ~universe ~start
+    ~end_ ~max_cache_mb : Snapshot_callbacks.t =
+  let symbols =
+    index_symbol :: universe |> List.dedup_and_sort ~compare:String.compare
+  in
+  let snapshot_dir, manifest =
+    match warehouse_dir with
+    | Some dir -> _load_warehouse ~warehouse_dir:dir
+    | None ->
+        Csv_snapshot_builder.build ~data_dir ~universe:symbols ~start_date:start
+          ~end_date:end_
+  in
+  let panels =
+    match Daily_panels.create ~snapshot_dir ~manifest ~max_cache_mb with
+    | Ok p -> p
+    | Error err ->
+        failwithf "snapshot_world: Daily_panels.create failed: %s"
+          (Status.show err) ()
+  in
+  Snapshot_callbacks.of_daily_panels panels

--- a/trading/trading/backtest/lib/snapshot_world.mli
+++ b/trading/trading/backtest/lib/snapshot_world.mli
@@ -1,0 +1,47 @@
+(** Bar-panel world construction for the diagnostic runners (optimal-strategy,
+    all-eligible).
+
+    Both runners scan a universe over a window and need a
+    {!Snapshot_runtime.Snapshot_callbacks.t} backed by a
+    {!Snapshot_runtime.Daily_panels.t}. They can source the bars two ways:
+
+    - from a {b pre-built snapshot warehouse} (its [manifest.sexp]) — used for
+      broad universes (e.g. top-3000) the CSV [data/] store doesn't hold; or
+    - by {b building an in-process snapshot from CSV} bars under a data dir (the
+      same pipeline the CSV scenario-runner mode uses).
+
+    This module unifies that construction so the two runners don't each carry a
+    near-identical private helper. *)
+
+open Core
+
+val default_cache_mb : unit -> int
+(** [default_cache_mb ()] is the LRU cache cap (MB) to pass as [max_cache_mb],
+    read from the [SNAPSHOT_CACHE_MB] env var (the same knob [scenario_runner]'s
+    snapshot mode reads), defaulting to 256 when unset/unparseable. Broad
+    universes (top-3000 ≈ 420 MB working set) need a larger cap to avoid the LRU
+    thrashing every symbol off disk each Friday. *)
+
+val build_callbacks :
+  warehouse_dir:string option ->
+  data_dir:Fpath.t ->
+  index_symbol:string ->
+  universe:string list ->
+  start:Date.t ->
+  end_:Date.t ->
+  max_cache_mb:int ->
+  Snapshot_runtime.Snapshot_callbacks.t
+(** [build_callbacks ~warehouse_dir ~data_dir ~index_symbol ~universe ~start
+     ~end_ ~max_cache_mb] opens a [Snapshot_callbacks.t] over
+    [universe ∪ {index_symbol}] for the [start..end_] window with an LRU cache
+    capped at [max_cache_mb].
+
+    When [warehouse_dir = Some dir] it reads [<dir>/manifest.sexp] and opens the
+    pre-built warehouse directly (the [data_dir] / [start] / [end_] / [universe]
+    args are unused for bar sourcing — the warehouse already holds them; the
+    scan window still bounds which Fridays the caller walks). When [None] it
+    materialises a tmp snapshot via [Csv_snapshot_builder.build] over [data_dir]
+    (left on disk; the OS reaps it on reboot).
+
+    Raises [Failure] if the warehouse manifest can't be read or
+    [Daily_panels.create] fails. *)

--- a/trading/trading/backtest/optimal/bin/optimal_strategy.ml
+++ b/trading/trading/backtest/optimal/bin/optimal_strategy.ml
@@ -13,23 +13,25 @@
 
 open Core
 
-type cli_args = { output_dir : string }
+type cli_args = { output_dir : string; warehouse_dir : string option }
 
 let _usage_and_exit () =
-  eprintf "Usage: optimal_strategy --output-dir <path>\n";
+  eprintf
+    "Usage: optimal_strategy --output-dir <path> [--snapshot-dir <warehouse>]\n";
   Stdlib.exit 1
 
 let _parse_args () : cli_args =
   let argv = Sys.get_argv () |> Array.to_list |> List.tl_exn in
-  let rec loop output_dir = function
-    | [] -> output_dir
-    | "--output-dir" :: v :: rest -> loop (Some v) rest
+  let rec loop output_dir warehouse_dir = function
+    | [] -> (output_dir, warehouse_dir)
+    | "--output-dir" :: v :: rest -> loop (Some v) warehouse_dir rest
+    | "--snapshot-dir" :: v :: rest -> loop output_dir (Some v) rest
     | _ :: _ -> _usage_and_exit ()
   in
-  match loop None argv with
-  | Some d -> { output_dir = d }
-  | None -> _usage_and_exit ()
+  match loop None None argv with
+  | Some d, warehouse_dir -> { output_dir = d; warehouse_dir }
+  | None, _ -> _usage_and_exit ()
 
 let () =
-  let { output_dir } = _parse_args () in
-  Backtest_optimal.Optimal_strategy_runner.run ~output_dir
+  let { output_dir; warehouse_dir } = _parse_args () in
+  Backtest_optimal.Optimal_strategy_runner.run ?warehouse_dir ~output_dir ()

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.ml
@@ -15,42 +15,10 @@ module OT = Optimal_types
 
 let _warmup_days = 210
 
-(** LRU cache cap for the [Daily_panels.t] backing the strategy bar reads. Sized
-    for the optimal-strategy runner's typical universe (sp500 ≈ 500 symbols ×
-    ~140 KB per symbol full-history snapshot ≈ 70 MB). 256 MB is a comfortable
-    headroom. *)
-let _snapshot_cache_mb = 256
-
-(* ---------------------------------------------------------------- *)
-(* Snapshot construction                                              *)
-(* ---------------------------------------------------------------- *)
-
-(** Build a [Snapshot_callbacks.t] over [universe ∪ {primary_index}] for the
-    [start..end_] window. Materialises a tmp snapshot directory via
-    [Csv_snapshot_builder.build] (the same in-process pipeline the CSV runner
-    mode uses), opens a [Daily_panels.t] over it with an LRU cache, and exposes
-    the field-accessor shim. The tmp directory is left in place; the OS reaps it
-    on reboot. *)
-let _build_snapshot_callbacks ~data_dir_fpath ~universe ~start ~end_ :
-    Snapshot_callbacks.t =
-  let symbols =
-    Helpers.index_symbol :: universe
-    |> List.dedup_and_sort ~compare:String.compare
-  in
-  let snapshot_dir, manifest =
-    Backtest.Csv_snapshot_builder.build ~data_dir:data_dir_fpath
-      ~universe:symbols ~start_date:start ~end_date:end_
-  in
-  let panels =
-    match
-      Daily_panels.create ~snapshot_dir ~manifest
-        ~max_cache_mb:_snapshot_cache_mb
-    with
-    | Ok p -> p
-    | Error err ->
-        failwithf "Daily_panels.create failed: %s" (Status.show err) ()
-  in
-  Snapshot_callbacks.of_daily_panels panels
+(** LRU cache cap for the [Daily_panels.t] backing the strategy bar reads. Reads
+    [SNAPSHOT_CACHE_MB] (default 256, sized for the sp500 ≈ 500-symbol working
+    set); bump it for broad top-3000 runs to avoid cache thrash. *)
+let _snapshot_cache_mb = Backtest.Snapshot_world.default_cache_mb ()
 
 (* ---------------------------------------------------------------- *)
 (* Forward-walk outlooks for the scorer                               *)
@@ -188,7 +156,7 @@ type _world = {
     optimal return. The sector_map is still loaded for
     [Helpers.build_sector_context_map], but its keys are no longer the universe
     source. *)
-let _build_world ~output_dir ~(actual_run : Report.actual_run)
+let _build_world ~warehouse_dir ~output_dir ~(actual_run : Report.actual_run)
     ~(universe : string list) : _world =
   let data_dir_fpath = Data_path.default_data_dir () in
   let sectors_tbl = Sector_map.load ~data_dir:data_dir_fpath in
@@ -198,8 +166,10 @@ let _build_world ~output_dir ~(actual_run : Report.actual_run)
     (Date.to_string warmup_start)
     (Date.to_string actual_run.end_date);
   let snapshot_callbacks =
-    _build_snapshot_callbacks ~data_dir_fpath ~universe ~start:warmup_start
-      ~end_:actual_run.end_date
+    Backtest.Snapshot_world.build_callbacks ~warehouse_dir
+      ~data_dir:data_dir_fpath ~index_symbol:Helpers.index_symbol ~universe
+      ~start:warmup_start ~end_:actual_run.end_date
+      ~max_cache_mb:_snapshot_cache_mb
   in
   let sector_ctx_map = Helpers.build_sector_context_map sectors_tbl in
   let fridays =
@@ -268,7 +238,7 @@ let _emit_report ~output_dir ~(actual_run : Report.actual_run) ~scored : unit =
       relaxed_macro = relaxed_macro.summary;
     }
 
-let run ~output_dir =
+let run ?warehouse_dir ~output_dir () =
   eprintf "optimal_strategy: reading artefacts from %s\n%!" output_dir;
   let inputs = Optimal_run_artefacts.load ~output_dir in
   let actual_run = _build_actual_run inputs in
@@ -276,6 +246,9 @@ let run ~output_dir =
     (Date.to_string actual_run.start_date)
     (Date.to_string actual_run.end_date)
     actual_run.universe_size;
-  let world = _build_world ~output_dir ~actual_run ~universe:inputs.universe in
+  let world =
+    _build_world ~warehouse_dir ~output_dir ~actual_run
+      ~universe:inputs.universe
+  in
   let scored = _scan_and_score ~world in
   _emit_report ~output_dir ~actual_run ~scored

--- a/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_strategy_runner.mli
@@ -101,15 +101,18 @@ val load_macro_trend :
     [Weinstein_types.Neutral]. Exposed for direct unit testing; the runner
     itself consumes it through {!run}. *)
 
-val run : output_dir:string -> unit
-(** [run ~output_dir] executes the full pipeline end-to-end:
+val run : ?warehouse_dir:string -> output_dir:string -> unit -> unit
+(** [run ?warehouse_dir ~output_dir ()] executes the full pipeline end-to-end:
 
     1. Loads actual-run artefacts from [output_dir] via
-    {!Optimal_run_artefacts.load}. 2. Builds the bar-panel world from
-    [Data_path.default_data_dir ()]. 3. Scans every Friday in the run window for
-    breakout candidates and scores each with a forward weekly walk. 4. Fills +
-    summarises the Constrained and Relaxed_macro variants, renders the markdown
-    report, and writes it to [<output_dir>/optimal_strategy.md].
+    {!Optimal_run_artefacts.load}. 2. Builds the bar-panel world — from the
+    pre-built snapshot warehouse at [warehouse_dir] when given (reads its
+    [manifest.sexp] and opens it directly, for broad universes the CSV [data/]
+    store doesn't hold), otherwise from [Data_path.default_data_dir ()]. 3.
+    Scans every Friday in the run window for breakout candidates and scores each
+    with a forward weekly walk. 4. Fills + summarises the Constrained and
+    Relaxed_macro variants, renders the markdown report, and writes it to
+    [<output_dir>/optimal_strategy.md].
 
     Raises [Failure] if [summary.sexp] or [actual.sexp] is missing / malformed,
     or if snapshot construction fails (corrupt CSVs, missing benchmark, etc.).

--- a/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_strategy_runner.ml
@@ -172,7 +172,7 @@ let test_run_emits_optimal_strategy_md _ =
   let data_dir, output_dir = _mk_tmpdirs "opt_runner_smoke" in
   _stage_fixture ~data_dir ~output_dir;
   _with_data_dir ~data_dir (fun () ->
-      Backtest_optimal.Optimal_strategy_runner.run ~output_dir);
+      Backtest_optimal.Optimal_strategy_runner.run ~output_dir ());
   let report_path = Filename.concat output_dir "optimal_strategy.md" in
   let exists = Sys_unix.file_exists_exn report_path in
   let body = if exists then In_channel.read_all report_path else "" in
@@ -257,7 +257,7 @@ let test_run_consumes_macro_trend_sexp _ =
       (Date.of_string "2024-01-26", Weinstein_types.Bearish);
     ];
   _with_data_dir ~data_dir (fun () ->
-      Backtest_optimal.Optimal_strategy_runner.run ~output_dir);
+      Backtest_optimal.Optimal_strategy_runner.run ~output_dir ());
   let report_path = Filename.concat output_dir "optimal_strategy.md" in
   let body = In_channel.read_all report_path in
   assert_that body
@@ -276,7 +276,7 @@ let test_run_emits_optimal_summary_sexp _ =
   let data_dir, output_dir = _mk_tmpdirs "opt_runner_summary_sexp" in
   _stage_fixture ~data_dir ~output_dir;
   _with_data_dir ~data_dir (fun () ->
-      Backtest_optimal.Optimal_strategy_runner.run ~output_dir);
+      Backtest_optimal.Optimal_strategy_runner.run ~output_dir ());
   let sexp_path = Filename.concat output_dir "optimal_summary.sexp" in
   let exists = Sys_unix.file_exists_exn sexp_path in
   let body = if exists then In_channel.read_all sexp_path else "" in
@@ -304,7 +304,7 @@ let test_run_handles_missing_trade_audit _ =
   let audit_path = Filename.concat output_dir "trade_audit.sexp" in
   assert_that (Sys_unix.file_exists_exn audit_path) (equal_to false);
   _with_data_dir ~data_dir (fun () ->
-      Backtest_optimal.Optimal_strategy_runner.run ~output_dir);
+      Backtest_optimal.Optimal_strategy_runner.run ~output_dir ());
   let report_path = Filename.concat output_dir "optimal_strategy.md" in
   let body = In_channel.read_all report_path in
   assert_that body

--- a/trading/trading/backtest/scenarios/scenario_runner.ml
+++ b/trading/trading/backtest/scenarios/scenario_runner.ml
@@ -336,8 +336,16 @@ let _run_scenario_in_child ~output_root ~fixtures_root ~progress_every
      [all_eligible_runner.exe] invocation. Failures inside the runner are
      logged + swallowed by [Scenario_post_step.emit] so a diagnostic crash
      never aborts the parent scenario. *)
+  (* In snapshot mode, hand the diagnostic the same warehouse the backtest used
+     so it works on broad universes the CSV [data/] store doesn't hold. *)
+  let warehouse_dir =
+    match bar_data_source with
+    | Some (Backtest.Bar_data_source.Snapshot { snapshot_dir; _ }) ->
+        Some snapshot_dir
+    | Some Backtest.Bar_data_source.Csv | None -> None
+  in
   Backtest_all_eligible.Scenario_post_step.emit ~enabled:emit_all_eligible
-    ~scenario_path ~scenario_dir
+    ~scenario_path ~scenario_dir ~warehouse_dir
 
 (* Fork-based worker pool. Scenarios run in parallel child processes up to
    [parallel] at a time. *)


### PR DESCRIPTION
## What
Adds `--snapshot-dir <warehouse>` to the **optimal-strategy** and **all-eligible** runners (and threads it through `scenario_runner`'s all-eligible post-step, derived from the backtest's `bar_data_source`). When given, the runner opens a `Daily_panels.t` over a pre-built snapshot warehouse (reads its `manifest.sexp` — same pattern as `Bar_source_resolver`) instead of building an in-process snapshot from CSV `data/`.

## Why
These diagnostic runners were CSV-only (built their world from `Data_path.default_data_dir()`), so broad universes (top-1000/3000) the CSV store doesn't hold couldn't be analyzed — blocking the 'optimal strategy / missed-trades' lens on broad universes without a 3000-name EODHD fetch. The snapshot warehouse already exists and `Daily_panels` is format-detecting (#1626/#1631), so this is a localized data-source seam.

## Change
- `Optimal_strategy_runner.run` gains `?warehouse_dir`; `optimal_strategy.exe --snapshot-dir`.
- `All_eligible_runner` `cli_args.warehouse_dir` + `--snapshot-dir`; threaded through `run_with_args` → `_build_world` → `_build_snapshot_callbacks`.
- `Scenario_post_step.emit ~warehouse_dir`; `scenario_runner` passes the snapshot dir when in snapshot mode (so broad scenario runs auto-emit all-eligible against the warehouse instead of failing on missing CSV).
- Default (no flag) = unchanged build-from-CSV path; bit-identical to today.

## Test
`dune build` + `dune runtest` green for both runner dirs. New parser tests pin `--snapshot-dir` → `Some` / absent → `None`. CSV-path smoke tests unchanged. (No domain/strategy logic — pure tooling data-source seam.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)