### PR TITLE
fix(eligible-universe): configurable staleness tolerance + observability (#1783)

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -27,6 +27,9 @@ READY_FOR_REVIEW
   default-0 excludes a 1-day-stale symbol = parity; tolerance=2 keeps
   symbols ≤2 trading days stale; report counts + samples the
   staleness-excluded set). PR: `feat/eligible-universe-staleness-guard`.
+  Linter rework (2026-06-29): extracted the freshness primitives +
+  `staleness_report` into a sibling `staleness.{ml,mli}` to clear the
+  file-length (304→283) + nesting linters; behaviour unchanged.
 
 ## Blocking Refactors
 - **2026-05-16 Option B pivot — IWV scrape becomes the primary

--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -1,9 +1,32 @@
 # Status: data-foundations
 
-## Last updated: 2026-06-14
+## Last updated: 2026-06-29
 
 ## Status
 READY_FOR_REVIEW
+
+## Completed
+- [x] **2026-06-29 — eligible-universe staleness guard (issue #1783).**
+  `Build_eligible_universe`'s active filter dropped any symbol whose
+  last bar was even one trading day stale (`data_end_date < date`),
+  silently shrinking a screen when a partial data refresh lagged.
+  Added a configurable `max_staleness_trading_days : int`
+  (default `0` = bit-identical to prior behaviour) to
+  `Build_eligible_universe.config`: the end-date gate now also keeps a
+  symbol whose last bar is within that many *trading days* (weekdays;
+  holidays not modelled) of `date`. Added a `staleness_report`
+  (count + ticker sample of symbols dropped specifically for staleness)
+  returned by the new `build_with_staleness_report`; `build` delegates
+  to it (snapshot identical). `build_eligible_universe_runner` gained a
+  `-max-staleness-trading-days` flag and prints
+  `[eligible-universe] N symbols excluded for staleness (sample: …)`
+  when N > 0. Lives in
+  `analysis/data/universe/lib/build_eligible_universe.{ml,mli}` +
+  `analysis/data/universe/bin/build_eligible_universe_runner{,_lib}.{ml,mli}`.
+  Verify: `dune runtest analysis/data/universe/` (3 new tests:
+  default-0 excludes a 1-day-stale symbol = parity; tolerance=2 keeps
+  symbols ≤2 trading days stale; report counts + samples the
+  staleness-excluded set). PR: `feat/eligible-universe-staleness-guard`.
 
 ## Blocking Refactors
 - **2026-05-16 Option B pivot — IWV scrape becomes the primary

--- a/trading/analysis/data/universe/bin/build_eligible_universe_runner.ml
+++ b/trading/analysis/data/universe/bin/build_eligible_universe_runner.ml
@@ -25,11 +25,23 @@ open! Core
 
 let _default_min_price = 5.0
 let _default_min_adv = 1_000_000.0
+let _default_max_staleness_trading_days = 0
+
+(* Surface a freshness-gate exclusion so a silent universe-shrink is visible.
+   A zero count prints nothing (no noise on a fully-fresh build). *)
+let _print_staleness
+    (report : Universe.Build_eligible_universe.staleness_report) =
+  if report.excluded_count > 0 then
+    Stdlib.Printf.printf
+      "[eligible-universe] %d symbols excluded for staleness (sample: %s)\n"
+      report.excluded_count
+      (String.concat ~sep:" " report.sample)
 
 let _print_result (result : Build_eligible_universe_runner_lib.result) =
   Stdlib.Printf.printf
     "build_eligible_universe_runner: wrote %d eligible symbols to %s\n"
-    result.entry_count result.written_path
+    result.entry_count result.written_path;
+  _print_staleness result.staleness_report
 
 let _exit_with_error msg =
   Stdlib.Printf.fprintf Stdlib.stderr "build_eligible_universe_runner: %s\n" msg;
@@ -37,10 +49,10 @@ let _exit_with_error msg =
   Stdlib.exit 1
 
 let _run ~inventory_path ~csv_data_dir ~date ~min_price ~min_avg_dollar_volume
-    ~output_path =
+    ~max_staleness_trading_days ~output_path =
   match
     Build_eligible_universe_runner_lib.run ~inventory_path ~csv_data_dir ~date
-      ~min_price ~min_avg_dollar_volume ~output_path
+      ~min_price ~min_avg_dollar_volume ~max_staleness_trading_days ~output_path
   with
   | Ok result -> _print_result result
   | Error err -> _exit_with_error (Status.show err)
@@ -74,6 +86,15 @@ let command =
            (Printf.sprintf
               "FLOAT min trailing avg dollar volume (default: %.0f)"
               _default_min_adv)
+     and max_staleness_trading_days =
+       flag "-max-staleness-trading-days"
+         (optional_with_default _default_max_staleness_trading_days int)
+         ~doc:
+           (Printf.sprintf
+              "INT keep symbols whose last bar is up to N trading days \
+               (weekdays) before -date (default: %d = require a bar on/after \
+               -date)"
+              _default_max_staleness_trading_days)
      and output_path =
        flag "-output-path" (required string)
          ~doc:"PATH where to write the snapshot .sexp"
@@ -81,6 +102,6 @@ let command =
      fun () ->
        let date = Date.of_string date in
        _run ~inventory_path ~csv_data_dir ~date ~min_price
-         ~min_avg_dollar_volume ~output_path)
+         ~min_avg_dollar_volume ~max_staleness_trading_days ~output_path)
 
 let () = Command_unix.run command

