### PR TITLE
feat(decision-audit): per-screen faithfulness audit (enrich near-misses + report)

### DIFF
--- a/dev/status/decision-audit.md
+++ b/dev/status/decision-audit.md
@@ -1,0 +1,57 @@
+# Status: decision-audit
+
+## Last updated: 2026-07-01
+
+## Status
+READY_FOR_REVIEW
+
+Per-screen faithfulness decision-audit (spec #8,
+`dev/plans/per-screen-decision-audit-2026-06-30.md`). Additive, default-off
+(read-only lens), no engine/strategy behaviour change. Consumes the
+`trade-audit` track's `trade_audit.sexp`.
+
+## Goal
+
+Surface the near-miss data already captured in `trade_audit.sexp` as a
+per-screen **faithfulness** audit — comparing each weekly screen's **funded**
+entries against the **cash-rejected near-misses** on the *captured decision-time
+features* (score, grade, stage, weeks_advancing, rs_value, volume_ratio,
+sector). Not an outcome grader: the question is capture/use-completeness ("does
+any signal we record separate funded from near-miss, and are we funding on it?"),
+not "did the picks make money" (which is WAI-poor).
+
+## Completed
+
+- [x] **Phase 0 — enrich `alternative_candidate`** (this PR, commit 1).
+  Added `stage / weeks_advancing / rs_value / volume_ratio / sector_name /
+  score_components` to `Backtest.Trade_audit.alternative_candidate` so
+  near-misses carry the same decision-time features the funded `entry_decision`
+  records. Sourced in `trade_audit_recorder._alternative_of_event` from each
+  near-miss's own `Screener.scored_candidate` (analysis.stage / .rs / .volume /
+  sector). `score_components` is `[]` until the screener exposes per-component
+  contributions (same ceiling the funded `cascade_score_components` has today).
+  Additive + default-populated; existing readers unchanged. Round-trip sexp test
+  extended. Verify: `dune runtest trading/backtest/test` (test_trade_audit, 19
+  tests).
+- [x] **Phase 1 — `decision_audit` lib + bin + tests** (this PR, commit 2).
+  New `trading/trading/backtest/decision_audit/{lib,bin,test}/`.
+  - `Screen_record.of_audit_records` groups entry decisions by screen date,
+    projects funded/near-miss, dedups near-misses by symbol (score-desc),
+    computes summary (min funded score, max near-miss score, inversion flag).
+  - `Report.feature_stats` + `to_markdown` render the faithfulness roll-up
+    (funded-vs-near-miss means per feature + skip-reason breakdown) plus one
+    section per screen date.
+  - `decision_audit_bin` CLI: `--audit <trade_audit.sexp> [--out <md>]`.
+  Verify: `dune runtest trading/backtest/decision_audit` (10 tests: 6
+  screen_record + 4 report). Smoke: `dune exec
+  trading/backtest/decision_audit/bin/decision_audit_bin.exe -- --audit
+  <trade_audit.sexp>`.
+
+## Follow-ups
+
+- **Phase 2 (stretch)** — forward-return counterfactual on the cash-rejected
+  names (reuse `decision_grading/post_exit`), the one place outcome enters, to
+  test whether *usable captured signal* is left on the table. Out of scope here.
+- **score_components** — populate once the screener splits its additive score
+  into per-component contributions (would lift the current ceiling for both the
+  funded path and near-misses).

--- a/dev/status/decision-audit.md
+++ b/dev/status/decision-audit.md
@@ -5,6 +5,9 @@
 ## Status
 READY_FOR_REVIEW
 
+## Interface stable
+YES
+
 Per-screen faithfulness decision-audit (spec #8,
 `dev/plans/per-screen-decision-audit-2026-06-30.md`). Additive, default-off
 (read-only lens), no engine/strategy behaviour change. Consumes the

--- a/trading/trading/backtest/decision_audit/bin/decision_audit_bin.ml
+++ b/trading/trading/backtest/decision_audit/bin/decision_audit_bin.ml
@@ -1,0 +1,75 @@
+(** [decision_audit] — per-screen faithfulness audit of a backtest's entries.
+
+    Reads a [trade_audit.sexp] (produced by {!Backtest.Result_writer.write}
+    alongside [trades.csv]), groups the entry decisions by weekly screen date,
+    and for each screen compares the {b funded} entries against the
+    {b cash-rejected near-misses} on the captured decision-time features (score,
+    grade, stage, weeks_advancing, rs_value, volume_ratio, sector).
+
+    This is a read-only faithfulness lens — it changes no strategy behaviour and
+    grades no picks by outcome. It answers: at each screen, do the funded names
+    differ from the near-misses on any signal we capture? If none, the tie is
+    uninformative and selection is faithful; if one does and we are not funding
+    on it, that is a candidate lever. See
+    [dev/plans/per-screen-decision-audit-2026-06-30.md].
+
+    Usage:
+    {[
+      decision_audit --audit <trade_audit.sexp> [--out report.md]
+    ]}
+
+    [--audit] is required. [--out], when given, writes the markdown there;
+    otherwise it goes to stdout. *)
+
+open Core
+module TA = Backtest.Trade_audit
+module DA = Decision_audit
+
+let _usage () =
+  eprintf "Usage: decision_audit --audit <trade_audit.sexp> [--out report.md]\n";
+  Stdlib.exit 1
+
+type _parse_acc = {
+  mutable audit_path : string option;
+  mutable out_path : string option;
+}
+
+let _parse_flag args =
+  let acc = { audit_path = None; out_path = None } in
+  let rec loop = function
+    | [] -> acc
+    | "--audit" :: p :: rest ->
+        acc.audit_path <- Some p;
+        loop rest
+    | "--out" :: p :: rest ->
+        acc.out_path <- Some p;
+        loop rest
+    | _ -> _usage ()
+  in
+  loop args
+
+(** Load the audit records from [path]. Accepts both the combined
+    {!TA.audit_blob} envelope and the bare {!TA.audit_records} list, matching
+    the loader in [decision_grading_bin]. *)
+let _load_audit_records ~path : TA.audit_record list =
+  let sexp = Sexp.load_sexp path in
+  try (TA.audit_blob_of_sexp sexp).audit_records
+  with _ -> TA.audit_records_of_sexp sexp
+
+let () =
+  let acc = _parse_flag (List.tl_exn (Array.to_list (Sys.get_argv ()))) in
+  let audit_path =
+    Option.value_or_thunk acc.audit_path ~default:(fun () ->
+        eprintf "--audit is required\n";
+        _usage ())
+  in
+  let records = _load_audit_records ~path:audit_path in
+  let screens = DA.Screen_record.of_audit_records records in
+  eprintf "decision_audit: %d entries across %d screens from %s\n%!"
+    (List.length records) (List.length screens) audit_path;
+  let markdown = DA.Report.to_markdown screens in
+  match acc.out_path with
+  | Some path ->
+      Out_channel.write_all path ~data:markdown;
+      eprintf "decision_audit: wrote %s\n%!" path
+  | None -> print_string markdown

