### PR TITLE
feat(strategy): declining-MA long-entry gate (default-off)

### DIFF
--- a/trading/trading/weinstein/strategy/gate/declining_ma/lib/declining_ma_gate.ml
+++ b/trading/trading/weinstein/strategy/gate/declining_ma/lib/declining_ma_gate.ml
@@ -1,0 +1,15 @@
+open Core
+
+(* A long whose 30-week MA is still declining at entry is a misclassified
+   Stage-2 (a counter-trend bounce). Shorts keep a declining MA. *)
+let _keep (c : Screener.scored_candidate) =
+  match c.Screener.side with
+  | Trading_base.Types.Short -> true
+  | Trading_base.Types.Long ->
+      not
+        (Weinstein_types.equal_ma_direction
+           c.Screener.analysis.Stock_analysis.stage.Stage.ma_direction
+           Weinstein_types.Declining)
+
+let filter ~reject candidates =
+  if not reject then candidates else List.filter candidates ~f:_keep

--- a/trading/trading/weinstein/strategy/gate/declining_ma/lib/declining_ma_gate.mli
+++ b/trading/trading/weinstein/strategy/gate/declining_ma/lib/declining_ma_gate.mli
@@ -1,0 +1,26 @@
+(** Long-entry faithfulness gate: drop long candidates whose 30-week MA is still
+    {b declining} at entry.
+
+    Weinstein Stage 2 is defined as price above a {e rising} 30-week MA. The
+    stage classifier nonetheless tags a minority of breakouts [Stage2] while the
+    MA is still declining — these are counter-trend bounces inside a Stage-4
+    downtrend (e.g. dead-cat bounces under a prior top). A broad top-3000 audit
+    (2026-06-27) found such entries win only ~13% (avg P&L −0.1%) vs ~34%
+    (+2.6%) for rising-MA entries.
+
+    The gate {e tightens} the existing Stage-2-only buy rule toward the book's
+    rising-MA definition — it removes misclassified entries, it does not add a
+    new mechanism. Shorts are never touched (a declining MA is correct for a
+    Stage-4 short). Default-off at the call site
+    ([Weinstein_strategy_config.reject_declining_ma_long_entry]); with
+    [reject = false] this is the identity, so the entry candidate list is
+    bit-identical to prior behaviour. *)
+
+val filter :
+  reject:bool ->
+  Screener.scored_candidate list ->
+  Screener.scored_candidate list
+(** [filter ~reject candidates] returns [candidates] unchanged when
+    [reject = false]. When [reject = true], drops every [Long] candidate whose
+    [analysis.stage.ma_direction] is [Weinstein_types.Declining]; [Rising] /
+    [Flat] longs and all [Short] candidates are retained, in order. *)

--- a/trading/trading/weinstein/strategy/gate/declining_ma/lib/dune
+++ b/trading/trading/weinstein/strategy/gate/declining_ma/lib/dune
@@ -1,0 +1,10 @@
+(library
+ (name declining_ma_gate)
+ (public_name weinstein_trading.declining_ma_gate)
+ (libraries
+  core
+  weinstein.screener
+  weinstein.stock_analysis
+  weinstein.stage
+  weinstein.types
+  trading.base))

--- a/trading/trading/weinstein/strategy/lib/dune
+++ b/trading/trading/weinstein/strategy/lib/dune
@@ -23,6 +23,7 @@
   weinstein.sector
   weinstein.screener
   weinstein_trading.short_side_gate
+  weinstein_trading.declining_ma_gate
   weinstein_trading.liquidity_gate
   weinstein.stock_analysis
   weinstein.continuation