--- a/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.ml
+++ b/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.ml
@@ -1,7 +1,12 @@
 open Core
 module BEU = Universe.Build_eligible_universe
 
-type result = { written_path : string; entry_count : int } [@@deriving show, eq]
+type result = {
+  written_path : string;
+  entry_count : int;
+  staleness_report : BEU.staleness_report;
+}
+[@@deriving show, eq]
 
 let _symbol_types_path ~csv_data_dir =
   Filename.concat csv_data_dir "symbol_types.sexp"
@@ -9,7 +14,8 @@ let _symbol_types_path ~csv_data_dir =
 let _sectors_csv_path ~csv_data_dir = Filename.concat csv_data_dir "sectors.csv"
 
 (* The live-universe spec config with the caller-supplied gate values. *)
-let _config ~inventory_path ~csv_data_dir ~min_price ~min_avg_dollar_volume =
+let _config ~inventory_path ~csv_data_dir ~min_price ~min_avg_dollar_volume
+    ~max_staleness_trading_days =
   {
     (BEU.spec_config ~bars_root:csv_data_dir
        ~symbol_types_path:(_symbol_types_path ~csv_data_dir)
@@ -18,14 +24,23 @@ let _config ~inventory_path ~csv_data_dir ~min_price ~min_avg_dollar_volume =
     with
     min_price;
     min_avg_dollar_volume;
+    max_staleness_trading_days;
   }
 
 let run ~inventory_path ~csv_data_dir ~date ~min_price ~min_avg_dollar_volume
-    ~output_path =
+    ~max_staleness_trading_days ~output_path =
   let open Result.Let_syntax in
   let config =
     _config ~inventory_path ~csv_data_dir ~min_price ~min_avg_dollar_volume
+      ~max_staleness_trading_days
   in
-  let%bind snapshot = BEU.build ~date ~config in
+  let%bind snapshot, staleness_report =
+    BEU.build_with_staleness_report ~date ~config
+  in
   let%bind () = Universe.Snapshot.save snapshot ~path:output_path in
-  Ok { written_path = output_path; entry_count = List.length snapshot.entries }
+  Ok
+    {
+      written_path = output_path;
+      entry_count = List.length snapshot.entries;
+      staleness_report;
+    }

--- a/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.mli
+++ b/trading/analysis/data/universe/bin/build_eligible_universe_runner_lib.mli
@@ -6,9 +6,16 @@
 
 open Core
 
-type result = { written_path : string; entry_count : int } [@@deriving show, eq]
-(** Outcome of a successful run: where the snapshot was written and how many
-    eligible symbols it contains. *)
+type result = {
+  written_path : string;
+  entry_count : int;
+  staleness_report : Universe.Build_eligible_universe.staleness_report;
+}
+[@@deriving show, eq]
+(** Outcome of a successful run: where the snapshot was written, how many
+    eligible symbols it contains, and the freshness-gate
+    {!Universe.Build_eligible_universe.staleness_report} (count + sample of
+    symbols dropped specifically for stale data). *)
 
 val run :
   inventory_path:string ->
@@ -16,18 +23,20 @@ val run :
   date:Date.t ->
   min_price:float ->
   min_avg_dollar_volume:float ->
+  max_staleness_trading_days:int ->
   output_path:string ->
   result Status.status_or
 (** [run ~inventory_path ~csv_data_dir ~date ~min_price ~min_avg_dollar_volume
-     ~output_path] builds the eligible universe at [date] from the inventory +
-    cached bars under [csv_data_dir], applying the live-universe spec gates
-    (REIT-exclude, preferred-exclude, the supplied [min_price] /
-    [min_avg_dollar_volume]), and writes the resulting {!Universe.Snapshot.t} to
-    [output_path].
+     ~max_staleness_trading_days ~output_path] builds the eligible universe at
+    [date] from the inventory + cached bars under [csv_data_dir], applying the
+    live-universe spec gates (REIT-exclude, preferred-exclude, the supplied
+    [min_price] / [min_avg_dollar_volume]) and the freshness tolerance
+    [max_staleness_trading_days] (0 = require a bar on / after [date]), and
+    writes the resulting {!Universe.Snapshot.t} to [output_path].
 
     [csv_data_dir] is both the bars root and the directory holding
     [symbol_types.sexp] and [sectors.csv] (the standard cached-data layout).
 
     Returns [Error] when the build or the on-disk write fails (propagating the
     {!Universe.Build_eligible_universe.build} status), else
-    [Ok { written_path; entry_count }]. *)
+    [Ok { written_path; entry_count; staleness_report }]. *)

--- a/trading/analysis/data/universe/lib/build_eligible_universe.ml
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.ml
@@ -9,6 +9,13 @@ module CPT = Composition_policy_types
 let _default_trailing_window_days = 60
 let _default_min_window_bars = 30
 
