### PR TITLE
[main-fix] arch_layer: whitelist stage_chart trailing-stop deps

### DIFF
--- a/trading/devtools/checks/linter_exceptions.conf
+++ b/trading/devtools/checks/linter_exceptions.conf
@@ -39,3 +39,5 @@ nesting analysis/scripts/universe_filter  CSV parsing + multi-rule sexp pattern 
 nesting analysis/scripts/fetch_finviz_sectors  HTTP fetch + HTML parsing + manifest I/O inherently nests; these are one-shot operator scripts not hot-path code  # review_at: never (operator script)
 nesting analysis/scripts/shiller_weinstein_decades  one-shot analysis script (M1 cross-cycle plan); CSV parsing + degenerate-input guards in compute helpers; no hot-path callers  # review_at: never (analysis script)
 nesting analysis/scripts/hold_period_per_stage_analysis  one-shot analysis script (P4 hold-period probe); CSV parser handles 10+ optional columns; no hot-path callers  # review_at: never (analysis script)
+
+arch_layer analysis/scripts/stage_chart  Diagnostic viz tool replays the Weinstein_stops state machine to draw the true trailing stop; uses Trading_base.Types.position_side (shared Long | Short domain variant) + weinstein_trading.stops. Not trading-core logic embedded in analysis.  # review_at: never (diagnostic visualization tool)


### PR DESCRIPTION
Fixes red main. PR #1771 added `weinstein_trading.stops` + `trading.base` to stage_chart (trailing-stop replay), tripping the arch_layer linter (analysis/ → trading/trading/). Adds an arch_layer exception mirroring the existing `analysis/weinstein/screener` one — `position_side` is a shared Long|Short domain variant and the stop machine is replayed for diagnostic viz, not trading-core logic in analysis. 1-line conf change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)