### PR TITLE
docs(goldens): fix stale max_position_pct_long=0.14 prose comments after 0.30 re-pin

### DIFF
--- a/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/bull-crash-2015-2020.sexp
@@ -11,7 +11,7 @@
 ;; because of a regression — see the migration plan for the diagnosis.
 ;;
 ;; enable_short_side stays false (short-side gaps G1-G4, dev/notes/short-side-gaps-2026-04-29.md).
-;; Cell E config (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
+;; Cell E config (max_position_pct_long=0.30, max_long_exposure_pct=0.70, min_cash_pct=0.30,
 ;; stage3 force-exit h=1, laggard rotation h=2).
 ;;
 ;; Measured 2026-06-05 (Cell E, PIT top-1000-2015). Tolerances ±20%

--- a/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/covid-recovery-2020-2024.sexp
@@ -12,7 +12,7 @@
 ;; see the migration plan for the full diagnosis.
 ;;
 ;; enable_short_side stays false (short-side gaps G1-G4, dev/notes/short-side-gaps-2026-04-29.md).
-;; Cell E config (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
+;; Cell E config (max_position_pct_long=0.30, max_long_exposure_pct=0.70, min_cash_pct=0.30,
 ;; stage3 force-exit h=1, laggard rotation h=2).
 ;;
 ;; Measured 2026-06-05 (Cell E, PIT top-1000-2020):

--- a/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/decade-2014-2023.sexp
@@ -11,7 +11,7 @@
 ;; because of a regression — see the migration plan for the diagnosis.
 ;;
 ;; enable_short_side stays false (short-side gaps G1-G4, dev/notes/short-side-gaps-2026-04-29.md).
-;; Cell E config (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
+;; Cell E config (max_position_pct_long=0.30, max_long_exposure_pct=0.70, min_cash_pct=0.30,
 ;; stage3 force-exit h=1, laggard rotation h=2).
 ;;
 ;; Measured 2026-06-05 (Cell E, PIT top-1000-2014). Tolerances ±20%

--- a/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/six-year-2018-2023.sexp
@@ -11,7 +11,7 @@
 ;; because of a regression — see the migration plan for the diagnosis.
 ;;
 ;; enable_short_side stays false (short-side gaps G1-G4, dev/notes/short-side-gaps-2026-04-29.md).
-;; Cell E config (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
+;; Cell E config (max_position_pct_long=0.30, max_long_exposure_pct=0.70, min_cash_pct=0.30,
 ;; stage3 force-exit h=1, laggard rotation h=2).
 ;;
 ;; Measured 2026-06-05 (Cell E, PIT top-1000-2018). Tolerances ±20%

--- a/trading/test_data/backtest_scenarios/goldens-broad/sp500-30y-capacity-1996.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-broad/sp500-30y-capacity-1996.sexp
@@ -40,7 +40,7 @@
  (universe_path "universes/broad-1000-30y.sexp")
  (universe_size 1000)
  ;; Cell E rollout 2026-05-11: applies the standard Cell E strategy config
- ;; (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
+ ;; (max_position_pct_long=0.30, max_long_exposure_pct=0.70, min_cash_pct=0.30,
  ;; stage3 force-exit h=1, laggard rotation h=2) for consistency with the
  ;; rest of the goldens. Capacity testing isn't affected by the config knobs
  ;; — pin ranges are intentionally wide and tolerate the new shape.

--- a/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500/sp500-2019-2023-long-only.sexp
@@ -46,7 +46,7 @@
  (universe_path "universes/sp500.sexp")
  (universe_size 503)
  ;; Cell E rollout 2026-05-11: applies the new standard strategy config
- ;; (max_position_pct_long=0.14, max_long_exposure_pct=0.70, min_cash_pct=0.30,
+ ;; (max_position_pct_long=0.30, max_long_exposure_pct=0.70, min_cash_pct=0.30,
  ;; stage3 force-exit h=1, laggard rotation h=2). Replaces prior 0.30/0.90/0.10
  ;; default-sized baseline (79.74% / 74 trades / 30.8% DD).
  ;; Measured 2026-05-12 (Cell E, post-#1052 force-liq fix + #1053 metric schema):


### PR DESCRIPTION
Follow-up to #1753. The re-pin updated config + expected-block comments to 0.30 but left a stale descriptive `Cell E config (max_position_pct_long=0.14, ...)` line in 6 goldens, making them self-contradictory. Comment-only, behavior-neutral (config + bands unchanged). The with-shorts `sp500-2019-2023.sexp` correctly keeps 0.14 (out of re-pin scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)