+(* No-op staleness tolerance: 0 trading days ⇒ a symbol is active only if its
+   last bar is on / after [date] (exactly the pre-tolerance behaviour). *)
+let _default_max_staleness_trading_days = 0
+
+(* Tickers carried in a [staleness_report.sample] (a logging aid, not a gate). *)
+let staleness_sample_size = 10
+
 (* Live-universe spec gate values (the spec, not the no-op record default). *)
 let _spec_min_price = 5.0
 let _spec_min_avg_dollar_volume = 1_000_000.0
@@ -20,6 +27,7 @@ let _spec_min_avg_dollar_volume = 1_000_000.0
 type config = {
   min_price : float;
   min_avg_dollar_volume : float;
+  max_staleness_trading_days : int;
   trailing_window_days : int;
   min_window_bars : int;
   reit_policy : CPT.reit_policy;
@@ -31,11 +39,15 @@ type config = {
 }
 [@@deriving sexp]
 
+type staleness_report = { excluded_count : int; sample : string list }
+[@@deriving sexp, show, eq]
+
 let default_config ~bars_root ~symbol_types_path ~sectors_csv_path
     ~inventory_path =
   {
     min_price = 0.0;
     min_avg_dollar_volume = 0.0;
+    max_staleness_trading_days = _default_max_staleness_trading_days;
     trailing_window_days = _default_trailing_window_days;
     min_window_bars = _default_min_window_bars;
     reit_policy = CPT.Include;
@@ -62,19 +74,82 @@ let spec_config ~bars_root ~symbol_types_path ~sectors_csv_path ~inventory_path
 (* Active + equity-like filtering                                      *)
 (* ------------------------------------------------------------------ *)
 
-let _is_active ~date ~required_start (entry : CI.inventory_entry) =
+(* Whether [d] is a weekday (Mon–Fri). Holidays are not modelled, so a
+   "trading day" here is a weekday — see the [.mli] freshness-gate docs. *)
+let _is_weekday d =
+  match Date.day_of_week d with
+  | Day_of_week.Sat | Day_of_week.Sun -> false
+  | _ -> true
+
+(* Count weekdays strictly after [end_date] up to and including [date] — i.e.
+   how many trading days the last bar ([end_date]) lags [date]. [0] when
+   [end_date >= date] (the symbol is fresh, or ahead). *)
+let _trading_days_late ~end_date ~date =
+  if Date.( >= ) end_date date then 0
+  else
+    Date.dates_between ~min:(Date.add_days end_date 1) ~max:date
+    |> List.count ~f:_is_weekday
+
+(* A symbol clears the trailing-history start gate (enough lead-in to score). *)
+let _has_enough_history ~required_start (entry : CI.inventory_entry) =
   Date.( <= ) entry.data_start_date required_start
-  && Date.( >= ) entry.data_end_date date
+
+(* The last bar is fresh enough: on / after [date], or stale by at most
+   [max_staleness_trading_days] trading days. *)
+let _is_fresh_enough ~date ~max_staleness_trading_days
+    (entry : CI.inventory_entry) =
+  _trading_days_late ~end_date:entry.data_end_date ~date
+  <= max_staleness_trading_days
+
+let _is_active ~date ~required_start ~max_staleness_trading_days
+    (entry : CI.inventory_entry) =
+  _has_enough_history ~required_start entry
+  && _is_fresh_enough ~date ~max_staleness_trading_days entry
+
+let _required_start ~date ~config =
+  Date.add_days date (-config.trailing_window_days)
 
 let _active_symbols ~date ~config (inventory : CI.inventory) =
-  let required_start = Date.add_days date (-config.trailing_window_days) in
+  let required_start = _required_start ~date ~config in
   List.filter_map inventory.symbols ~f:(fun e ->
-      if _is_active ~date ~required_start e then Some e.symbol else None)
+      if
+        _is_active ~date ~required_start
+          ~max_staleness_trading_days:config.max_staleness_trading_days e
+      then Some e.symbol
+      else None)
 
 let _is_equity_like ~equity_like_lookup symbol =
   match Hashtbl.find equity_like_lookup symbol with
   | Some true -> true
   | _ -> false
+
+(* Symbols dropped {b specifically} for staleness: they clear the history start
+   gate and are equity-like, but their last bar is too old for the freshness
+   gate ([data_end_date < date] and beyond [max_staleness_trading_days]). The
+   observability counterpart to the active filter — a non-zero count means a
+   partial data refresh shrank the universe. Inventory order is preserved so the
+   report is deterministic. *)
+let _staleness_excluded ~date ~config ~equity_like_lookup
+    (inventory : CI.inventory) =
+  let required_start = _required_start ~date ~config in
+  List.filter_map inventory.symbols ~f:(fun (e : CI.inventory_entry) ->
+      if
+        _has_enough_history ~required_start e
+        && (not
+              (_is_fresh_enough ~date
+                 ~max_staleness_trading_days:config.max_staleness_trading_days e))
+        && _is_equity_like ~equity_like_lookup e.symbol
+      then Some e.symbol
+      else None)
+
+let _staleness_report ~date ~config ~equity_like_lookup inventory =
+  let excluded =
+    _staleness_excluded ~date ~config ~equity_like_lookup inventory
+  in
+  {
+    excluded_count = List.length excluded;
+    sample = List.take excluded staleness_sample_size;
+  }
 
 (* ------------------------------------------------------------------ *)
 (* Per-symbol scoring + eligibility gates                              *)
@@ -208,7 +283,7 @@ let _build_validated ~date ~config ~inventory ~equity_like_lookup
   in
   _make_snapshot ~date ~kept
 
-let build ~date ~config =
+let build_with_staleness_report ~date ~config =
   let open Result.Let_syntax in
   let%bind inventory = CI.load_inventory config.inventory_path in
   let%bind equity_like_lookup =
@@ -218,5 +293,12 @@ let build ~date ~config =
     CI.load_asset_type_lookup config.symbol_types_path
   in
   let%bind sector_lookup = CI.load_sectors config.sectors_csv_path in
-  _build_validated ~date ~config ~inventory ~equity_like_lookup
-    ~asset_type_lookup ~sector_lookup
+  let%bind snapshot =
+    _build_validated ~date ~config ~inventory ~equity_like_lookup
+      ~asset_type_lookup ~sector_lookup
+  in
+  let report = _staleness_report ~date ~config ~equity_like_lookup inventory in
+  Ok (snapshot, report)
+
+let build ~date ~config =
+  Result.map (build_with_staleness_report ~date ~config) ~f:fst

--- a/trading/analysis/data/universe/lib/build_eligible_universe.ml
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.ml
@@ -4,6 +4,7 @@ module BR = Composition_bar_reader
 module BFI = Build_from_individuals
 module CP = Composition_policy
 module CPT = Composition_policy_types
+module S = Staleness
 
 (* Defaults documented in [build_eligible_universe.mli]. *)
 let _default_trailing_window_days = 60
@@ -13,8 +14,8 @@ let _default_min_window_bars = 30
    last bar is on / after [date] (exactly the pre-tolerance behaviour). *)
 let _default_max_staleness_trading_days = 0
 