--- a/trading/trading/backtest/decision_audit/bin/dune
+++ b/trading/trading/backtest/decision_audit/bin/dune
@@ -1,0 +1,6 @@
+(executable
+ (name decision_audit_bin)
+ (modules decision_audit_bin)
+ (libraries core status backtest decision_audit)
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/lib/dune
+++ b/trading/trading/backtest/decision_audit/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name decision_audit)
+ (libraries core types trading.base backtest)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/lib/report.ml
+++ b/trading/trading/backtest/decision_audit/lib/report.ml
@@ -1,0 +1,158 @@
+(** Markdown rendering for the per-screen decision-audit. See [report.mli]. *)
+
+open Core
+module SR = Screen_record
+module TA = Backtest.Trade_audit
+
+type feature_stat = {
+  feature : string;
+  funded_n : int;
+  funded_mean : float option;
+  near_miss_n : int;
+  near_miss_mean : float option;
+}
+[@@deriving sexp]
+
+(* Short one-letter stage label for the compact per-screen listing. *)
+let _stage_label : Weinstein_types.stage -> string = function
+  | Stage1 _ -> "S1"
+  | Stage2 { late; _ } -> if late then "S2L" else "S2"
+  | Stage3 _ -> "S3"
+  | Stage4 _ -> "S4"
+
+let _skip_reason_label (r : TA.skip_reason) : string =
+  Sexp.to_string (TA.sexp_of_skip_reason r)
+
+let _mean = function
+  | [] -> None
+  | xs ->
+      Some (List.sum (module Float) xs ~f:Fn.id /. Float.of_int (List.length xs))
+
+let _opt_float = Option.value_map ~default:"-" ~f:(Printf.sprintf "%.2f")
+
+(* Pool a numeric feature across screens from both sides, dropping [None]s. *)
+let _stat ~feature ~(funded : float list) ~(near_miss : float list) :
+    feature_stat =
+  {
+    feature;
+    funded_n = List.length funded;
+    funded_mean = _mean funded;
+    near_miss_n = List.length near_miss;
+    near_miss_mean = _mean near_miss;
+  }
+
+let _collect_funded records ~f =
+  List.concat_map records ~f:(fun (s : SR.t) -> List.filter_map s.funded ~f)
+
+let _collect_near records ~f =
+  List.concat_map records ~f:(fun (s : SR.t) ->
+      List.filter_map s.near_misses ~f)
+
+let feature_stats (records : SR.t list) : feature_stat list =
+  let stat feature ~funded_f ~near_f =
+    _stat ~feature
+      ~funded:(_collect_funded records ~f:funded_f)
+      ~near_miss:(_collect_near records ~f:near_f)
+  in
+  [
+    stat "score"
+      ~funded_f:(fun (e : SR.funded_entry) -> Some (Float.of_int e.score))
+      ~near_f:(fun (n : SR.near_miss) -> Some (Float.of_int n.score));
+    stat "rs_value"
+      ~funded_f:(fun e -> e.rs_value)
+      ~near_f:(fun n -> n.rs_value);
+    stat "volume_ratio"
+      ~funded_f:(fun e -> e.volume_ratio)
+      ~near_f:(fun n -> n.volume_ratio);
+    stat "weeks_advancing"
+      ~funded_f:(fun e -> Option.map e.weeks_advancing ~f:Float.of_int)
+      ~near_f:(fun n -> Option.map n.weeks_advancing ~f:Float.of_int);
+  ]
+
+let _feature_table (records : SR.t list) : string =
+  let row (s : feature_stat) =
+    Printf.sprintf "| %s | %s (n=%d) | %s (n=%d) |\n" s.feature
+      (_opt_float s.funded_mean) s.funded_n
+      (_opt_float s.near_miss_mean)
+      s.near_miss_n
+  in
+  "| feature | funded mean | near-miss mean |\n|---|---|---|\n"
+  ^ String.concat (List.map (feature_stats records) ~f:row)
+
+(* Near-miss skip_reason breakdown: which constraint dropped the near-misses. *)
+let _reason_breakdown (records : SR.t list) : string =
+  let all =
+    List.concat_map records ~f:(fun (s : SR.t) ->
+        List.map s.near_misses ~f:(fun n -> _skip_reason_label n.reason_skipped))
+  in
+  let counts =
+    List.map all ~f:(fun r -> (r, ()))
+    |> Map.of_alist_multi (module String)
+    |> Map.to_alist
+    |> List.map ~f:(fun (r, hits) -> (r, List.length hits))
+    |> List.sort ~compare:(fun (_, a) (_, b) -> Int.compare b a)
+  in
+  match counts with
+  | [] -> ""
+  | _ ->
+      "\nNear-miss skip reasons: "
+      ^ String.concat ~sep:", "
+          (List.map counts ~f:(fun (r, c) -> Printf.sprintf "%s=%d" r c))
+      ^ "\n"
+
+let _header (records : SR.t list) : string =
+  let n_screens = List.length records in
+  let n_funded =
+    List.sum (module Int) records ~f:(fun (s : SR.t) -> s.summary.n_funded)
+  in
+  let n_near =
+    List.sum (module Int) records ~f:(fun (s : SR.t) -> s.summary.n_near_miss)
+  in
+  let n_inv = List.count records ~f:(fun (s : SR.t) -> s.summary.inversion) in
+  Printf.sprintf
+    "# Per-screen faithfulness audit\n\n\
+     Screens: %d | funded: %d | near-misses: %d | screens with inversion: %d\n\n\
+     Faithfulness question: does any captured feature separate the funded set \
+     from the cash-rejected near-misses? Overlapping means = uninformative tie \
+     (faithful/expected).\n\n\
+     ## Funded vs near-miss on captured features\n\n\
+     %s%s\n"
+    n_screens n_funded n_near n_inv (_feature_table records)
+    (_reason_breakdown records)
+
+let _funded_line (e : SR.funded_entry) : string =
+  Printf.sprintf "%s s%d %s %s" e.symbol e.score
+    (Weinstein_types.grade_to_string e.grade)
+    (_stage_label e.stage)
+
+let _near_line (n : SR.near_miss) : string =
+  Printf.sprintf "%s s%d %s %s [%s]" n.symbol n.score
+    (Weinstein_types.grade_to_string n.grade)
+    (_stage_label n.stage)
+    (_skip_reason_label n.reason_skipped)
+
+let _screen_section (s : SR.t) : string =
+  let funded =
+    if List.is_empty s.funded then "  (none)\n"
+    else
+      String.concat
+        (List.map s.funded ~f:(fun e -> "  " ^ _funded_line e ^ "\n"))
+  in
+  let near =
+    if List.is_empty s.near_misses then "  (none)\n"
+    else
+      String.concat
+        (List.map s.near_misses ~f:(fun n -> "  " ^ _near_line n ^ "\n"))
+  in
+  Printf.sprintf
+    "## %s  (funded %d, near-misses %d)\n\
+     funded:\n\
+     %snear-miss:\n\
+     %sinversion: %b\n\n"
+    (Date.to_string s.screen_date)
+    s.summary.n_funded s.summary.n_near_miss funded near s.summary.inversion
+
+let to_markdown (records : SR.t list) : string =
+  match records with
+  | [] -> "# Per-screen faithfulness audit\n\nNo entry decisions in audit.\n"
+  | _ -> _header records ^ String.concat (List.map records ~f:_screen_section)