--- a/trading/trading/weinstein/strategy/lib/entry_assembly.ml
+++ b/trading/trading/weinstein/strategy/lib/entry_assembly.ml
@@ -1,0 +1,16 @@
+open Weinstein_strategy_config
+
+let assemble ~config ~bar_reader ~current_date (screen_result : Screener.result)
+    =
+  let combined =
+    Short_side_gate.combine ~enable_short_side:config.enable_short_side
+      ~short_min_price:config.short_min_price
+      ~buy_candidates:screen_result.Screener.buy_candidates
+      ~short_candidates:screen_result.Screener.short_candidates
+  in
+  let combined =
+    Declining_ma_gate.filter ~reject:config.reject_declining_ma_long_entry
+      combined
+  in
+  Entry_liquidity_gate.apply ~config:config.liquidity_config ~bar_reader
+    ~current_date combined

--- a/trading/trading/weinstein/strategy/lib/entry_assembly.mli
+++ b/trading/trading/weinstein/strategy/lib/entry_assembly.mli
@@ -1,0 +1,18 @@
+(** Entry-candidate assembly: the single seam where the per-candidate entry
+    gates compose before the entry walk.
+
+    Pipeline: {!Short_side_gate.combine} (short-side enable + short-min-price) →
+    {!Declining_ma_gate.filter} (drop misclassified declining-MA longs,
+    default-off) → {!Entry_liquidity_gate.apply} (dollar-ADV gate, default-off).
+    With every gate at its no-op default the result is the plain
+    [buy_candidates @ short_candidates], bit-identical to prior behaviour. *)
+
+val assemble :
+  config:Weinstein_strategy_config.config ->
+  bar_reader:Bar_reader.t ->
+  current_date:Core.Date.t ->
+  Screener.result ->
+  Screener.scored_candidate list
+(** [assemble ~config ~bar_reader ~current_date screen_result] runs the gate
+    pipeline over [screen_result]'s buy + short candidates and returns the final
+    ordered entry-candidate list. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -467,6 +467,11 @@ type config = {
           {b spine} is untouched — it changes only when the tail-RISK-insurance
           absolute stop arms. [Variant_matrix] float axis. See
           [Weinstein_strategy_config] for full semantics. *)
+  reject_declining_ma_long_entry : bool; [@sexp.default false]
+      (** Long-entry faithfulness gate (default-off): drop long candidates whose
+          stage-classification MA direction is [Declining] at entry (a
+          misclassified Stage-2 / counter-trend bounce). [Variant_matrix] flag
+          axis. See [Weinstein_strategy_config] for full semantics. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -110,6 +110,9 @@ type config = {
       (** Fast-V arming rate threshold (whipsaw-suppression dial); default
           [fast_v_min_rate_no_op] (0.08) reproduces the classifier default. See
           [.mli]. *)
+  reject_declining_ma_long_entry : bool; [@sexp.default false]
+      (** Long-entry faithfulness gate (default-off): drop long candidates whose
+          MA direction is [Declining] at entry. See [.mli]. *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Master switch for the late-Stage-2 stop-tighten runner; see [.mli]. *)
   late_stage2_stop_buffer_pct : float; [@sexp.default 0.0]
@@ -180,6 +183,7 @@ let default_config ~universe ~index_symbol =
     enable_slow_grind_short_gate = false;
     fast_v_arm_on_rate_alone = false;
     fast_v_min_rate_pct = fast_v_min_rate_no_op;
+    reject_declining_ma_long_entry = false;
     enable_late_stage2_stop_tighten = false;
     late_stage2_stop_buffer_pct = 0.0;
     enable_macro_bearish_exposure_trim = false;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -256,6 +256,29 @@ type config = {
           [((flag fast_v_min_rate_pct) (values (0.08 0.12 0.16)))]). Default
           no-op until an experiment-ledger ACCEPT (per
           [.claude/rules/experiment-flag-discipline.md]). *)
+  reject_declining_ma_long_entry : bool; [@sexp.default false]
+      (** Long-entry faithfulness gate (default-off): when [true], drop any long
+          candidate whose stage-classification MA direction is
+          [Weinstein_types.Declining] at entry. Weinstein Stage 2 is defined as
+          price above a {b rising} 30-week MA; the classifier nonetheless tags a
+          minority of breakouts [Stage2] while the MA is still declining — these
+          are counter-trend bounces in a Stage-4 downtrend (e.g. dead-cat
+          bounces under a prior top), which the broad top-3000 audit shows win
+          only ~13% vs ~34% for rising-MA entries (n=30, avg P&L −0.1% vs
+          +2.6%). Default [false] preserves all baselines bit-for-bit (no
+          candidate is dropped). Shorts are unaffected — a declining MA is
+          correct for a Stage-4 short.
+
+          This keeps the strategy {b spine} intact (it {e tightens} the
+          Stage-2-only buy rule toward the book's rising-MA definition, removing
+          misclassified entries rather than adding any new mechanism). Wired as
+          a real config field, so it is a single-component [Variant_matrix] flag
+          axis
+          ([((flag reject_declining_ma_long_entry) (values (true false)))]).
+          Evidence: the 2026-06-27 drawdown-driver chart review + entry-quality
+          quantification (dev/charts/, the declining-MA bucket). Default-off
+          until an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md]). *)
   enable_late_stage2_stop_tighten : bool; [@sexp.default false]
       (** Held-position risk dial (default-off): when [true], the
           {!Late_stage2_stop_runner} tightens the trailing stop of every held

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -433,16 +433,6 @@ let _run_screener ?membership_at ~config ~(macro_result : Macro.result)
     Phase 1 runs. Symbols whose [active_through < fold_start_date] are dropped
     from the per-Friday classification loop, eliminating the Phase-1 cost on
     symbols that cannot contribute to the fold. *)