-(* Tickers carried in a [staleness_report.sample] (a logging aid, not a gate). *)
-let staleness_sample_size = 10
+(* Re-exported from {!Staleness} so the public surface stays unchanged. *)
+let staleness_sample_size = S.sample_size
 
 (* Live-universe spec gate values (the spec, not the no-op record default). *)
 let _spec_min_price = 5.0
@@ -39,7 +40,10 @@ type config = {
 }
 [@@deriving sexp]
 
-type staleness_report = { excluded_count : int; sample : string list }
+type staleness_report = S.staleness_report = {
+  excluded_count : int;
+  sample : string list;
+}
 [@@deriving sexp, show, eq]
 
 let default_config ~bars_root ~symbol_types_path ~sectors_csv_path
@@ -74,37 +78,14 @@ let spec_config ~bars_root ~symbol_types_path ~sectors_csv_path ~inventory_path
 (* Active + equity-like filtering                                      *)
 (* ------------------------------------------------------------------ *)
 
-(* Whether [d] is a weekday (Mon–Fri). Holidays are not modelled, so a
-   "trading day" here is a weekday — see the [.mli] freshness-gate docs. *)
-let _is_weekday d =
-  match Date.day_of_week d with
-  | Day_of_week.Sat | Day_of_week.Sun -> false
-  | _ -> true
-
-(* Count weekdays strictly after [end_date] up to and including [date] — i.e.
-   how many trading days the last bar ([end_date]) lags [date]. [0] when
-   [end_date >= date] (the symbol is fresh, or ahead). *)
-let _trading_days_late ~end_date ~date =
-  if Date.( >= ) end_date date then 0
-  else
-    Date.dates_between ~min:(Date.add_days end_date 1) ~max:date
-    |> List.count ~f:_is_weekday
-
 (* A symbol clears the trailing-history start gate (enough lead-in to score). *)
 let _has_enough_history ~required_start (entry : CI.inventory_entry) =
   Date.( <= ) entry.data_start_date required_start
 
-(* The last bar is fresh enough: on / after [date], or stale by at most
-   [max_staleness_trading_days] trading days. *)
-let _is_fresh_enough ~date ~max_staleness_trading_days
-    (entry : CI.inventory_entry) =
-  _trading_days_late ~end_date:entry.data_end_date ~date
-  <= max_staleness_trading_days
-
 let _is_active ~date ~required_start ~max_staleness_trading_days
     (entry : CI.inventory_entry) =
   _has_enough_history ~required_start entry
-  && _is_fresh_enough ~date ~max_staleness_trading_days entry
+  && S.is_fresh_enough ~date ~max_staleness_trading_days entry
 
 let _required_start ~date ~config =
   Date.add_days date (-config.trailing_window_days)
@@ -129,27 +110,25 @@ let _is_equity_like ~equity_like_lookup symbol =
    observability counterpart to the active filter — a non-zero count means a
    partial data refresh shrank the universe. Inventory order is preserved so the
    report is deterministic. *)
+let _is_staleness_excluded ~required_start ~date ~config ~equity_like_lookup
+    (e : CI.inventory_entry) =
+  _has_enough_history ~required_start e
+  && (not
+        (S.is_fresh_enough ~date
+           ~max_staleness_trading_days:config.max_staleness_trading_days e))
+  && _is_equity_like ~equity_like_lookup e.symbol
+
 let _staleness_excluded ~date ~config ~equity_like_lookup
     (inventory : CI.inventory) =
   let required_start = _required_start ~date ~config in