--- a/trading/trading/backtest/decision_audit/lib/report.mli
+++ b/trading/trading/backtest/decision_audit/lib/report.mli
@@ -1,0 +1,39 @@
+(** Markdown rendering for the per-screen decision-audit — the faithfulness
+    lens.
+
+    Two parts:
+    - a {b roll-up header} answering the faithfulness question: across all
+      screens, does any captured feature (score / rs_value / volume_ratio /
+      weeks_advancing / stage / sector) separate the {b funded} entries from the
+      {b cash-rejected near-misses}? If none does, the tie is uninformative and
+      selection is faithful.
+    - a {b per-screen section} listing each screen's funded entries, its
+      near-misses (emphasising [Insufficient_cash] — the binding constraint),
+      and the inversion flag.
+
+    Pure: same {!Screen_record.t} list in → same markdown out. *)
+
+type feature_stat = {
+  feature : string;  (** Human-readable feature name, e.g. ["rs_value"]. *)
+  funded_n : int;  (** Count of funded entries with the feature present. *)
+  funded_mean : float option;
+      (** Mean of the feature over funded entries, or [None] when
+          [funded_n = 0]. *)
+  near_miss_n : int;
+  near_miss_mean : float option;
+}
+[@@deriving sexp]
+(** Funded-vs-near-miss central-tendency comparison for one numeric captured
+    feature. A feature whose funded and near-miss means overlap does not
+    separate the two sets — the faithful/expected case. *)
+
+val feature_stats : Screen_record.t list -> feature_stat list
+(** Compute the funded-vs-near-miss {!feature_stat} for each numeric captured
+    feature (score, rs_value, volume_ratio, weeks_advancing) pooled across all
+    screens. [None]-valued features contribute to neither count nor mean. *)
+
+val to_markdown : Screen_record.t list -> string
+(** Render the full report: roll-up header (screen/entry/near-miss totals,
+    inversion count, the funded-vs-near-miss {!feature_stats} table, and a
+    near-miss [skip_reason] breakdown) followed by one section per screen date.
+    Emits a graceful "no entry decisions" note when the input is empty. *)

--- a/trading/trading/backtest/decision_audit/lib/screen_record.ml
+++ b/trading/trading/backtest/decision_audit/lib/screen_record.ml
@@ -1,0 +1,135 @@
+(** Per-screen decision-audit records. See [screen_record.mli]. *)
+
+open Core
+module TA = Backtest.Trade_audit
+
+type funded_entry = {
+  symbol : string;
+  score : int;
+  grade : Weinstein_types.grade;
+  stage : Weinstein_types.stage;
+  weeks_advancing : int option;
+  rs_value : float option;
+  volume_ratio : float option;
+  sector_name : string;
+}
+[@@deriving sexp]
+
+type near_miss = {
+  symbol : string;
+  score : int;
+  grade : Weinstein_types.grade;
+  reason_skipped : TA.skip_reason;
+  stage : Weinstein_types.stage;
+  weeks_advancing : int option;
+  rs_value : float option;
+  volume_ratio : float option;
+  sector_name : string;
+}
+[@@deriving sexp]
+
+type summary = {
+  n_funded : int;
+  n_near_miss : int;
+  min_funded_score : int option;
+  max_nearmiss_score : int option;
+  inversion : bool;
+}
+[@@deriving sexp]
+
+type t = {
+  screen_date : Date.t;
+  funded : funded_entry list;
+  near_misses : near_miss list;
+  summary : summary;
+}
+[@@deriving sexp]
+
+let _funded_of_entry (e : TA.entry_decision) : funded_entry =
+  {
+    symbol = e.symbol;
+    score = e.cascade_score;
+    grade = e.cascade_grade;
+    stage = e.stage;
+    weeks_advancing =
+      (match e.stage with
+      | Stage2 { weeks_advancing; _ } -> Some weeks_advancing
+      | _ -> None);
+    rs_value = e.rs_value;
+    volume_ratio = e.volume_ratio;
+    sector_name = e.sector_name;
+  }
+
+let _near_miss_of_alt (a : TA.alternative_candidate) : near_miss =
+  {
+    symbol = a.symbol;
+    score = a.score;
+    grade = a.grade;
+    reason_skipped = a.reason_skipped;
+    stage = a.stage;
+    weeks_advancing = a.weeks_advancing;
+    rs_value = a.rs_value;
+    volume_ratio = a.volume_ratio;
+    sector_name = a.sector_name;
+  }
+
+(** Deduplicate near-misses by symbol (keep the first, i.e. highest-scored after
+    the score-desc sort), then re-sort score-desc so the report reads top-down.
+*)
+let _dedup_near_misses (alts : near_miss list) : near_miss list =
+  let sorted =
+    List.stable_sort alts ~compare:(fun a b -> Int.compare b.score a.score)
+  in
+  List.remove_consecutive_duplicates
+    (List.sort sorted ~compare:(fun a b -> String.compare a.symbol b.symbol))
+    ~equal:(fun a b -> String.equal a.symbol b.symbol)
+  |> List.sort ~compare:(fun a b -> Int.compare b.score a.score)
+
+let _summary_of ~(funded : funded_entry list) ~(near_misses : near_miss list) :
+    summary =
+  let min_funded_score =
+    List.min_elt funded ~compare:(fun (a : funded_entry) b ->
+        Int.compare a.score b.score)
+    |> Option.map ~f:(fun (e : funded_entry) -> e.score)
+  in
+  let max_nearmiss_score =
+    List.max_elt near_misses ~compare:(fun (a : near_miss) b ->
+        Int.compare a.score b.score)
+    |> Option.map ~f:(fun (n : near_miss) -> n.score)
+  in
+  let inversion =
+    match min_funded_score with
+    | None -> false
+    | Some min_f ->
+        List.exists near_misses ~f:(fun (n : near_miss) -> n.score > min_f)
+  in
+  {
+    n_funded = List.length funded;
+    n_near_miss = List.length near_misses;
+    min_funded_score;
+    max_nearmiss_score;
+    inversion;
+  }
+
+let _record_of_screen ~screen_date ~(entries : TA.entry_decision list) : t =
+  let funded = List.map entries ~f:_funded_of_entry in
+  let raw_near_misses =
+    List.concat_map entries ~f:(fun e ->
+        List.map e.alternatives_considered ~f:_near_miss_of_alt)
+  in
+  let near_misses = _dedup_near_misses raw_near_misses in
+  {
+    screen_date;
+    funded;
+    near_misses;
+    summary = _summary_of ~funded ~near_misses;
+  }
+
+let of_audit_records (records : TA.audit_record list) : t list =
+  let by_date = Hashtbl.create (module Date) in
+  List.iter records ~f:(fun (r : TA.audit_record) ->
+      Hashtbl.add_multi by_date ~key:r.entry.entry_date ~data:r.entry);
+  Hashtbl.to_alist by_date
+  |> List.sort ~compare:(fun (d1, _) (d2, _) -> Date.compare d1 d2)
+  |> List.map ~f:(fun (screen_date, entries_rev) ->
+      _record_of_screen ~screen_date ~entries:(List.rev entries_rev))