-let _assemble_candidates ~config ~bar_reader ~current_date
-    (screen_result : Screener.result) =
-  let combined =
-    Short_side_gate.combine ~enable_short_side:config.enable_short_side
-      ~short_min_price:config.short_min_price
-      ~buy_candidates:screen_result.Screener.buy_candidates
-      ~short_candidates:screen_result.Screener.short_candidates
-  in
-  Entry_liquidity_gate.apply ~config:config.liquidity_config ~bar_reader
-    ~current_date combined
 
 let screen_universe ?active_through_for ?fold_start_date ?membership_at ~config
     ~index_view ~(macro_result : Macro.result) ~sector_map ~stop_states
@@ -468,7 +458,7 @@ let screen_universe ?active_through_for ?fold_start_date ?membership_at ~config
       ~stocks ~portfolio ~last_stop_out_dates ~current_date ()
   in
   let combined_candidates =
-    _assemble_candidates ~config ~bar_reader ~current_date screen_result
+    Entry_assembly.assemble ~config ~bar_reader ~current_date screen_result
   in
   let entries =
     entries_from_candidates

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -15,6 +15,7 @@
   test_sector_rotation_weinstein_strategy
   test_short_side_bear_window
   test_short_min_price_gate
+  test_declining_ma_gate
   test_short_side_gate
   test_liquidity_metric
   test_liquidity_gate
@@ -53,6 +54,7 @@
   weinstein.screener
   weinstein_trading.short_min_price_gate
   weinstein_trading.short_side_gate
+  weinstein_trading.declining_ma_gate
   weinstein_trading.liquidity_gate
   weinstein.stage
   indicators.types