-  List.filter_map inventory.symbols ~f:(fun (e : CI.inventory_entry) ->
-      if
-        _has_enough_history ~required_start e
-        && (not
-              (_is_fresh_enough ~date
-                 ~max_staleness_trading_days:config.max_staleness_trading_days e))
-        && _is_equity_like ~equity_like_lookup e.symbol
-      then Some e.symbol
-      else None)
+  List.filter inventory.symbols
+    ~f:
+      (_is_staleness_excluded ~required_start ~date ~config ~equity_like_lookup)
+  |> List.map ~f:(fun (e : CI.inventory_entry) -> e.symbol)
 
 let _staleness_report ~date ~config ~equity_like_lookup inventory =
-  let excluded =
-    _staleness_excluded ~date ~config ~equity_like_lookup inventory
-  in
-  {
-    excluded_count = List.length excluded;
-    sample = List.take excluded staleness_sample_size;
-  }
+  S.report
+    ~excluded:(_staleness_excluded ~date ~config ~equity_like_lookup inventory)
 
 (* ------------------------------------------------------------------ *)
 (* Per-symbol scoring + eligibility gates                              *)

--- a/trading/analysis/data/universe/lib/build_eligible_universe.mli
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.mli
@@ -16,7 +16,12 @@
 
     1. {b Active filter} — keep inventory entries with
     [data_start_date <= date - trailing_window_days] (enough trailing history to
-    score) and [data_end_date >= date] (actively trading).
+    score) and a {b fresh-enough} [data_end_date]: by default
+    [data_end_date >= date] (actively trading through [date]), but a symbol
+    whose last bar is at most [max_staleness_trading_days] trading days before
+    [date] is also kept (see {!config}). A "trading day" here is a weekday
+    (Mon–Fri); market holidays are {b not} modelled, so the budget counts
+    weekdays, not exchange sessions.
 
     2. {b Equity-like filter} — drop ETF / Mutual_fund / Fund / Bond / Index /
     Currency / Commodity via {!Eodhd.Asset_type.is_equity_like}; keeps
@@ -63,6 +68,17 @@ type config = {
       (** Drop symbols whose trailing-window average [close * volume] is
           strictly below this floor. No-op default [0.0]; the spec uses
           [1_000_000.0]. *)
+  max_staleness_trading_days : int;
+      (** How many trading days (weekdays, Mon–Fri) the latest bar
+          ([data_end_date]) may lag [date] and still count the symbol as active.
+          No-op default [0]: a symbol is active only if [data_end_date >= date]
+          (exactly the pre-tolerance behaviour). A positive value keeps symbols
+          whose data is up to that many trading days stale — e.g. [2] keeps a
+          name whose last bar is two trading days before [date], so a partial /
+          lagging data refresh no longer silently shrinks the universe. Market
+          holidays are {b not} modelled; the count is weekdays, not exchange
+          sessions, so the field is named {i trading_days} rather than
+          {i sessions}. *)
   trailing_window_days : int;
       (** Calendar days of trailing data used for the dollar-volume score and
           activity gate. Default [60]. *)
@@ -93,10 +109,11 @@ val default_config :
   inventory_path:string ->
   config
 (** [default_config ...] is the keep-all no-op: [min_price = 0.0],
-    [min_avg_dollar_volume = 0.0], [trailing_window_days = 60],
-    [min_window_bars = 30], [reit_policy = Include],
-    [exclude_preferred = false]. A build through this config keeps every active
-    equity-like symbol (the only drop is the always-on dual-class dedup). *)
+    [min_avg_dollar_volume = 0.0], [max_staleness_trading_days = 0],
+    [trailing_window_days = 60], [min_window_bars = 30],
+    [reit_policy = Include], [exclude_preferred = false]. A build through this
+    config keeps every active equity-like symbol (the only drop is the always-on
+    dual-class dedup). *)
 
 val spec_config :
   bars_root:string ->
@@ -106,7 +123,22 @@ val spec_config :
   config
 (** [spec_config ...] is {!default_config} with the live-universe gates flipped
     on: [min_price = 5.0], [min_avg_dollar_volume = 1_000_000.0],
-    [reit_policy = Exclude], [exclude_preferred = true]. *)
+    [reit_policy = Exclude], [exclude_preferred = true].
+    [max_staleness_trading_days] stays at the no-op [0]. *)
+
+type staleness_report = { excluded_count : int; sample : string list }
+[@@deriving sexp, show, eq]
+(** Observability for the active-filter's freshness gate: how many symbols were
+    excluded {b specifically} because their latest bar is stale — i.e. they
+    passed the trailing-history start gate and are equity-like, but their
+    [data_end_date] is more than [max_staleness_trading_days] trading days
+    before [date]. [excluded_count] is the total such symbols; [sample] is a
+    small, deterministic (inventory-order) prefix of their tickers for logging.
+    A non-zero count is the signal that a partial / lagging data refresh shrank
+    the universe — the silent-shrink this report exists to surface. *)
+
+val staleness_sample_size : int
+(** Maximum number of tickers carried in {!staleness_report.sample}. *)
 
 val build : date:Date.t -> config:config -> Snapshot.t Status.status_or
 (** [build ~date ~config] runs the pipeline in the module docstring and returns
@@ -120,3 +152,13 @@ val build : date:Date.t -> config:config -> Snapshot.t Status.status_or
     - [Ok snapshot] otherwise, with [snapshot.size] equal to the survivor count
       ({b not} truncated) and uniform per-entry weights. Symbols whose
       per-symbol [data.csv] is missing / unreadable are silently dropped. *)