--- a/trading/trading/backtest/decision_audit/lib/screen_record.mli
+++ b/trading/trading/backtest/decision_audit/lib/screen_record.mli
@@ -1,0 +1,86 @@
+(** Per-screen decision-audit records — group a backtest's entry decisions by
+    the weekly screen (Friday) they were taken on, and pair each screen's
+    {b funded} entries against the {b cash-rejected near-misses} that scored at
+    the same screen call.
+
+    This is a {b faithfulness} lens, not an outcome grader (see
+    [dev/plans/per-screen-decision-audit-2026-06-30.md]): it compares funded vs
+    near-miss on the {b captured decision-time features} — score, grade, stage,
+    [weeks_advancing], [rs_value], [volume_ratio], sector — to ask whether any
+    signal the screener records separates the two sets. If none does, the tie is
+    genuinely uninformative and selection is faithful; if one does and we do not
+    fund on it, that is a candidate lever.
+
+    Pure: same [audit_record] list in → same records out. *)
+
+open Core
+
+type funded_entry = {
+  symbol : string;
+  score : int;
+  grade : Weinstein_types.grade;
+  stage : Weinstein_types.stage;
+  weeks_advancing : int option;
+      (** [weeks_advancing] when [stage] is [Stage2], else [None]. *)
+  rs_value : float option;
+  volume_ratio : float option;
+  sector_name : string;
+}
+[@@deriving sexp]
+(** A candidate that was actually entered on a given screen date. Projected from
+    {!Backtest.Trade_audit.entry_decision}. *)
+
+type near_miss = {
+  symbol : string;
+  score : int;
+  grade : Weinstein_types.grade;
+  reason_skipped : Backtest.Trade_audit.skip_reason;
+  stage : Weinstein_types.stage;
+  weeks_advancing : int option;
+  rs_value : float option;
+  volume_ratio : float option;
+  sector_name : string;
+}
+[@@deriving sexp]
+(** A candidate that scored at the same screen call but was not entered.
+    Projected from {!Backtest.Trade_audit.alternative_candidate}. *)
+
+type summary = {
+  n_funded : int;
+  n_near_miss : int;
+  min_funded_score : int option;
+      (** Lowest score among the funded entries, or [None] when none were
+          funded. *)
+  max_nearmiss_score : int option;
+      (** Highest score among the near-misses, or [None] when there were none.
+      *)
+  inversion : bool;
+      (** [true] when some near-miss scored strictly higher than the lowest
+          funded entry — i.e. a higher-scored name was skipped for a
+          lower-scored one. Usually [false] (funding walks score-desc); an
+          inversion flags a sizing / sector-cap quirk worth eyeballing. *)
+}
+[@@deriving sexp]
+(** Per-screen roll-up counts + the inversion flag. *)
+
+type t = {
+  screen_date : Date.t;  (** The Friday the screen ran (the entry date). *)
+  funded : funded_entry list;
+      (** Entries taken this screen, in screener order (score-desc). *)
+  near_misses : near_miss list;
+      (** Union of [alternatives_considered] across this screen's entries,
+          deduplicated by symbol (first occurrence wins), sorted score-desc. *)
+  summary : summary;
+}
+[@@deriving sexp]
+(** One record per weekly screen date. *)
+
+val of_audit_records : Backtest.Trade_audit.audit_record list -> t list
+(** Group the entry side of [audit_records] by [entry_date] into one {!t} per
+    screen, sorted by [screen_date] ascending.
+
+    For each screen: [funded] = the entries taken that date; [near_misses] = the
+    union of every entry's [alternatives_considered], deduplicated by symbol
+    (keeping the first, i.e. highest-scored, occurrence) and sorted score-desc;
+    [summary] computes the counts + [inversion] flag. Exit records are ignored —
+    this lens is entry-side only. *)

