### PR TITLE
feat(goldens): promote concentration 0.14 → 0.30 (long-only goldens)

### DIFF
--- a/dev/notes/concentration-0.30-goldens-repin-2026-06-25.md
+++ b/dev/notes/concentration-0.30-goldens-repin-2026-06-25.md
@@ -1,0 +1,66 @@
+# Concentration = 0.30 — long-only goldens re-pin (2026-06-25)
+
+Re-pins the long-only regression goldens from `max_position_pct_long 0.14 → 0.30`
+(the production default) so the research basis **matches production**. Authorized by
+the user on the back of the broad top-3000 WF-CV ACCEPT
+(`2026-06-25-capacity-concentration-broad`). **Not a live-behavior change** — the
+canonical default is already 0.30; production already runs it. The goldens were
+artificially overriding *down* to 0.14, so they were **mis-stating** production.
+
+## Store resolution (the earlier "data-store landmine", resolved)
+Each golden is re-measured against **the store its own validator uses**, both
+reproducible locally:
+- **sp500 goldens** → committed `test_data` CSV (set `TRADING_DATA_DIR`), the
+  `golden-runs-sp500-15y` cron store. Verified: each reproduces its prior 0.14 band
+  against test_data before the change.
+- **broad goldens** → the delisting-complete warehouse (`--snapshot-dir
+  /tmp/snap_top3000_1998_2026`), the #1733/#1738 standard.
+
+The earlier blocker (same golden → 23.5% / 49.1% / ≤30-band across three stores) was
+running against the *wrong* store (gitignored `data/`). None of these 8 goldens is in
+PR CI (all postsubmit / local-verify), so the re-pin cannot break the PR build.
+
+## The honest per-window picture — 0.30 is regime-dependent
+
+| golden | window | 0.14 → 0.30 return | verdict |
+|--------|-------:|-------------------:|---------|
+| sp500-2010-2026 | 16y | 340 → **672%** (DD 19→**18%**, Sharpe 0.84→0.92, Calmar 0.49→0.74) | 0.30 dominates |
+| sp500-1998-2026 | 28y | 227% (sentinel band) | ✓ |
+| decade-2014-2023 | 10y | 95 → **134%** (DD 37→39) | 0.30 better |
+| covid-recovery-2020-2024 | 4y | 41 → **53%** (Sharpe 0.46→0.57) | 0.30 better |
+| sp500-30y-capacity-1996 | 30y | 952% (sentinel band) | ✓ |
+| sp500-2019-2023-long-only | 5y | 26 → 41% (DD 31→**39%**, Calmar ~flat) | wash (return-for-DD) |
+| **bull-crash-2015-2020** | 5y | 38 → **10%** (Sharpe 0.47→0.18) | **0.30 hurts** |
+| **six-year-2018-2023** | 6y | 19 → **4%** (Sharpe 0.28→0.11) | **0.30 hurts** |
+
+**0.30 helps the long / multi-regime windows (where the broad WF-CV ACCEPT came from)
+and the aggregate, but HURTS some short windows** (bull-crash, six-year). This is the
+same high-dispersion signature the broad surface showed (σ roughly doubles with
+concentration). The ACCEPT is a **broad-aggregate verdict, not a per-window guarantee**
+— concentrating capital amplifies the fat tail, which pays off across a full cycle but
+can sting in a single short window where the concentrated names underperform.
+
+This is exactly why re-pinning matters: at 0.14 the goldens **overstated** production
+on the short windows (showing 38% / 19% when production does 10% / 4%) and
+**understated** it on the long windows (340% vs the true 672%). 0.30 is the honest
+production picture, warts and all.
+
+## Scope — what was and wasn't touched
+**Re-pinned (8, long-only):** `goldens-sp500/sp500-2019-2023-long-only`,
+`goldens-sp500-historical/{sp500-1998-2026, sp500-2010-2026}`,
+`goldens-broad/{decade-2014-2023, six-year-2018-2023, bull-crash-2015-2020,
+covid-recovery-2020-2024, sp500-30y-capacity-1996}`.
+
+**Deliberately NOT touched:**
+- `experiments/*` — frozen historical experiment records (config is part of the record).
+- Any `*-longshort* / enable_short_side true` golden — 0.14 has a real
+  force-liquidation-cascade rationale on the short side; re-pin separately if at all.
+- `goldens-small/*` smoke variants — left at 0.14 for now (fast-CI smoke; a follow-up
+  could align them for consistency, lower priority).
+- The canonical default config — already 0.30; no code change.
+
+## Verification
+Every re-pinned golden re-run against its store **PASSES** the new bands (3/3 sp500 via
+test_data, 5/5 broad via warehouse). Bands: ±15% (sp500) / ±20% (broad) around the 0.30
+actuals; wide absolute bands on the two near-zero-return windows (six-year, bull-crash)
+to absorb their volatility.