+
+val build_with_staleness_report :
+  date:Date.t ->
+  config:config ->
+  (Snapshot.t * staleness_report) Status.status_or
+(** [build_with_staleness_report ~date ~config] is {!build} paired with the
+    {!staleness_report} computed from the same inventory pass. [build] is
+    exactly [build_with_staleness_report] with the report discarded, so the
+    snapshot is identical. Use this variant when the caller wants to surface how
+    many symbols the freshness gate dropped (the runner logs it to stdout). *)

--- a/trading/analysis/data/universe/lib/dune
+++ b/trading/analysis/data/universe/lib/dune
@@ -6,6 +6,7 @@
   build_from_index
   build_from_individuals
   build_eligible_universe
+  staleness
   composition_inputs
   composition_bar_reader
   composition_policy_types

--- a/trading/analysis/data/universe/lib/staleness.ml
+++ b/trading/analysis/data/universe/lib/staleness.ml
@@ -1,0 +1,35 @@
+open Core
+module CI = Composition_inputs
+
+(* Tickers carried in a [staleness_report.sample] (a logging aid, not a gate). *)
+let sample_size = 10
+
+(* Whether [d] is a weekday (Mon–Fri). Holidays are not modelled, so a
+   "trading day" here is a weekday — see the [.mli] freshness-gate docs. *)
+let _is_weekday d =
+  match Date.day_of_week d with
+  | Day_of_week.Sat | Day_of_week.Sun -> false
+  | _ -> true
+
+(* Count weekdays strictly after [end_date] up to and including [date] — i.e.
+   how many trading days the last bar ([end_date]) lags [date]. [0] when
+   [end_date >= date] (the symbol is fresh, or ahead). *)
+let _trading_days_late ~end_date ~date =
+  if Date.( >= ) end_date date then 0
+  else
+    Date.dates_between ~min:(Date.add_days end_date 1) ~max:date
+    |> List.count ~f:_is_weekday
+
+let is_fresh_enough ~date ~max_staleness_trading_days
+    (entry : CI.inventory_entry) =
+  _trading_days_late ~end_date:entry.data_end_date ~date
+  <= max_staleness_trading_days
+
+type staleness_report = { excluded_count : int; sample : string list }
+[@@deriving sexp, show, eq]
+
+let report ~excluded =
+  {
+    excluded_count = List.length excluded;
+    sample = List.take excluded sample_size;
+  }

--- a/trading/analysis/data/universe/lib/staleness.mli
+++ b/trading/analysis/data/universe/lib/staleness.mli
@@ -1,0 +1,35 @@
+(** Freshness primitives + the active-filter staleness report for
+    {!Build_eligible_universe}.
+
+    Splits the data-freshness logic out of the builder: the trading-day-lateness
+    count, the freshness gate itself, and the {!staleness_report} observability
+    record. A "trading day" here is a {b weekday} (Mon–Fri); market holidays are
+    not modelled (see the [Build_eligible_universe] freshness-gate docs). *)
+
+open Core
+module CI = Composition_inputs
+
+val is_fresh_enough :
+  date:Date.t -> max_staleness_trading_days:int -> CI.inventory_entry -> bool
+(** [is_fresh_enough ~date ~max_staleness_trading_days entry] is [true] when the
+    entry's last bar ([data_end_date]) is on / after [date], or stale by at most
+    [max_staleness_trading_days] trading days (weekdays) before [date]. With the
+    no-op [max_staleness_trading_days = 0] this reduces to
+    [data_end_date >= date]. *)
+
+type staleness_report = { excluded_count : int; sample : string list }
+[@@deriving sexp, show, eq]
+(** Observability for the active-filter's freshness gate: how many symbols were
+    excluded {b specifically} because their latest bar is stale.
+    [excluded_count] is the total such symbols; [sample] is a small,
+    deterministic (inventory-order) prefix of their tickers for logging. A
+    non-zero count is the signal that a partial / lagging data refresh shrank
+    the universe. *)
+
+val sample_size : int
+(** Maximum number of tickers carried in {!staleness_report.sample}. *)
+
+val report : excluded:string list -> staleness_report
+(** [report ~excluded] packages the staleness-excluded symbols (in inventory
+    order) into a {!staleness_report}: [excluded_count] is their length and
+    [sample] the first {!sample_size} tickers. *)

--- a/trading/analysis/data/universe/test/test_build_eligible_universe.ml
+++ b/trading/analysis/data/universe/test/test_build_eligible_universe.ml
@@ -144,6 +144,90 @@ let _setup ~specs =
   in
   (root, config)
 