--- a/trading/trading/backtest/decision_audit/test/dune
+++ b/trading/trading/backtest/decision_audit/test/dune
@@ -1,0 +1,5 @@
+(tests
+ (names test_screen_record test_report)
+ (libraries ounit2 core matchers decision_audit backtest types trading.base)
+ (preprocess
+  (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/test/test_report.ml
+++ b/trading/trading/backtest/decision_audit/test/test_report.ml
@@ -1,0 +1,141 @@
+(** Unit tests for [Decision_audit.Report].
+
+    Covers the funded-vs-near-miss feature statistics (means + counts, [None]s
+    dropped) and the markdown roll-up header content, on synthetic
+    [Screen_record.t] lists built directly (bypassing the audit projection). *)
+
+open OUnit2
+open Core
+open Matchers
+module TA = Backtest.Trade_audit
+module SR = Decision_audit.Screen_record
+module Report = Decision_audit.Report
+
+let _date d = Date.of_string d
+
+let _funded ~symbol ~score ?(rs_value = Some 1.0) ?(volume_ratio = Some 2.0)
+    ?(weeks_advancing = Some 2) () : SR.funded_entry =
+  {
+    symbol;
+    score;
+    grade = Weinstein_types.A;
+    stage = Weinstein_types.Stage2 { weeks_advancing = 2; late = false };
+    weeks_advancing;
+    rs_value;
+    volume_ratio;
+    sector_name = "Tech";
+  }
+
+let _near ~symbol ~score ?(rs_value = Some 0.9) ?(volume_ratio = Some 1.2)
+    ?(weeks_advancing = Some 5) () : SR.near_miss =
+  {
+    symbol;
+    score;
+    grade = Weinstein_types.B;
+    reason_skipped = TA.Insufficient_cash;
+    stage = Weinstein_types.Stage2 { weeks_advancing = 5; late = false };
+    weeks_advancing;
+    rs_value;
+    volume_ratio;
+    sector_name = "Tech";
+  }
+
+let _screen ~funded ~near_misses : SR.t =
+  {
+    screen_date = _date "2024-03-01";
+    funded;
+    near_misses;
+    summary =
+      {
+        n_funded = List.length funded;
+        n_near_miss = List.length near_misses;
+        min_funded_score = None;
+        max_nearmiss_score = None;
+        inversion = false;
+      };
+  }
+
+let _find_stat stats name =
+  List.find_exn stats ~f:(fun (s : Report.feature_stat) ->
+      String.equal s.feature name)
+
+let test_feature_stats_means_and_counts _ =
+  let screens =
+    [
+      _screen
+        ~funded:
+          [
+            _funded ~symbol:"A" ~score:80 ~rs_value:(Some 1.0) ();
+            _funded ~symbol:"B" ~score:70 ~rs_value:(Some 1.2) ();
+          ]
+        ~near_misses:[ _near ~symbol:"C" ~score:60 ~rs_value:(Some 0.8) () ];
+    ]
+  in
+  let stats = Report.feature_stats screens in
+  assert_that (_find_stat stats "score")
+    (all_of
+       [
+         field (fun (s : Report.feature_stat) -> s.funded_n) (equal_to 2);
+         field
+           (fun (s : Report.feature_stat) -> s.funded_mean)
+           (is_some_and (float_equal 75.0));
+         field (fun (s : Report.feature_stat) -> s.near_miss_n) (equal_to 1);
+         field
+           (fun (s : Report.feature_stat) -> s.near_miss_mean)
+           (is_some_and (float_equal 60.0));
+       ])
+
+let test_feature_stats_drops_none_values _ =
+  (* One funded rs_value is None → funded_n counts only the present one. *)
+  let screens =
+    [
+      _screen
+        ~funded:
+          [
+            _funded ~symbol:"A" ~score:80 ~rs_value:(Some 1.4) ();
+            _funded ~symbol:"B" ~score:70 ~rs_value:None ();
+          ]
+        ~near_misses:[];
+    ]
+  in
+  let stats = Report.feature_stats screens in
+  assert_that
+    (_find_stat stats "rs_value")
+    (all_of
+       [
+         field (fun (s : Report.feature_stat) -> s.funded_n) (equal_to 1);
+         field
+           (fun (s : Report.feature_stat) -> s.funded_mean)
+           (is_some_and (float_equal 1.4));
+         field (fun (s : Report.feature_stat) -> s.near_miss_n) (equal_to 0);
+         field (fun (s : Report.feature_stat) -> s.near_miss_mean) is_none;
+       ])
+
+let test_markdown_header_reports_totals _ =
+  let screens =
+    [
+      _screen
+        ~funded:[ _funded ~symbol:"A" ~score:80 () ]
+        ~near_misses:
+          [ _near ~symbol:"C" ~score:60 (); _near ~symbol:"D" ~score:55 () ];
+    ]
+  in
+  let md = Report.to_markdown screens in
+  assert_that md (contains_substring "Screens: 1 | funded: 1 | near-misses: 2")
+
+let test_markdown_empty_input _ =
+  assert_that (Report.to_markdown [])
+    (contains_substring "No entry decisions in audit")
+
+let suite =
+  "Decision_audit.Report"
+  >::: [
+         "feature_stats means + counts" >:: test_feature_stats_means_and_counts;
+         "feature_stats drops None values"
+         >:: test_feature_stats_drops_none_values;
+         "markdown header reports totals"
+         >:: test_markdown_header_reports_totals;
+         "markdown empty input" >:: test_markdown_empty_input;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/decision_audit/test/test_screen_record.ml
+++ b/trading/trading/backtest/decision_audit/test/test_screen_record.ml
@@ -1,0 +1,255 @@
+(** Unit tests for [Decision_audit.Screen_record].
+
+    Covers grouping entry decisions by screen date, the funded / near-miss
+    projection, near-miss dedup + score-desc ordering, and the summary (min/max
+    score + inversion flag) — all on synthetic [audit_record] lists. *)
+
+open OUnit2
+open Core
+open Matchers
+module TA = Backtest.Trade_audit
+module SR = Decision_audit.Screen_record
+
+let _date d = Date.of_string d
+
+let _alt ?(side = Trading_base.Types.Long)
+    ?(stage = Weinstein_types.Stage2 { weeks_advancing = 3; late = false })
+    ?(weeks_advancing = Some 3) ?(rs_value = Some 1.0)
+    ?(volume_ratio = Some 1.5) ?(sector_name = "Tech") ?(score_components = [])
+    ~symbol ~score ~grade ~reason () : TA.alternative_candidate =
+  {
+    symbol;
+    side;
+    score;
+    grade;
+    reason_skipped = reason;
+    stage;
+    weeks_advancing;
+    rs_value;
+    volume_ratio;
+    sector_name;
+    score_components;
+  }
+
+(** Minimal [entry_decision] carrying the fields [Screen_record] projects, plus
+    an [alternatives_considered] list. Non-projected fields get inert defaults.
+*)
+let _entry ?(entry_date = _date "2024-03-01") ?(symbol = "AAPL")
+    ?(position_id = "AAPL-1") ?(score = 80) ?(grade = Weinstein_types.A)
+    ?(stage = Weinstein_types.Stage2 { weeks_advancing = 2; late = false })
+    ?(rs_value = Some 1.1) ?(volume_ratio = Some 2.0) ?(sector_name = "Tech")
+    ?(alternatives = []) () : TA.entry_decision =
+  {
+    symbol;
+    entry_date;
+    position_id;
+    macro_trend = Weinstein_types.Bullish;
+    macro_confidence = 0.7;
+    macro_indicators = [];
+    stage;
+    ma_direction = Weinstein_types.Rising;
+    ma_slope_pct = 0.01;
+    rs_trend = None;
+    rs_value;
+    volume_quality = None;
+    volume_ratio;
+    resistance_quality = None;
+    support_quality = None;
+    sector_name;
+    sector_rating = Screener.Neutral;
+    cascade_score = score;
+    cascade_grade = grade;
+    cascade_score_components = [];
+    cascade_rationale = [];
+    side = Trading_base.Types.Long;
+    suggested_entry = 100.0;
+    suggested_stop = 92.0;
+    installed_stop = 92.0;
+    stop_floor_kind = TA.Buffer_fallback;
+    risk_pct = 0.08;
+    initial_position_value = 10_000.0;
+    initial_risk_dollars = 800.0;
+    alternatives_considered = alternatives;
+  }
+
+let _record entry : TA.audit_record = { entry; exit_ = None }
+
+(* Grouping -------------------------------------------------------------- *)
+
+let test_groups_by_screen_date _ =
+  let records =
+    [
+      _record
+        (_entry ~entry_date:(_date "2024-03-08") ~symbol:"MSFT"
+           ~position_id:"MSFT-1" ());
+      _record (_entry ~entry_date:(_date "2024-03-01") ~symbol:"AAPL" ());
+      _record
+        (_entry ~entry_date:(_date "2024-03-01") ~symbol:"NVDA"
+           ~position_id:"NVDA-1" ());
+    ]
+  in
+  assert_that
+    (SR.of_audit_records records)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (s : SR.t) -> Date.to_string s.screen_date)
+               (equal_to "2024-03-01");
+             field (fun (s : SR.t) -> s.summary.n_funded) (equal_to 2);
+           ];
+         all_of
+           [
+             field
+               (fun (s : SR.t) -> Date.to_string s.screen_date)
+               (equal_to "2024-03-08");
+             field (fun (s : SR.t) -> s.summary.n_funded) (equal_to 1);
+           ];
+       ])
+
+let test_funded_projection_carries_features _ =
+  let records =
+    [
+      _record
+        (_entry ~symbol:"AAPL" ~score:78 ~grade:Weinstein_types.A
+           ~stage:(Weinstein_types.Stage2 { weeks_advancing = 4; late = false })
+           ~rs_value:(Some 1.2) ~volume_ratio:(Some 2.3) ~sector_name:"Health"
+           ());
+    ]
+  in
+  assert_that
+    (SR.of_audit_records records)
+    (elements_are
+       [
+         field
+           (fun (s : SR.t) -> s.funded)
+           (elements_are
+              [
+                all_of
+                  [
+                    field
+                      (fun (e : SR.funded_entry) -> e.symbol)
+                      (equal_to "AAPL");
+                    field (fun (e : SR.funded_entry) -> e.score) (equal_to 78);
+                    field
+                      (fun (e : SR.funded_entry) -> e.weeks_advancing)
+                      (is_some_and (equal_to 4));
+                    field
+                      (fun (e : SR.funded_entry) -> e.rs_value)
+                      (is_some_and (float_equal 1.2));
+                    field
+                      (fun (e : SR.funded_entry) -> e.sector_name)
+                      (equal_to "Health");
+                  ];
+              ]);
+       ])
+
+(* Near-misses ----------------------------------------------------------- *)
+
+let test_near_misses_union_dedup_and_sorted _ =
+  (* Two entries on the same screen share the near-miss ADBE; it must dedup to
+     one, and near-misses must sort score-desc. *)
+  let alts_a =
+    [
+      _alt ~symbol:"ADBE" ~score:75 ~grade:Weinstein_types.A
+        ~reason:TA.Insufficient_cash ();
+      _alt ~symbol:"AMD" ~score:70 ~grade:Weinstein_types.B
+        ~reason:TA.Insufficient_cash ();
+    ]
+  in
+  let alts_b =
+    [
+      _alt ~symbol:"ADBE" ~score:75 ~grade:Weinstein_types.A
+        ~reason:TA.Insufficient_cash ();
+      _alt ~symbol:"CRM" ~score:72 ~grade:Weinstein_types.B
+        ~reason:TA.Sized_to_zero ();
+    ]
+  in
+  let records =
+    [
+      _record (_entry ~symbol:"AAPL" ~alternatives:alts_a ());
+      _record
+        (_entry ~symbol:"MSFT" ~position_id:"MSFT-1" ~alternatives:alts_b ());
+    ]
+  in
+  assert_that
+    (SR.of_audit_records records)
+    (elements_are
+       [
+         field
+           (fun (s : SR.t) -> s.near_misses)
+           (elements_are
+              [
+                field (fun (n : SR.near_miss) -> n.symbol) (equal_to "ADBE");
+                field (fun (n : SR.near_miss) -> n.symbol) (equal_to "CRM");
+                field (fun (n : SR.near_miss) -> n.symbol) (equal_to "AMD");
+              ]);
+       ])
+
+(* Summary + inversion --------------------------------------------------- *)
+
+let test_summary_scores_and_no_inversion _ =
+  (* Funded min score 80; near-misses all below → no inversion. *)
+  let alts =
+    [
+      _alt ~symbol:"AMD" ~score:70 ~grade:Weinstein_types.B
+        ~reason:TA.Insufficient_cash ();
+    ]
+  in
+  let records =
+    [ _record (_entry ~symbol:"AAPL" ~score:80 ~alternatives:alts ()) ]
+  in
+  assert_that
+    (SR.of_audit_records records)
+    (elements_are
+       [
+         field
+           (fun (s : SR.t) -> s.summary)
+           (all_of
+              [
+                field
+                  (fun (m : SR.summary) -> m.min_funded_score)
+                  (is_some_and (equal_to 80));
+                field
+                  (fun (m : SR.summary) -> m.max_nearmiss_score)
+                  (is_some_and (equal_to 70));
+                field (fun (m : SR.summary) -> m.inversion) (equal_to false);
+              ]);
+       ])
+
+let test_inversion_flagged_when_near_miss_outscores_funded _ =
+  (* A near-miss scored 90 > funded min 80 → inversion. *)
+  let alts =
+    [
+      _alt ~symbol:"NVDA" ~score:90 ~grade:Weinstein_types.A_plus
+        ~reason:TA.Sector_exposure_cap ();
+    ]
+  in
+  let records =
+    [ _record (_entry ~symbol:"AAPL" ~score:80 ~alternatives:alts ()) ]
+  in
+  assert_that
+    (SR.of_audit_records records)
+    (elements_are
+       [ field (fun (s : SR.t) -> s.summary.inversion) (equal_to true) ])
+
+let test_empty_input_yields_no_screens _ =
+  assert_that (SR.of_audit_records []) is_empty
+
+let suite =
+  "Decision_audit.Screen_record"
+  >::: [
+         "groups by screen date" >:: test_groups_by_screen_date;
+         "funded projection carries features"
+         >:: test_funded_projection_carries_features;
+         "near-misses union / dedup / sorted"
+         >:: test_near_misses_union_dedup_and_sorted;
+         "summary scores + no inversion"
+         >:: test_summary_scores_and_no_inversion;
+         "inversion flagged when near-miss outscores funded"
+         >:: test_inversion_flagged_when_near_miss_outscores_funded;
+         "empty input yields no screens" >:: test_empty_input_yields_no_screens;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/lib/trade_audit.ml
+++ b/trading/trading/backtest/lib/trade_audit.ml
@@ -24,6 +24,12 @@ type alternative_candidate = {
   score : int;
   grade : Weinstein_types.grade;
   reason_skipped : skip_reason;
+  stage : Weinstein_types.stage;
+  weeks_advancing : int option;
+  rs_value : float option;
+  volume_ratio : float option;
+  sector_name : string;
+  score_components : (string * int) list;
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/lib/trade_audit.mli
+++ b/trading/trading/backtest/lib/trade_audit.mli
@@ -78,9 +78,41 @@ type alternative_candidate = {
   score : int;
   grade : Weinstein_types.grade;
   reason_skipped : skip_reason;
+  (* Decision-time features, mirroring the funded {!entry_decision} so the
+     per-screen faithfulness audit can compare funded vs cash-rejected
+     near-misses on the same signals — not just [score]/[grade]. Sourced from
+     the near-miss's own [Screener.scored_candidate] at projection time (the
+     same values the funded path reads). See [decision_audit]. *)
+  stage : Weinstein_types.stage;
+      (** Weinstein stage at decision time (from the candidate's
+          [analysis.stage.stage]). *)
+  weeks_advancing : int option;
+      (** [weeks_advancing] when [stage] is [Stage2], else [None]. Redundant
+          with [stage] but surfaced so the report need not re-derive it. *)
+  rs_value : float option;
+      (** Normalized relative-strength value at decision time, or [None] when
+          the candidate carried no RS analysis. Same source as
+          [entry_decision.rs_value]. *)
+  volume_ratio : float option;
+      (** Breakout-bar volume / 4-week average at decision time, or [None] when
+          no breakout volume event was classified. Same source as
+          [entry_decision.volume_ratio]. *)
+  sector_name : string;
+      (** Sector the candidate sat in ([candidate.sector.sector_name]); empty
+          string when unknown. *)
+  score_components : (string * int) list;
+      (** Itemised score breakdown, mirroring
+          [entry_decision.cascade_score_components]. Empty until the screener
+          exposes per-component contributions (same ceiling the funded path has
+          today). *)
 }
 [@@deriving sexp]
-(** A screener candidate that was scored at decision time but not entered. *)
+(** A screener candidate that was scored at decision time but not entered.
+
+    Carries the same decision-time features as the funded {!entry_decision}
+    ([stage], [rs_value], [volume_ratio], [sector_name], ...) so the per-screen
+    faithfulness audit can ask whether any captured signal separates the funded
+    set from the cash-rejected near-misses. *)
 
 (** Whether the installed initial stop sat on a support floor or fell back to a
     fixed-buffer stop below the screener's suggested level. Routed from

--- a/trading/trading/backtest/lib/trade_audit_recorder.ml
+++ b/trading/trading/backtest/lib/trade_audit_recorder.ml
@@ -16,14 +16,35 @@ let _skip_reason_of_event = function
   | AR.Stop_too_wide -> Trade_audit.Stop_too_wide
   | AR.Sector_exposure_cap -> Trade_audit.Sector_exposure_cap
 
+(** [weeks_advancing] for a [Stage2] classification, [None] otherwise. Surfaced
+    on the near-miss so the audit need not re-derive it from [stage]. *)
+let _weeks_advancing_of_stage : Weinstein_types.stage -> int option = function
+  | Stage2 { weeks_advancing; _ } -> Some weeks_advancing
+  | Stage1 _ | Stage3 _ | Stage4 _ -> None
+
+(** Project a near-miss into a {!Trade_audit.alternative_candidate}, sourcing
+    the same decision-time features the funded {!_entry_decision_of_event} reads
+    from the candidate's [Screener.scored_candidate]. [score_components] mirrors
+    the funded path's [cascade_score_components] ceiling (empty until the
+    screener exposes per-component contributions). *)
 let _alternative_of_event (alt : AR.alternative_input) :
     Trade_audit.alternative_candidate =
+  let cand = alt.candidate in
+  let analysis = cand.analysis in
   {
-    symbol = alt.candidate.ticker;
-    side = alt.candidate.side;
-    score = alt.candidate.score;
-    grade = alt.candidate.grade;
+    symbol = cand.ticker;
+    side = cand.side;
+    score = cand.score;
+    grade = cand.grade;
     reason_skipped = _skip_reason_of_event alt.reason;
+    stage = analysis.stage.stage;
+    weeks_advancing = _weeks_advancing_of_stage analysis.stage.stage;
+    rs_value =
+      Option.map analysis.rs ~f:(fun (r : Rs.result) -> r.current_normalized);
+    volume_ratio =
+      Option.map analysis.volume ~f:(fun (v : Volume.result) -> v.volume_ratio);
+    sector_name = cand.sector.sector_name;
+    score_components = [];
   }
 
 (** Translate one {!AR.entry_event} into a {!Trade_audit.entry_decision}. Pure

--- a/trading/trading/backtest/test/test_trade_audit.ml
+++ b/trading/trading/backtest/test/test_trade_audit.ml
@@ -107,13 +107,23 @@ let make_exit ?(symbol = "AAPL") ?(exit_date = _date "2024-04-20")
     weeks_stage_left_2;
   }
 
-let _alt ~symbol ~score ~grade ~reason : TA.alternative_candidate =
+let _alt ~symbol ~score ~grade ~reason
+    ?(stage = Weinstein_types.Stage2 { weeks_advancing = 3; late = false })
+    ?(weeks_advancing = Some 3) ?(rs_value = Some 1.02)
+    ?(volume_ratio = Some 1.8) ?(sector_name = "Information Technology")
+    ?(score_components = []) () : TA.alternative_candidate =
   {
     symbol;
     side = Trading_base.Types.Long;
     score;
     grade;
     reason_skipped = reason;
+    stage;
+    weeks_advancing;
+    rs_value;
+    volume_ratio;
+    sector_name;
+    score_components;
   }
 
 (* Sexp round-trip ------------------------------------------------------- *)
@@ -143,9 +153,17 @@ let test_stop_floor_kind_sexp_round_trip _ =
   assert_that parsed (elements_are (List.map all ~f:equal_to))
 
 let test_alternative_candidate_sexp_round_trip _ =
+  (* Exercise the enriched decision-time fields (stage / weeks_advancing /
+     rs_value / volume_ratio / sector_name / score_components) through the
+     codec, not just the score+grade+reason base. *)
   let alt =
     _alt ~symbol:"MSFT" ~score:62 ~grade:Weinstein_types.B
       ~reason:TA.Insufficient_cash
+      ~stage:(Weinstein_types.Stage2 { weeks_advancing = 6; late = true })
+      ~weeks_advancing:(Some 6) ~rs_value:(Some 0.94) ~volume_ratio:(Some 2.1)
+      ~sector_name:"Health Care"
+      ~score_components:[ ("stage2_breakout", 30); ("strong_volume", 20) ]
+      ()
   in
   let parsed =
     TA.alternative_candidate_of_sexp (TA.sexp_of_alternative_candidate alt)
@@ -158,9 +176,9 @@ let test_entry_decision_sexp_round_trip _ =
       ~alternatives_considered:
         [
           _alt ~symbol:"MSFT" ~score:62 ~grade:Weinstein_types.B
-            ~reason:TA.Insufficient_cash;
+            ~reason:TA.Insufficient_cash ();
           _alt ~symbol:"NVDA" ~score:55 ~grade:Weinstein_types.B
-            ~reason:TA.Sized_to_zero;
+            ~reason:TA.Sized_to_zero ();
         ]
       ()
   in
@@ -278,7 +296,7 @@ let test_collector_round_trips_through_sexp _ =
        ~alternatives_considered:
          [
            _alt ~symbol:"MSFT" ~score:62 ~grade:Weinstein_types.B
-             ~reason:TA.Top_n_cutoff;
+             ~reason:TA.Top_n_cutoff ();
          ]
        ());
   TA.record_exit t (make_exit ());