--- a/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
@@ -40,7 +40,7 @@
  (universe_size 1000)
  (config_overrides
   (((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -48,9 +48,15 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min 30.3) (max 45.5)))
-   (total_trades       ((min 207) (max 311)))
-   (win_rate           ((min 29.7) (max 39.7)))
-   (sharpe_ratio       ((min 0.38) (max 0.57)))
-   (max_drawdown_pct   ((min 14.0) (max 20.9)))
-   (avg_holding_days   ((min 35.0) (max 52.6))))))
+  ;; Concentration=0.30 promotion 2026-06-25 (max_position_pct_long 0.14 -> 0.30, the
+  ;; production default; ledger 2026-06-25-capacity-concentration-broad). Warehouse
+  ;; re-measure. ⚠ 0.30 HURTS this 5y window: ret 37.91 -> 10.44, sharpe 0.47 -> 0.184
+  ;; (concentration is regime-dependent — helps long/aggregate windows, hurts some
+  ;; short ones; the ACCEPT is a broad-aggregate verdict, not per-window).
+  ;; Wide bands around the near-zero 0.30 actuals (ret 10.44 sharpe 0.184 maxDD 22.65).
+  ((total_return_pct   ((min -3.0)  (max 24.0)))
+   (total_trades       ((min 175)   (max 237)))
+   (win_rate           ((min 33.8)  (max 43.8)))
+   (sharpe_ratio       ((min -0.05) (max 0.42)))
+   (max_drawdown_pct   ((min 18.1)  (max 27.2)))
+   (avg_holding_days   ((min 37.7)  (max 56.5))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
@@ -43,7 +43,7 @@
  (universe_size 1000)
  (config_overrides
   (((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -51,9 +51,13 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min  28.2)  (max  42.4)))
-   (total_trades       ((min 222)    (max 332)))
-   (win_rate           ((min  30.7)  (max  40.7)))
-   (sharpe_ratio       ((min   0.38) (max   0.56)))
-   (max_drawdown_pct   ((min  23.8)  (max  35.7)))
-   (avg_holding_days   ((min  31.3)  (max  46.9))))))
+  ;; Concentration=0.30 promotion 2026-06-25 (max_position_pct_long 0.14 -> 0.30, the
+  ;; production default; ledger 2026-06-25-capacity-concentration-broad). Warehouse
+  ;; re-measure, ±20% around 0.30 actuals (ret 52.86 sharpe 0.571 maxDD 34.55).
+  ;; 0.30 lifts this 4y window's return (41->53%) and sharpe (0.46->0.57).
+  ((total_return_pct   ((min  42.3)  (max  63.4)))
+   (total_trades       ((min 187)    (max 281)))
+   (win_rate           ((min  33.9)  (max  43.9)))
+   (sharpe_ratio       ((min   0.46) (max   0.69)))
+   (max_drawdown_pct   ((min  27.6)  (max  41.5)))
+   (avg_holding_days   ((min  34.0)  (max  51.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
@@ -39,7 +39,7 @@
  (universe_size 1000)
  (config_overrides
   (((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -47,9 +47,13 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min 76.2) (max 114.3)))
-   (total_trades       ((min 370) (max 554)))
-   (win_rate           ((min 27.3) (max 37.3)))
-   (sharpe_ratio       ((min 0.40) (max 0.60)))
-   (max_drawdown_pct   ((min 29.7) (max 44.5)))
-   (avg_holding_days   ((min 36.2) (max 54.2))))))
+  ;; Concentration=0.30 promotion 2026-06-25 (max_position_pct_long 0.14 -> 0.30, the
+  ;; production default; ledger 2026-06-25-capacity-concentration-broad). Warehouse
+  ;; re-measure, ±20% around 0.30 actuals (ret 133.77 sharpe 0.565 maxDD 38.76).
+  ;; 0.30 lifts this 10y window's return (95->134%) at a modest DD rise (37->39%).
+  ((total_return_pct   ((min 107.0) (max 160.5)))
+   (total_trades       ((min 294) (max 440)))
+   (win_rate           ((min 33.1) (max 43.1)))
+   (sharpe_ratio       ((min 0.45) (max 0.68)))
+   (max_drawdown_pct   ((min 31.0) (max 46.5)))
+   (avg_holding_days   ((min 42.7) (max 64.1))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
@@ -41,7 +41,7 @@
  (universe_size 1000)
  (config_overrides
   (((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -49,9 +49,15 @@
    ((enable_laggard_rotation true))
    ((laggard_rotation_config ((hysteresis_weeks 2))))))
  (expected
-  ((total_return_pct   ((min 15.6) (max 23.3)))
-   (total_trades       ((min 224) (max 336)))
-   (win_rate           ((min 30.7) (max 40.7)))
-   (sharpe_ratio       ((min 0.23) (max 0.34)))
-   (max_drawdown_pct   ((min 17.4) (max 26.1)))
-   (avg_holding_days   ((min 31.7) (max 47.6))))))
+  ;; Concentration=0.30 promotion 2026-06-25 (max_position_pct_long 0.14 -> 0.30, the
+  ;; production default; ledger 2026-06-25-capacity-concentration-broad). Warehouse
+  ;; re-measure. ⚠ 0.30 HURTS this 6y window: ret 19.45 -> 4.02, sharpe 0.28 -> 0.115
+  ;; (concentration is regime-dependent — helps the long/aggregate windows, hurts
+  ;; some short ones; the ACCEPT is a broad-aggregate verdict, not per-window).
+  ;; Wide bands around the near-zero 0.30 actuals (ret 4.02 sharpe 0.115 maxDD 24.70).
+  ((total_return_pct   ((min -8.0)  (max 16.0)))
+   (total_trades       ((min 176)   (max 238)))
+   (win_rate           ((min 33.2)  (max 43.2)))
+   (sharpe_ratio       ((min -0.10) (max 0.33)))
+   (max_drawdown_pct   ((min 19.8)  (max 29.6)))
+   (avg_holding_days   ((min 35.8)  (max 53.7))))))

--- a/trading/test_data/backtest_scenarios/goldens-broad/sp500-30y-capacity-1996.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/sp500-30y-capacity-1996.sexp
@@ -47,7 +47,7 @@
  (config_overrides
   (((universe_cap (1000)))
    ((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -60,6 +60,9 @@
  ;; dev/notes/n1000-30y-capacity-2026-04-30.md and the ranges below
  ;; merely confirm the run finished sanely.
  (expected
+  ;; Concentration=0.30 promotion 2026-06-25 (max_position_pct_long 0.14 -> 0.30, the
+  ;; production default; ledger 2026-06-25-capacity-concentration-broad). Capacity-test
+  ;; sentinel bands; 0.30 measured ret 951.9% / 958 trades / 40.9% win / 33.9% DD (PASS).
   ((total_return_pct   ((min -1000.0)      (max 1000000.0)))
    (total_trades       ((min 0)            (max 100000)))
    (win_rate           ((min 0.0)          (max 100.0)))

--- a/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-1998-2026.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-1998-2026.sexp
@@ -37,7 +37,7 @@
  ;; Cell E config — identical to sp500-2010-2026.sexp.
  (config_overrides
   (((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -54,6 +54,9 @@
  ;; crashes / NaN sentinels. Tightening per-fold bands is downstream of
  ;; T4.4 (sanity backtest) and T4.5 (sweep harvest).
  (expected
+  ;; Concentration=0.30 promotion 2026-06-25 (max_position_pct_long 0.14 -> 0.30, the
+  ;; production default; ledger 2026-06-25-capacity-concentration-broad). Catch-only
+  ;; sentinel bands; 0.30 measured ret 227.5% / 673 trades / 40.6% win / 28.5% DD (PASS).
   ((total_return_pct  ((min -90.0)  (max 5000.0)))
    (total_trades      ((min   0.0)  (max 100000.0)))
    (win_rate          ((min   0.0)  (max 100.0)))

--- a/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026.sexp
@@ -70,7 +70,7 @@
  ;; (28 → 18.4) while running 22x more trades (40 → 806). Tolerances ±15%.
  (config_overrides
   (((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -125,16 +125,22 @@
  ;; variance. NOTE: this golden is perf-tier 3-historical (NOT in PR CI), so the
  ;; stale pin never surfaced as a CI failure — local goldens drift silently.
  (expected
-  ;; Re-pinned 2026-06-23 for the A-D-live default flip (synthetic breadth tail).
-  ;; ±15% around A-D-live actuals; grid ACCEPT (dev/backtest/ad-grid-2026-06-23).
-  ((total_return_pct   ((min 294.0)         (max 398.0)))
-   (total_trades       ((min 678)           (max  918)))
-   (win_rate           ((min  30.9)         (max  41.8)))
-   (sharpe_ratio       ((min   0.62)        (max   0.84)))
-   (max_drawdown_pct   ((min  19.1)         (max  25.8)))
-   (avg_holding_days   ((min  37.1)         (max  50.2)))
-   (open_positions_value ((min 3256000.0)   (max 4406000.0)))
-   (sortino_ratio_annualized ((min  0.94)   (max   1.27)))
-   (calmar_ratio       ((min   0.36)        (max   0.49)))
-   (ulcer_index        ((min   7.35)        (max   9.95)))
+  ;; Re-pinned 2026-06-25 for the concentration=0.30 promotion (max_position_pct_long
+  ;; 0.14 -> 0.30, the production default; broad top-3000 WF-CV ACCEPT, ledger
+  ;; 2026-06-25-capacity-concentration-broad). Measured against test_data, ±15% around
+  ;; 0.30 actuals: ret 671.90  trades 558  win 42.29  sharpe 0.92  maxDD 18.07
+  ;;   open_pos 6117646  sortino 1.49  calmar 0.74  ulcer 5.99.
+  ;; Over the 16y multi-regime window 0.30 DOMINATES the prior 0.14 pin (ret 340->672,
+  ;; sharpe 0.84->0.92, calmar 0.49->0.74) AND lowers DD (19->18) — concentration's
+  ;; risk-adjusted win is clear on the long window (vs ~flat on the short 2019-2023).
+  ((total_return_pct   ((min 571.0)         (max 773.0)))
+   (total_trades       ((min 474)           (max  642)))
+   (win_rate           ((min  35.9)         (max  48.6)))
+   (sharpe_ratio       ((min   0.78)        (max   1.06)))
+   (max_drawdown_pct   ((min  15.4)         (max  20.8)))
+   (avg_holding_days   ((min  37.1)         (max  52.0)))
+   (open_positions_value ((min 5200000.0)   (max 7035000.0)))
+   (sortino_ratio_annualized ((min  1.27)   (max   1.71)))
+   (calmar_ratio       ((min   0.63)        (max   0.85)))
+   (ulcer_index        ((min   5.09)        (max   6.89)))
    (wall_seconds       ((min 300.0)         (max 3600.0))))))

--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
@@ -57,7 +57,7 @@
  ;; MaxDD cut 6.7pp (31 → 24), trade count 3.4x. Tolerances ±15%.
  (config_overrides
   (((enable_short_side false))
-   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
    ((portfolio_config ((max_long_exposure_pct 0.70))))
    ((portfolio_config ((min_cash_pct 0.30))))
    ((enable_stage3_force_exit true))
@@ -74,18 +74,22 @@
    (bid_ask_spread_bps 5.0)
    (market_impact_bps_per_pct_adv 0.0)))
  (expected
-  ;; Re-pinned 2026-06-23 for the A-D-live default flip (synthetic breadth tail).
-  ;; ±15% around A-D-live actuals; grid ACCEPT (dev/backtest/ad-grid-2026-06-23).
-  ;; Long-only 2019-2023 fell sharply (ret 66→26): A-D-live's conservative COVID
-  ;; gate, and long-only can't exploit the breadth's short-timing edge.
-  ((total_return_pct   ((min  22.2)        (max  30.0)))
-   (total_trades       ((min 237)          (max 321)))
-   (win_rate           ((min  30.2)        (max  40.8)))
-   (sharpe_ratio       ((min   0.32)       (max   0.43)))
-   (max_drawdown_pct   ((min  26.5)        (max  35.9)))
-   (avg_holding_days   ((min  32.7)        (max  44.2)))
-   (open_positions_value ((min 798000.0)   (max 1080000.0)))
-   (sortino_ratio_annualized ((min 0.37)   (max 0.50)))
-   (calmar_ratio       ((min   0.13)       (max   0.18)))
-   (ulcer_index        ((min  11.1)        (max  15.1)))
+  ;; Re-pinned 2026-06-25 for the concentration=0.30 promotion (max_position_pct_long
+  ;; 0.14 -> 0.30, the production default; broad top-3000 WF-CV ACCEPT, ledger
+  ;; 2026-06-25-capacity-concentration-broad). Measured against test_data (the
+  ;; golden-runs-sp500-15y store), ±15% around 0.30 actuals:
+  ;;   ret 41.13  trades 207  win 37.2  sharpe 0.47  maxDD 38.96  hold 45.86
+  ;;   sortino 0.58  calmar 0.18  ulcer 15.46
+  ;; vs prior 0.14 pin (ret 26 / maxDD 31): 0.30 = the honest production risk profile
+  ;; (higher return AND higher DD); the 0.14 override understated it.
+  ((total_return_pct   ((min  34.9)        (max  47.3)))
+   (total_trades       ((min 176)          (max 238)))
+   (win_rate           ((min  31.6)        (max  42.8)))
+   (sharpe_ratio       ((min   0.40)       (max   0.54)))
+   (max_drawdown_pct   ((min  33.1)        (max  44.8)))
+   (avg_holding_days   ((min  39.0)        (max  52.7)))
+   (open_positions_value ((min 798000.0)   (max 1300000.0)))
+   (sortino_ratio_annualized ((min 0.49)   (max 0.67)))
+   (calmar_ratio       ((min   0.15)       (max   0.21)))
+   (ulcer_index        ((min  13.1)        (max  17.8)))
    (wall_seconds       ((min 100.0)        (max 1500.0))))))


### PR DESCRIPTION
## What
Re-pins the **8 long-only regression goldens** from `max_position_pct_long 0.14 → 0.30` (the production default), so the research basis matches production. Authorized by the user on the broad top-3000 WF-CV **ACCEPT** (ledger `2026-06-25-capacity-concentration-broad`).

**Not a live-behavior change** — the canonical default is already 0.30; production already runs it. The goldens were overriding *down* to 0.14, **mis-stating** production. No code change.

## Each golden re-measured against its validator's store (both reproducible)
- sp500 goldens → committed `test_data` CSV (`TRADING_DATA_DIR`, the `golden-runs-sp500-15y` cron store)
- broad goldens → delisting-complete warehouse (`--snapshot-dir`)

**All 8 re-verified PASS** (3/3 sp500, 5/5 broad). None is in PR CI (all postsubmit/local-verify), so this can't break the PR build.

## The honest per-window picture — 0.30 is regime-dependent
| golden | window | 0.14 → 0.30 return | |
|---|---:|---:|---|
| sp500-2010-2026 | 16y | 340 → **672%** (DD 19→**18%**) | dominates |
| decade-2014-2023 | 10y | 95 → **134%** | better |
| covid-recovery | 4y | 41 → **53%** | better |
| sp500-1998-2026 / 30y-capacity | 28y/30y | 227% / 952% (sentinel) | ✓ |
| sp500-2019-2023 | 5y | 26 → 41% (DD 31→39) | wash |
| **bull-crash-2015-2020** | 5y | 38 → **10%** | **hurts** |
| **six-year-2018-2023** | 6y | 19 → **4%** | **hurts** |

0.30 helps the long/aggregate windows (where the ACCEPT came from) but **hurts some short windows** — concentration is regime-dependent (high dispersion). At 0.14 the goldens *overstated* production on short windows and *understated* it on long ones; 0.30 is the honest picture. Full detail: `dev/notes/concentration-0.30-goldens-repin-2026-06-25.md`.

## Scope
Long-only only. **Excludes** `experiments/*` (frozen records), `*-longshort*` (short-side cascade rationale), `goldens-small/*` smoke variants. 8 goldens + 1 note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)