+(* ---------------------------------------------------------------------- *)
+(* Staleness-fixture builders                                              *)
+(*                                                                         *)
+(* The active filter keys off the inventory's [data_end_date], so staleness *)
+(* tests need per-symbol end dates. They anchor on a weekday build date so   *)
+(* the trading-day (weekday) count is unambiguous, and write dense bars      *)
+(* (latest close >= the staleness build date) so any symbol that clears the  *)
+(* active filter also clears the price / dollar-volume / min-bars gates.     *)
+(* ---------------------------------------------------------------------- *)
+
+(* A Thursday. Prior trading days: Wed 2020-05-27 (1 day late),
+   Tue 2020-05-26 (2 days late), Mon 2020-05-25 (3 days late). The intervening
+   weekend (Sat 23 / Sun 24) does not count, so Fri 2020-05-22 is also 3 days
+   late — exercising the weekday-only count. *)
+let _staleness_build_date = Date.create_exn ~y:2020 ~m:Month.May ~d:28
+
+(* Write [n_bars] dense daily bars ending on [_staleness_build_date] so the
+   latest close is on the build date (clearing the freshness-of-bars view used
+   by the scoring gates, independent of the inventory end date under test). *)
+let _write_staleness_bars ~root sym =
+  let path = _bars_path ~root sym in
+  let buf = Buffer.create 1024 in
+  Buffer.add_string buf "date,open,high,low,close,adjusted_close,volume\n";
+  List.iter (List.init 60 ~f:Fn.id) ~f:(fun i ->
+      let date = Date.add_days _staleness_build_date (-i) in
+      Buffer.add_string buf
+        (Printf.sprintf "%s,50.00,50.00,50.00,50.00,50.00,1000000\n"
+           (Date.to_string date)));
+  Out_channel.write_all path ~data:(Buffer.contents buf)
+
+let _write_inventory_with_end_dates ~root entries =
+  let path = Filename.concat root "inventory.sexp" in
+  let body_lines =
+    List.map entries ~f:(fun (sym, end_date) ->
+        Printf.sprintf
+          "  ((symbol %s) (data_start_date 2010-01-01) (data_end_date %s))" sym
+          (Date.to_string end_date))
+  in
+  let sexp =
+    "((generated_at 2020-05-30)\n (symbols (\n"
+    ^ String.concat ~sep:"\n" body_lines
+    ^ ")))\n"
+  in
+  Out_channel.write_all path ~data:sexp;
+  path
+
+(* [entries] is [(symbol, asset_type, data_end_date)]. Returns [(root, config)]
+   with the default config plus [max_staleness_trading_days]. *)
+let _setup_staleness ~max_staleness_trading_days ~entries =
+  let root = _make_tmp_dir "stale" in
+  let bars_root = Filename.concat root "bars" in
+  ignore
+    (Stdlib.Sys.command
+       (Printf.sprintf "mkdir -p %s" (Filename.quote bars_root))
+      : int);
+  List.iter entries ~f:(fun (sym, _, _) ->
+      _write_staleness_bars ~root:bars_root sym);
+  let symbol_types_path =
+    _write_symbol_types ~root
+      (List.map entries ~f:(fun (sym, asset_type, _) -> (sym, asset_type)))
+  in
+  let sectors_csv_path =
+    _write_sectors_csv ~root
+      (List.map entries ~f:(fun (sym, _, _) -> (sym, "Tech")))
+  in
+  let inventory_path =
+    _write_inventory_with_end_dates ~root
+      (List.map entries ~f:(fun (sym, _, end_date) -> (sym, end_date)))
+  in
+  let config =
+    {
+      (BEU.default_config ~bars_root ~symbol_types_path ~sectors_csv_path
+         ~inventory_path)
+      with
+      max_staleness_trading_days;
+    }
+  in
+  (root, config)
+
+let _build_staleness_or_fail ~config =
+  match BEU.build_with_staleness_report ~date:_staleness_build_date ~config with
+  | Ok result -> result
+  | Error err -> assert_failure ("build failed: " ^ Status.show err)
+
 let _build_or_fail ~config =
   match BEU.build ~date:_build_date ~config with
   | Ok snapshot -> snapshot
@@ -337,6 +421,69 @@ let test_entry_metadata _ =
          field (fun s -> s.aggregate_period_return) (float_equal 0.0);
        ])
 