--- a/trading/trading/weinstein/strategy/test/test_declining_ma_gate.ml
+++ b/trading/trading/weinstein/strategy/test/test_declining_ma_gate.ml
@@ -1,0 +1,83 @@
+(** Unit tests for the declining-MA long-entry gate
+    ({!Declining_ma_gate.filter}).
+
+    - [reject = false] (default) → identity: every candidate retained, so the
+      entry candidate list is bit-identical to prior behaviour.
+    - [reject = true] → drop Long candidates whose stage MA direction is
+      [Declining] (misclassified Stage-2 / counter-trend bounce); keep
+      rising/flat-MA Longs and all Shorts (a declining MA is correct for a
+      Stage-4 short). *)
+
+open OUnit2
+open Core
+open Matchers
+open Weinstein_types
+
+let reject_declining_ma_longs = Declining_ma_gate.filter
+
+(* Minimal [scored_candidate] with a chosen side + MA direction. Only [side] and
+   [analysis.stage.ma_direction] are load-bearing for the gate; the rest are
+   inert placeholders. *)
+let _make ~ticker ~side ~ma_direction : Screener.scored_candidate =
+  let base =
+    Stock_analysis.analyze ~config:Stock_analysis.default_config ~ticker
+      ~bars:[] ~benchmark_bars:[] ~prior_stage:None
+      ~as_of_date:(Date.of_string "2024-01-01")
+  in
+  {
+    ticker;
+    analysis = { base with stage = { base.stage with ma_direction } };
+    side;
+    sector =
+      {
+        sector_name = "Test";
+        rating = Screener.Neutral;
+        stage = Stage2 { weeks_advancing = 5; late = false };
+      };
+    grade = C;
+    score = 0;
+    suggested_entry = 50.0;
+    suggested_stop = 46.0;
+    risk_pct = 0.08;
+    swing_target = None;
+    rationale = [];
+  }
+
+let candidates () =
+  [
+    _make ~ticker:"LONG_RISING" ~side:Trading_base.Types.Long
+      ~ma_direction:Rising;
+    _make ~ticker:"LONG_DECLINING" ~side:Trading_base.Types.Long
+      ~ma_direction:Declining;
+    _make ~ticker:"SHORT_DECLINING" ~side:Trading_base.Types.Short
+      ~ma_direction:Declining;
+  ]
+
+let tickers cs =
+  List.map cs ~f:(fun (c : Screener.scored_candidate) -> c.ticker)
+
+(* reject = false → no-op: all three retained, in order. *)
+let test_default_is_noop _ =
+  assert_that
+    (tickers (reject_declining_ma_longs ~reject:false (candidates ())))
+    (elements_are
+       [
+         equal_to "LONG_RISING";
+         equal_to "LONG_DECLINING";
+         equal_to "SHORT_DECLINING";
+       ])
+
+(* reject = true → drop only the declining-MA Long; keep rising-MA Long + short. *)
+let test_drops_declining_longs_only _ =
+  assert_that
+    (tickers (reject_declining_ma_longs ~reject:true (candidates ())))
+    (elements_are [ equal_to "LONG_RISING"; equal_to "SHORT_DECLINING" ])
+
+let suite =
+  "declining_ma_gate"
+  >::: [
+         "default is a no-op" >:: test_default_is_noop;
+         "drops declining-MA longs only" >:: test_drops_declining_longs_only;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
Adds `reject_declining_ma_long_entry` config flag (default-off). When on, drops long candidates whose stage MA direction is **Declining** at entry — a misclassified Stage-2 (counter-trend bounce in a Stage-4 downtrend; the COO/WBA/DBD pattern). The broad top-3000 entry-quality audit (2026-06-27) found these win **~13% (avg −0.1%)** vs **~34% (+2.6%)** for rising-MA entries.

Faithful tightening of the Stage-2-only buy rule toward Weinstein's rising-MA definition (spine intact); shorts unaffected (a declining MA is correct for a Stage-4 short).

- New `weinstein_trading.declining_ma_gate` sub-lib (mirrors short_side_gate) + unit test (no-op default; drops declining-MA longs only).
- Extracted candidate-assembly pipeline → new `Entry_assembly` module (keeps screening.ml under the 500-line cap, the honest fix vs bumping the limit).
- Real config field → Variant_matrix flag axis (R2); default-off, bit-identical baselines until a ledger ACCEPT (R1/R3).

Remeasure (broad deep, on vs off) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)