### PR DESCRIPTION
## What

Per-screen **faithfulness** decision-audit (spec #8, `dev/plans/per-screen-decision-audit-2026-06-30.md`). Additive, read-only lens — no engine/strategy behaviour change. Surfaces the near-miss data already captured in `trade_audit.sexp` so we can ask, per weekly screen: **do the funded entries differ from the cash-rejected near-misses on any signal we capture?** If none does, the tie is uninformative and selection is faithful; if one does and we are not funding on it, that is a candidate lever. It is *not* an outcome grader (grading picks by return is WAI-poor).

Two commits so each can be diffed independently:

### Commit 1 — Phase 0: enrich `alternative_candidate`
`Backtest.Trade_audit.alternative_candidate` previously carried only `{symbol; side; score; grade; reason_skipped}`, so near-misses could only be compared on score+grade. Added the funded entry's decision-time features:
`stage`, `weeks_advancing`, `rs_value`, `volume_ratio`, `sector_name`, `score_components`.
Sourced in `trade_audit_recorder._alternative_of_event` from each near-miss's own `Screener.scored_candidate` (`analysis.stage` / `analysis.rs` / `analysis.volume` / `sector`) — the same values the funded `_entry_decision_of_event` projection reads. `score_components` is `[]` until the screener exposes per-component contributions (same ceiling the funded `cascade_score_components` has today). Additive + default-populated; existing readers (`trade_audit_report`, `release_report`, `decision_grading`) unchanged. `[@@deriving sexp]` round-trip test extended to cover the new fields.

### Commit 2 — Phase 1: `decision_audit` lib + bin + tests
New `trading/trading/backtest/decision_audit/{lib,bin,test}/`, mirroring the sibling `decision_grading/` layout.
- `Screen_record.of_audit_records` — group entry decisions by screen date; funded entries + near-misses (union of `alternatives_considered` across the screen's entries, dedup by symbol, sorted score-desc); summary = `n_funded` / `n_near_miss` / `min_funded_score` / `max_nearmiss_score` / `inversion` (any near-miss outscores the lowest funded).
- `Report.feature_stats` + `to_markdown` — faithfulness roll-up header (funded-vs-near-miss mean+count per captured feature + near-miss skip-reason breakdown) followed by one section per screen date.
- `decision_audit_bin` — `--audit <trade_audit.sexp> [--out <md>]`, reusing the audit-blob loader with a bare-records fallback (matching `decision_grading_bin`).

The enriched Phase-0 fields are **consumed by the Phase-1 report** (funded-vs-near-miss feature table) — not dead.

Phase 2 (forward-return counterfactual on the cash-rejected names) is out of scope, tracked in `dev/status/decision-audit.md` follow-ups.

## Test plan

- `dune runtest trading/backtest/decision_audit` — 10 OUnit cases (6 `Screen_record` + 4 `Report`) on synthetic audit records, asserting domain outcomes: grouping by date, funded/near-miss projection carries the features, near-miss union/dedup/score-desc order, min/max score + inversion flag (both no-inversion and inversion cases), feature means with `None`-drop, markdown header totals + empty-input path.
- `dune runtest trading/backtest/test` — `test_trade_audit` (19 tests) including the extended `alternative_candidate` sexp round-trip.
- End-to-end smoke: ran `decision_audit_bin` against a synthetic `trade_audit.sexp` — renders the per-screen section + faithfulness roll-up + skip-reason breakdown correctly.
- `dune build @fmt`, `dune build` clean project-wide. Pre-existing `test_trade_audit_capture` / `barbell_scenario` / `ad_bars_*` failures are missing-data-fixture failures in this checkout (`data/` is gitignored) and are unrelated to this change — none reference `Trade_audit` or `decision_audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