+(* Dates relative to the Thursday 2020-05-28 staleness build date. *)
+let _wed = Date.create_exn ~y:2020 ~m:Month.May ~d:27 (* 1 trading day late *)
+let _tue = Date.create_exn ~y:2020 ~m:Month.May ~d:26 (* 2 trading days late *)
+let _mon = Date.create_exn ~y:2020 ~m:Month.May ~d:25 (* 3 trading days late *)
+
+(* Parity: at max_staleness_trading_days = 0 a symbol whose last bar is one
+   trading day stale (Wed, the day before the Thursday build date) is excluded,
+   while a same-day (Thursday) symbol is kept — exactly the pre-tolerance
+   behaviour the default must preserve. *)
+let test_staleness_default_zero_excludes_one_day_stale _ =
+  let entries =
+    [ ("FRESH", _common, _staleness_build_date); ("STALE1D", _common, _wed) ]
+  in
+  let root, config = _setup_staleness ~max_staleness_trading_days:0 ~entries in
+  let snapshot, _report = _build_staleness_or_fail ~config in
+  _cleanup_dir root;
+  assert_that (_symbols snapshot) (elements_are [ equal_to "FRESH" ])
+
+(* Tolerance includes within budget: at max_staleness_trading_days = 2, symbols
+   stale by 1 and 2 trading days survive, while a 3-trading-day-stale symbol is
+   still dropped. Output is rank-ordered by dollar volume (all equal here), so
+   ties fall back to inventory order: FRESH, STALE1D, STALE2D. *)
+let test_staleness_tolerance_includes_within_budget _ =
+  let entries =
+    [
+      ("FRESH", _common, _staleness_build_date);
+      ("STALE1D", _common, _wed);
+      ("STALE2D", _common, _tue);
+      ("STALE3D", _common, _mon);
+    ]
+  in
+  let root, config = _setup_staleness ~max_staleness_trading_days:2 ~entries in
+  let snapshot, _report = _build_staleness_or_fail ~config in
+  _cleanup_dir root;
+  assert_that
+    (List.sort (_symbols snapshot) ~compare:String.compare)
+    (elements_are [ equal_to "FRESH"; equal_to "STALE1D"; equal_to "STALE2D" ])
+
+(* Observability: the staleness report counts symbols excluded specifically for
+   stale data and carries a sample of their tickers, in inventory order. At
+   tolerance 0, STALE1D and STALE3D (both equity-like, both past the budget) are
+   reported; the ETF is junk and not counted as a staleness exclusion. *)
+let test_staleness_report_counts_and_samples _ =
+  let entries =
+    [
+      ("FRESH", _common, _staleness_build_date);
+      ("STALE1D", _common, _wed);
+      ("STALEJUNK", _etf, _tue);
+      ("STALE3D", _common, _mon);
+    ]
+  in
+  let root, config = _setup_staleness ~max_staleness_trading_days:0 ~entries in
+  let _snapshot, report = _build_staleness_or_fail ~config in
+  _cleanup_dir root;
+  assert_that report
+    (all_of
+       [
+         field (fun r -> r.BEU.excluded_count) (equal_to 2);
+         field
+           (fun r -> r.BEU.sample)
+           (elements_are [ equal_to "STALE1D"; equal_to "STALE3D" ]);
+       ])
+
 let suite =
   "Build_eligible_universe"
   >::: [
@@ -350,6 +497,12 @@ let suite =
          "test_empty_universe_is_error" >:: test_empty_universe_is_error;
          "test_determinism" >:: test_determinism;
          "test_entry_metadata" >:: test_entry_metadata;
+         "test_staleness_default_zero_excludes_one_day_stale"
+         >:: test_staleness_default_zero_excludes_one_day_stale;
+         "test_staleness_tolerance_includes_within_budget"
+         >:: test_staleness_tolerance_includes_within_budget;
+         "test_staleness_report_counts_and_samples"
+         >:: test_staleness_report_counts_and_samples;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Fixes #1783. The eligible-universe builder's active filter
(`Build_eligible_universe._is_active`) dropped any symbol whose last bar
was even one trading day stale (`data_end_date < date`), silently
shrinking a screen when a partial / lagging data refresh left otherwise-
fresh names behind (the reported AAPL/MSFT/NVDA/AMZN + ~460 others).

Two surgical, default-preserving changes:

1. **Configurable staleness tolerance.** New
   `max_staleness_trading_days : int` field on
   `Build_eligible_universe.config` (default `0` = exactly the prior
   behaviour, bit-identical). The end-date gate now keeps a symbol whose
   last bar is within that many **trading days** of `date`. A "trading
   day" is a weekday (Mon–Fri); market holidays are not modelled, so the
   field is named `trading_days`, not `sessions`, and the budget counts
   weekdays via `Date.dates_between` + a weekday filter.

2. **Observability.** New `staleness_report = { excluded_count; sample }`
   counting symbols dropped **specifically** for staleness (past the
   start gate + equity-like, but stale beyond the budget), with a small
   deterministic ticker sample. Returned by the new
   `build_with_staleness_report`; `build` delegates to it (snapshot
   identical). `build_eligible_universe_runner` gains a
   `-max-staleness-trading-days` flag and prints
   `[eligible-universe] N symbols excluded for staleness (sample: …)`
   when `N > 0`, making a silent universe-shrink visible.

## Why

A symbol one trading day stale was silently excluded — brittle for live
runs and invisible when a partial refresh shrank the universe. Default
`0` keeps current behaviour; operators opt into a tolerance and always
see the staleness exclusion count.

## Test plan

`dune runtest analysis/data/universe/` (13 tests, 3 new):

- `test_staleness_default_zero_excludes_one_day_stale` — parity:
  at `max_staleness_trading_days = 0` a 1-trading-day-stale symbol is
  excluded, a same-day symbol kept (default == prior behaviour).
- `test_staleness_tolerance_includes_within_budget` — at tolerance `2`,
  symbols stale by 1 and 2 trading days survive; a 3-day-stale one is
  still dropped.
- `test_staleness_report_counts_and_samples` — the report counts the
  staleness-excluded set and samples their tickers in inventory order;
  a stale ETF is junk, not a staleness exclusion.

All 10 pre-existing tests still pass unchanged (default-0 parity).
`dune build` (whole repo) clean; `dune build @fmt` clean on touched
files. No Python added; new constants named
(`_default_max_staleness_trading_days`, `staleness_sample_size`).

> Note: the full-repo `dune runtest` was interrupted locally by a hung
> `linter_magic_numbers.sh` (stuck in `pipe_read` ~44 min, an
> environment artifact unrelated to this diff); CI runs the full linter
> suite authoritatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
