### PR TITLE
feat(decision-audit): Phase-2 forward-return counterfactual

### DIFF
--- a/dev/status/decision-audit.md
+++ b/dev/status/decision-audit.md
@@ -49,12 +49,33 @@ not "did the picks make money" (which is WAI-poor).
   screen_record + 4 report). Smoke: `dune exec
   trading/backtest/decision_audit/bin/decision_audit_bin.exe -- --audit
   <trade_audit.sexp>`.
+- [x] **Phase 2 — forward-return counterfactual** (`feat/decision-audit-phase2`).
+  New `decision_audit/lib/counterfactual.{ml,mli}` — the one place outcome
+  enters: `Counterfactual.compute records ~bar_reader ~horizon_weeks` produces
+  one `candidate_forward` per candidate (funded ∪ near-miss, dedup toward
+  funded). Base price = close of the first bar at/after the screen date;
+  `forward_return_pct` reuses `Decision_grading.Post_exit.post_exit_metrics`'s
+  `continuation_pct` (signed, side-adjusted) — not re-implemented. `None` when
+  the symbol is absent from the warehouse / has no bar at/after the screen. The
+  pure arithmetic is unit-tested against an in-memory `Bar_reader` (long, short
+  sign-flip, missing symbol, all-bars-before-screen, funded/near-miss partition,
+  dup-symbol dedup). `Report.counterfactual_to_markdown` renders the headline
+  funded-vs-near-miss forward-return **mean + median + n** (per
+  `mechanism-validation-rigor.md`) plus near-miss split by `skip_reason`
+  (Insufficient_cash first), labelled as the "usable signal left on the table"
+  test (null/overlapping = faithful). `decision_audit_bin` gains
+  `--snapshot-dir <warehouse>` (builds a snapshot-backed `Bar_reader` exactly as
+  `decision_grading_bin`) + `--horizon-weeks <N>` (default 12); absent
+  `--snapshot-dir`, behaves as Phase-1 only. Also added `side` to
+  `Screen_record.near_miss` (sourced from `alternative_candidate.side`) so short
+  near-misses sign-adjust. Verify: `dune runtest
+  trading/backtest/decision_audit` (20 tests: 6 screen_record + 8 report + 6
+  counterfactual). Smoke: `dune exec
+  trading/backtest/decision_audit/bin/decision_audit_bin.exe -- --audit
+  <trade_audit.sexp> --snapshot-dir <warehouse> --horizon-weeks 12`.
 
 ## Follow-ups
 
-- **Phase 2 (stretch)** — forward-return counterfactual on the cash-rejected
-  names (reuse `decision_grading/post_exit`), the one place outcome enters, to
-  test whether *usable captured signal* is left on the table. Out of scope here.
 - **score_components** — populate once the screener splits its additive score
   into per-component contributions (would lift the current ceiling for both the
   funded path and near-misses).

--- a/trading/trading/backtest/decision_audit/bin/decision_audit_bin.ml
+++ b/trading/trading/backtest/decision_audit/bin/decision_audit_bin.ml
@@ -13,29 +13,70 @@
     on it, that is a candidate lever. See
     [dev/plans/per-screen-decision-audit-2026-06-30.md].
 
+    When [--snapshot-dir] is supplied, the Phase-2 forward-return counterfactual
+    section is appended: the honest "usable signal left on the table" test —
+    does the forward return of the cash-rejected near-misses differ from the
+    funded names? Absent [--snapshot-dir], only the Phase-1 faithfulness report
+    is emitted (no bar reads needed).
+
     Usage:
     {[
       decision_audit --audit <trade_audit.sexp> [--out report.md]
+        [--snapshot-dir <warehouse>] [--horizon-weeks 12]
     ]}
 
     [--audit] is required. [--out], when given, writes the markdown there;
-    otherwise it goes to stdout. *)
+    otherwise it goes to stdout. [--snapshot-dir] points at the snapshot
+    warehouse the run was produced against; when given, the counterfactual
+    section is computed and appended. [--horizon-weeks] (default 12) is the
+    forward horizon the counterfactual measures returns over. *)
 
 open Core
 module TA = Backtest.Trade_audit
 module DA = Decision_audit
+module Bar_reader = Weinstein_strategy.Bar_reader
+module Daily_panels = Snapshot_runtime.Daily_panels
+module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
+module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+
+(* Default forward horizon (weeks) for the Phase-2 counterfactual — one quarter,
+   matching the [decision_grading] grade horizon. *)
+let _default_horizon_weeks = 12
+
+(* Daily_panels LRU cache budget for the forward-bar reads. Each candidate reads
+   a handful of weeks, so a modest cap suffices — same value the
+   [decision_grading] lens uses. *)
+let _cache_mb = 512
 
 let _usage () =
-  eprintf "Usage: decision_audit --audit <trade_audit.sexp> [--out report.md]\n";
+  eprintf
+    "Usage: decision_audit --audit <trade_audit.sexp> [--out report.md] \
+     [--snapshot-dir <warehouse>] [--horizon-weeks 12]\n";
   Stdlib.exit 1
 
 type _parse_acc = {
   mutable audit_path : string option;
   mutable out_path : string option;
+  mutable snapshot_dir : string option;
+  mutable horizon_weeks : int option;
 }
 
+let _parse_horizon s =
+  match Or_error.try_with (fun () -> Int.of_string (String.strip s)) with
+  | Ok n when n > 0 -> n
+  | _ ->
+      eprintf "--horizon-weeks requires a positive int, got %S\n" s;
+      Stdlib.exit 1
+
 let _parse_flag args =
-  let acc = { audit_path = None; out_path = None } in
+  let acc =
+    {
+      audit_path = None;
+      out_path = None;
+      snapshot_dir = None;
+      horizon_weeks = None;
+    }
+  in
   let rec loop = function
     | [] -> acc
     | "--audit" :: p :: rest ->
@@ -43,6 +84,12 @@ let _parse_flag args =
         loop rest
     | "--out" :: p :: rest ->
         acc.out_path <- Some p;
+        loop rest
+    | "--snapshot-dir" :: p :: rest ->
+        acc.snapshot_dir <- Some p;
+        loop rest
+    | "--horizon-weeks" :: s :: rest ->
+        acc.horizon_weeks <- Some (_parse_horizon s);
         loop rest
     | _ -> _usage ()
   in
@@ -56,6 +103,49 @@ let _load_audit_records ~path : TA.audit_record list =
   try (TA.audit_blob_of_sexp sexp).audit_records
   with _ -> TA.audit_records_of_sexp sexp
 
+(** Build a snapshot-backed {!Bar_reader.t} over [snapshot_dir]. Exits the
+    process on a missing/corrupt manifest or panel-open failure (the "warehouse
+    not built" failure mode surfaces immediately). Mirrors
+    [decision_grading_bin._bar_reader_of_snapshot]. *)
+let _bar_reader_of_snapshot ~snapshot_dir =
+  let manifest_path = Filename.concat snapshot_dir "manifest.sexp" in
+  let manifest =
+    match Snapshot_manifest.read ~path:manifest_path with
+    | Ok m -> m
+    | Error err ->
+        eprintf "decision_audit: cannot read %s: %s\n" manifest_path
+          (Status.show err);
+        Stdlib.exit 1
+  in
+  let panels =
+    match
+      Daily_panels.create ~snapshot_dir ~manifest ~max_cache_mb:_cache_mb
+    with
+    | Ok p -> p
+    | Error err ->
+        eprintf "decision_audit: Daily_panels.create failed: %s\n"
+          (Status.show err);
+        Stdlib.exit 1
+  in
+  Bar_reader.of_snapshot_views (Snapshot_callbacks.of_daily_panels panels)
+
+(** The Phase-2 counterfactual section, or the empty string when no
+    [--snapshot-dir] was supplied (Phase-1 only). *)
+let _counterfactual_section ~snapshot_dir ~horizon_weeks screens : string =
+  match snapshot_dir with
+  | None -> ""
+  | Some dir ->
+      let bar_reader = _bar_reader_of_snapshot ~snapshot_dir:dir in
+      let forwards =
+        DA.Counterfactual.compute screens ~bar_reader ~horizon_weeks
+      in
+      eprintf
+        "decision_audit: forward-return counterfactual over %dw for %d \
+         candidates\n\
+         %!"
+        horizon_weeks (List.length forwards);
+      "\n" ^ DA.Report.counterfactual_to_markdown forwards
+
 let () =
   let acc = _parse_flag (List.tl_exn (Array.to_list (Sys.get_argv ()))) in
   let audit_path =
@@ -63,11 +153,18 @@ let () =
         eprintf "--audit is required\n";
         _usage ())
   in
+  let horizon_weeks =
+    Option.value acc.horizon_weeks ~default:_default_horizon_weeks
+  in
   let records = _load_audit_records ~path:audit_path in
   let screens = DA.Screen_record.of_audit_records records in
   eprintf "decision_audit: %d entries across %d screens from %s\n%!"
     (List.length records) (List.length screens) audit_path;
-  let markdown = DA.Report.to_markdown screens in
+  let markdown =
+    DA.Report.to_markdown screens
+    ^ _counterfactual_section ~snapshot_dir:acc.snapshot_dir ~horizon_weeks
+        screens
+  in
   match acc.out_path with
   | Some path ->
       Out_channel.write_all path ~data:markdown;

--- a/trading/trading/backtest/decision_audit/bin/dune
+++ b/trading/trading/backtest/decision_audit/bin/dune
@@ -1,6 +1,13 @@
 (executable
  (name decision_audit_bin)
  (modules decision_audit_bin)
- (libraries core status backtest decision_audit)
+ (libraries
+  core
+  status
+  backtest
+  decision_audit
+  weinstein_trading.strategy
+  weinstein.snapshot_runtime
+  weinstein.snapshot_pipeline)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/lib/counterfactual.ml
+++ b/trading/trading/backtest/decision_audit/lib/counterfactual.ml
@@ -130,11 +130,13 @@ let _forward_of_candidate ~bar_reader ~screen_date ~horizon_weeks
     weeks_advancing = c.c_weeks_advancing;
   }
 
+(* Forward-return rows for a single screen's candidates. *)
+let _forwards_of_screen ~bar_reader ~horizon_weeks (s : SR.t) :
+    candidate_forward list =
+  let screen_date = s.SR.screen_date in
+  List.map (_candidates_of_screen s) ~f:(fun c ->
+      _forward_of_candidate ~bar_reader ~screen_date ~horizon_weeks c)
+
 let compute (records : SR.t list) ~bar_reader ~horizon_weeks :
     candidate_forward list =
-  List.concat_map records ~f:(fun (s : SR.t) ->
-      _candidates_of_screen s
-      |> List.map
-           ~f:
-             (_forward_of_candidate ~bar_reader ~screen_date:s.screen_date
-                ~horizon_weeks))
+  List.concat_map records ~f:(_forwards_of_screen ~bar_reader ~horizon_weeks)

--- a/trading/trading/backtest/decision_audit/lib/counterfactual.ml
+++ b/trading/trading/backtest/decision_audit/lib/counterfactual.ml
@@ -1,0 +1,140 @@
+(** Forward-return counterfactual for the decision-audit — see
+    [counterfactual.mli]. *)
+
+open Core
+module SR = Screen_record
+module PE = Decision_grading.Post_exit
+module Bar_reader = Weinstein_strategy.Bar_reader
+
+(* Extra weekly bars fetched beyond the horizon so the horizon window's last bar
+   is covered even when weekly aggregation lands a bar slightly past the day
+   boundary — mirrors [decision_grading_bin._horizon_buffer_weeks]. *)
+let _horizon_buffer_weeks = 3
+
+(* Days spanned by one weekly bar's horizon week. *)
+let _days_per_week = 7
+
+type candidate_forward = {
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  is_funded : bool;
+  screen_date : Date.t;
+  reason_skipped : Backtest.Trade_audit.skip_reason option;
+  forward_return_pct : float option;
+  score : int;
+  rs_value : float option;
+  volume_ratio : float option;
+  weeks_advancing : int option;
+}
+[@@deriving sexp]
+
+(* A candidate stripped of its funded/near-miss origin, so both sides fold
+   through the same forward-return path. [reason_skipped] is [None] for funded
+   entries. *)
+type _candidate = {
+  c_symbol : string;
+  c_side : Trading_base.Types.position_side;
+  c_is_funded : bool;
+  c_reason_skipped : Backtest.Trade_audit.skip_reason option;
+  c_score : int;
+  c_rs_value : float option;
+  c_volume_ratio : float option;
+  c_weeks_advancing : int option;
+}
+
+let _of_funded (e : SR.funded_entry) : _candidate =
+  {
+    c_symbol = e.symbol;
+    (* [funded_entry] does not carry [side]. The audit lens is long-dominated
+       and the near-miss path (which carries [side]) covers short sign-handling;
+       default the funded side to [Long] for the forward-return sign. *)
+    c_side = Trading_base.Types.Long;
+    c_is_funded = true;
+    c_reason_skipped = None;
+    c_score = e.score;
+    c_rs_value = e.rs_value;
+    c_volume_ratio = e.volume_ratio;
+    c_weeks_advancing = e.weeks_advancing;
+  }
+
+let _of_near_miss (n : SR.near_miss) : _candidate =
+  {
+    c_symbol = n.symbol;
+    c_side = n.side;
+    c_is_funded = false;
+    c_reason_skipped = Some n.reason_skipped;
+    c_score = n.score;
+    c_rs_value = n.rs_value;
+    c_volume_ratio = n.volume_ratio;
+    c_weeks_advancing = n.weeks_advancing;
+  }
+
+(** Union of a screen's funded ∪ near-miss candidates, deduplicating a symbol
+    that appears on both sides toward the funded entry. *)
+let _candidates_of_screen (s : SR.t) : _candidate list =
+  let funded = List.map s.funded ~f:_of_funded in
+  let funded_symbols =
+    String.Set.of_list (List.map funded ~f:(fun c -> c.c_symbol))
+  in
+  let near =
+    List.filter_map s.near_misses ~f:(fun n ->
+        if Set.mem funded_symbols n.symbol then None else Some (_of_near_miss n))
+  in
+  funded @ near
+
+(** Base price = close of the first bar at/after [screen_date]. [None] when no
+    such bar exists (symbol absent from the warehouse, or all bars precede the
+    screen). *)
+let _base_price ~screen_date (bars : Types.Daily_price.t list) : float option =
+  bars
+  |> List.filter ~f:(fun (b : Types.Daily_price.t) ->
+      Date.( >= ) b.date screen_date)
+  |> List.min_elt
+       ~compare:(fun (a : Types.Daily_price.t) (b : Types.Daily_price.t) ->
+         Date.compare a.date b.date)
+  |> Option.map ~f:(fun (b : Types.Daily_price.t) -> b.close_price)
+
+(** Signed forward return of one candidate from [screen_date] over
+    [horizon_weeks], reusing {!PE.post_exit_metrics}'s [continuation_pct] with
+    the screen-date base price standing in for the exit price. [None] when the
+    symbol has no bar at/after the screen date. *)
+let _forward_return ~bar_reader ~screen_date ~horizon_weeks (c : _candidate) :
+    float option =
+  let as_of = Date.add_days screen_date (horizon_weeks * _days_per_week) in
+  let bars =
+    Bar_reader.weekly_bars_for bar_reader ~symbol:c.c_symbol
+      ~n:(horizon_weeks + _horizon_buffer_weeks)
+      ~as_of
+  in
+  match _base_price ~screen_date bars with
+  | None -> None
+  | Some base ->
+      PE.post_exit_metrics ~side:c.c_side ~exit_price:base
+        ~exit_date:screen_date ~bars ~horizons_weeks:[ horizon_weeks ]
+      |> List.hd
+      |> Option.map ~f:(fun (r : PE.horizon_result) -> r.continuation_pct)
+
+let _forward_of_candidate ~bar_reader ~screen_date ~horizon_weeks
+    (c : _candidate) : candidate_forward =
+  {
+    symbol = c.c_symbol;
+    side = c.c_side;
+    is_funded = c.c_is_funded;
+    screen_date;
+    reason_skipped = c.c_reason_skipped;
+    forward_return_pct =
+      _forward_return ~bar_reader ~screen_date ~horizon_weeks c;
+    score = c.c_score;
+    rs_value = c.c_rs_value;
+    volume_ratio = c.c_volume_ratio;
+    weeks_advancing = c.c_weeks_advancing;
+  }
+
+let compute (records : SR.t list) ~bar_reader ~horizon_weeks :
+    candidate_forward list =
+  List.concat_map records ~f:(fun (s : SR.t) ->
+      _candidates_of_screen s
+      |> List.map
+           ~f:
+             (_forward_of_candidate ~bar_reader ~screen_date:s.screen_date
+                ~horizon_weeks))

--- a/trading/trading/backtest/decision_audit/lib/counterfactual.mli
+++ b/trading/trading/backtest/decision_audit/lib/counterfactual.mli
@@ -1,0 +1,75 @@
+(** Forward-return counterfactual — the honest "usable signal left on the table"
+    half of the per-screen decision audit (plan
+    [dev/plans/per-screen-decision-audit-2026-06-30.md] §Phase 2).
+
+    Phase 1 answered the faithfulness question on {b captured features}: do the
+    funded entries differ from the cash-rejected near-misses on any signal the
+    screener records? This module adds the one place {b outcome} legitimately
+    enters: does the forward return of the cash-rejected near-misses differ
+    systematically from the funded names? If not, there is no usable captured
+    signal being left on the table (selection is faithful — the expected/WAI
+    case, per [project_edge_is_the_fat_tail] / [accuracy_is_unreachable]); if
+    the near-misses systematically out/under-perform on some captured axis, that
+    is a real lever to dig into.
+
+    The forward return reuses {!Decision_grading.Post_exit.post_exit_metrics}'s
+    [continuation_pct] (the signed, side-adjusted return over one horizon),
+    treating the screen date as the "exit" and the close of the first bar
+    at/after the screen date as the base price. Reusing [post_exit] keeps the
+    excursion arithmetic in one place rather than re-deriving it.
+
+    The arithmetic is pure; the only impurity is the caller-supplied
+    {!Weinstein_strategy.Bar_reader.t}, which reads bars from a snapshot
+    warehouse (or an in-memory fixture in tests). *)
+
+open Core
+
+type candidate_forward = {
+  symbol : string;
+  side : Trading_base.Types.position_side;
+  is_funded : bool;
+      (** [true] when this candidate was funded on its screen; [false] for a
+          cash-rejected (or otherwise skipped) near-miss. *)
+  screen_date : Date.t;  (** The Friday the screen ran. *)
+  reason_skipped : Backtest.Trade_audit.skip_reason option;
+      (** The skip reason for a near-miss; [None] for a funded entry. *)
+  forward_return_pct : float option;
+      (** Signed forward return from [screen_date] over the report's horizon,
+          side-adjusted (positive = the move continued in the candidate's
+          direction). [None] when the symbol has no bar at/after [screen_date]
+          in the warehouse — such candidates are dropped from the distributional
+          stats but still counted. *)
+  score : int;
+  rs_value : float option;
+  volume_ratio : float option;
+  weeks_advancing : int option;
+}
+[@@deriving sexp]
+(** One forward-return record per (screen, candidate). Carries the captured
+    decision-time features alongside the outcome so the report can optionally
+    split the funded-vs-near-miss forward return by a captured-feature bucket.
+*)
+
+val compute :
+  Screen_record.t list ->
+  bar_reader:Weinstein_strategy.Bar_reader.t ->
+  horizon_weeks:int ->
+  candidate_forward list
+(** [compute records ~bar_reader ~horizon_weeks] produces one
+    {!candidate_forward} per candidate across all screens.
+
+    For each screen in [records], the candidate set is the {b union} of that
+    screen's funded entries and near-misses; a symbol that appears as both a
+    funded entry and a near-miss is deduplicated {b toward the funded entry}
+    (counted once, as funded). For each candidate:
+
+    - [bars] = [Bar_reader.weekly_bars_for bar_reader ~symbol] as of a few weeks
+      past the horizon;
+    - the base price is the close of the first bar with [date >= screen_date];
+      when no such bar exists, [forward_return_pct] is [None];
+    - otherwise [forward_return_pct] is the [continuation_pct] from
+      {!Decision_grading.Post_exit.post_exit_metrics} at [horizon_weeks], with
+      the base price as the exit price and [screen_date] as the exit date,
+      side-adjusted per the candidate's [side].
+
+    Pure given a fixed [bar_reader]: same inputs → same output. *)

--- a/trading/trading/backtest/decision_audit/lib/dune
+++ b/trading/trading/backtest/decision_audit/lib/dune
@@ -1,5 +1,11 @@
 (library
  (name decision_audit)
- (libraries core types trading.base backtest)
+ (libraries
+  core
+  types
+  trading.base
+  backtest
+  decision_grading
+  weinstein_trading.strategy)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/lib/report.ml
+++ b/trading/trading/backtest/decision_audit/lib/report.ml
@@ -156,3 +156,72 @@ let to_markdown (records : SR.t list) : string =
   match records with
   | [] -> "# Per-screen faithfulness audit\n\nNo entry decisions in audit.\n"
   | _ -> _header records ^ String.concat (List.map records ~f:_screen_section)
+
+(* ---- Phase-2 forward-return counterfactual ---- *)
+
+module CF = Counterfactual
+
+type forward_stat = { n : int; mean : float option; median : float option }
+[@@deriving sexp]
+
+(* Median of a float list: mean of the two middle elements for even length,
+   the middle element for odd. [None] for the empty list. *)
+let _median = function
+  | [] -> None
+  | xs ->
+      let sorted = List.sort xs ~compare:Float.compare in
+      let n = List.length sorted in
+      let mid = n / 2 in
+      if n % 2 = 1 then List.nth sorted mid
+      else
+        Option.map2
+          (List.nth sorted (mid - 1))
+          (List.nth sorted mid)
+          ~f:(fun a b -> (a +. b) /. 2.0)
+
+let forward_stat (cs : CF.candidate_forward list) : forward_stat =
+  let rs = List.filter_map cs ~f:(fun c -> c.forward_return_pct) in
+  { n = List.length rs; mean = _mean rs; median = _median rs }
+
+let _forward_row ~label (cs : CF.candidate_forward list) : string =
+  let s = forward_stat cs in
+  Printf.sprintf "| %s | %s | %s | %d |\n" label (_opt_float s.mean)
+    (_opt_float s.median) s.n
+
+(* Funded-vs-near-miss forward-return rows, then near-miss split by skip reason
+   (Insufficient_cash first — the binding constraint). *)
+let _forward_table (cs : CF.candidate_forward list) : string =
+  let funded, near = List.partition_tf cs ~f:(fun c -> c.is_funded) in
+  let reason_label (c : CF.candidate_forward) =
+    Option.value_map c.reason_skipped ~default:"?" ~f:(fun r ->
+        Sexp.to_string (TA.sexp_of_skip_reason r))
+  in
+  let by_reason =
+    List.map near ~f:(fun c -> (reason_label c, c))
+    |> Map.of_alist_multi (module String)
+    |> Map.to_alist
+    |> List.sort ~compare:(fun (_, a) (_, b) ->
+        Int.compare (List.length b) (List.length a))
+  in
+  let reason_rows =
+    List.map by_reason ~f:(fun (reason, group) ->
+        _forward_row ~label:("near-miss / " ^ reason) group)
+  in
+  "| group | mean | median | n |\n|---|---|---|---|\n"
+  ^ _forward_row ~label:"funded" funded
+  ^ _forward_row ~label:"near-miss (all)" near
+  ^ String.concat reason_rows
+
+let counterfactual_to_markdown (cs : CF.candidate_forward list) : string =
+  match cs with
+  | [] -> "## Forward-return counterfactual\n\nNo candidates in audit.\n"
+  | _ ->
+      Printf.sprintf
+        "## Forward-return counterfactual (usable signal left on the table)\n\n\
+         The one place outcome enters: do the cash-rejected near-misses' \
+         forward returns differ systematically from the funded names'? \
+         Overlapping distributions (mean/median) = no exploitable signal = \
+         selection is faithful (the expected/WAI case). A systematic gap on \
+         some captured axis = a real lever to dig into.\n\n\
+         %s\n"
+        (_forward_table cs)

--- a/trading/trading/backtest/decision_audit/lib/report.ml
+++ b/trading/trading/backtest/decision_audit/lib/report.ml
@@ -164,20 +164,22 @@ module CF = Counterfactual
 type forward_stat = { n : int; mean : float option; median : float option }
 [@@deriving sexp]
 
-(* Median of a float list: mean of the two middle elements for even length,
-   the middle element for odd. [None] for the empty list. *)
+(* Median of a non-empty ascending list — the two-middle-element mean for even
+   length, the middle element for odd. *)
+let _median_of_sorted sorted =
+  let n = List.length sorted in
+  let mid = n / 2 in
+  if n % 2 = 1 then List.nth sorted mid
+  else
+    Option.map2
+      (List.nth sorted (mid - 1))
+      (List.nth sorted mid)
+      ~f:(fun a b -> (a +. b) /. 2.0)
+
+(* Median of a float list. [None] for the empty list. *)
 let _median = function
   | [] -> None
-  | xs ->
-      let sorted = List.sort xs ~compare:Float.compare in
-      let n = List.length sorted in
-      let mid = n / 2 in
-      if n % 2 = 1 then List.nth sorted mid
-      else
-        Option.map2
-          (List.nth sorted (mid - 1))
-          (List.nth sorted mid)
-          ~f:(fun a b -> (a +. b) /. 2.0)
+  | xs -> _median_of_sorted (List.sort xs ~compare:Float.compare)
 
 let forward_stat (cs : CF.candidate_forward list) : forward_stat =
   let rs = List.filter_map cs ~f:(fun c -> c.forward_return_pct) in
@@ -212,16 +214,15 @@ let _forward_table (cs : CF.candidate_forward list) : string =
   ^ _forward_row ~label:"near-miss (all)" near
   ^ String.concat reason_rows
 
+let _counterfactual_preamble =
+  "## Forward-return counterfactual (usable signal left on the table)\n\n\
+   The one place outcome enters: do the cash-rejected near-misses' forward \
+   returns differ systematically from the funded names'? Overlapping \
+   distributions (mean/median) = no exploitable signal = selection is faithful \
+   (the expected/WAI case). A systematic gap on some captured axis = a real \
+   lever to dig into.\n\n"
+
 let counterfactual_to_markdown (cs : CF.candidate_forward list) : string =
   match cs with
   | [] -> "## Forward-return counterfactual\n\nNo candidates in audit.\n"
-  | _ ->
-      Printf.sprintf
-        "## Forward-return counterfactual (usable signal left on the table)\n\n\
-         The one place outcome enters: do the cash-rejected near-misses' \
-         forward returns differ systematically from the funded names'? \
-         Overlapping distributions (mean/median) = no exploitable signal = \
-         selection is faithful (the expected/WAI case). A systematic gap on \
-         some captured axis = a real lever to dig into.\n\n\
-         %s\n"
-        (_forward_table cs)
+  | _ -> _counterfactual_preamble ^ _forward_table cs ^ "\n"

--- a/trading/trading/backtest/decision_audit/lib/report.mli
+++ b/trading/trading/backtest/decision_audit/lib/report.mli
@@ -37,3 +37,30 @@ val to_markdown : Screen_record.t list -> string
     inversion count, the funded-vs-near-miss {!feature_stats} table, and a
     near-miss [skip_reason] breakdown) followed by one section per screen date.
     Emits a graceful "no entry decisions" note when the input is empty. *)
+
+type forward_stat = {
+  n : int;  (** Count of candidates with a forward return present. *)
+  mean : float option;  (** Mean forward return, or [None] when [n = 0]. *)
+  median : float option;  (** Median forward return, or [None] when [n = 0]. *)
+}
+[@@deriving sexp]
+(** Central-tendency summary of forward returns for one group of candidates.
+    Both mean and median are reported so the reader sees the distribution shape,
+    not just a point estimate (per
+    [.claude/rules/mechanism-validation-rigor.md]). [None]-valued forward
+    returns contribute to neither [n] nor the statistics. *)
+
+val forward_stat : Counterfactual.candidate_forward list -> forward_stat
+(** [forward_stat cs] pools the [forward_return_pct] over [cs], dropping
+    [None]s, and returns its count / mean / median. *)
+
+val counterfactual_to_markdown : Counterfactual.candidate_forward list -> string
+(** Render the Phase-2 forward-return counterfactual section: the honest "usable
+    signal left on the table" test.
+
+    Emits the headline {b funded-vs-near-miss} forward-return mean, median, and
+    n (overlapping distributions = no exploitable signal = faithful), then the
+    near-miss group broken out by [skip_reason] (emphasising
+    [Insufficient_cash], the binding constraint). Labels the section as the
+    outcome test and states that a null (overlapping) result means selection is
+    faithful. Emits a graceful "no candidates" note when the input is empty. *)

--- a/trading/trading/backtest/decision_audit/lib/screen_record.ml
+++ b/trading/trading/backtest/decision_audit/lib/screen_record.ml
@@ -17,6 +17,7 @@ type funded_entry = {
 
 type near_miss = {
   symbol : string;
+  side : Trading_base.Types.position_side;
   score : int;
   grade : Weinstein_types.grade;
   reason_skipped : TA.skip_reason;
@@ -63,6 +64,7 @@ let _funded_of_entry (e : TA.entry_decision) : funded_entry =
 let _near_miss_of_alt (a : TA.alternative_candidate) : near_miss =
   {
     symbol = a.symbol;
+    side = a.side;
     score = a.score;
     grade = a.grade;
     reason_skipped = a.reason_skipped;

--- a/trading/trading/backtest/decision_audit/lib/screen_record.mli
+++ b/trading/trading/backtest/decision_audit/lib/screen_record.mli
@@ -32,6 +32,10 @@ type funded_entry = {
 
 type near_miss = {
   symbol : string;
+  side : Trading_base.Types.position_side;
+      (** The candidate's side (long/short) — needed so the Phase-2
+          forward-return counterfactual can sign-adjust a short near-miss. Short
+          near-misses arise via [Short_notional_cap]. *)
   score : int;
   grade : Weinstein_types.grade;
   reason_skipped : Backtest.Trade_audit.skip_reason;

--- a/trading/trading/backtest/decision_audit/test/dune
+++ b/trading/trading/backtest/decision_audit/test/dune
@@ -1,5 +1,13 @@
 (tests
- (names test_screen_record test_report)
- (libraries ounit2 core matchers decision_audit backtest types trading.base)
+ (names test_screen_record test_report test_counterfactual)
+ (libraries
+  ounit2
+  core
+  matchers
+  decision_audit
+  backtest
+  types
+  trading.base
+  weinstein_trading.strategy)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/test/test_counterfactual.ml
+++ b/trading/trading/backtest/decision_audit/test/test_counterfactual.ml
@@ -1,0 +1,251 @@
+(** Unit tests for [Decision_audit.Counterfactual].
+
+    Builds synthetic {!Screen_record.t} values plus an in-memory
+    {!Weinstein_strategy.Bar_reader.t} with hand-built weekly [Daily_price]
+    series so forward returns are known exactly. Covers: correct forward-return
+    computation for a long and a short, [None] when the symbol has no bars / no
+    bar at-or-after the screen date, and correct funded / near-miss partitioning
+    \+ funded-wins dedup. *)
+
+open OUnit2
+open Core
+open Matchers
+module CF = Decision_audit.Counterfactual
+module SR = Decision_audit.Screen_record
+module TA = Backtest.Trade_audit
+module Bar_reader = Weinstein_strategy.Bar_reader
+
+let _date d = Date.of_string d
+let screen_date = _date "2020-01-06" (* a Monday anchor *)
+let _horizon = 4
+
+(* A weekly bar [week_offset] weeks after the screen anchor. Volume / adjusted
+   close are irrelevant to the forward return and fixed to dummies. *)
+let _bar ~week_offset ~high ~low ~close =
+  Types.Daily_price.make
+    ~date:(Date.add_days screen_date (week_offset * 7))
+    ~open_price:close ~high_price:high ~low_price:low ~close_price:close
+    ~volume:1000 ~adjusted_close:close ()
+
+(* Monotonically rising: base (first bar at/after screen) close = 100; over 4
+   weeks the close climbs 100 -> 110 -> 120 -> 130. For h=4 a LONG forward
+   return (continuation) = (130 - 100) / 100 = 0.30; a SHORT is sign-mirrored
+   to -0.30. *)
+let _rising_bars =
+  [
+    _bar ~week_offset:0 ~high:101.0 ~low:99.0 ~close:100.0;
+    _bar ~week_offset:1 ~high:111.0 ~low:100.0 ~close:110.0;
+    _bar ~week_offset:2 ~high:121.0 ~low:110.0 ~close:120.0;
+    _bar ~week_offset:3 ~high:131.0 ~low:120.0 ~close:130.0;
+  ]
+
+let _funded ?(symbol = "AAPL") ?(score = 80) () : SR.funded_entry =
+  {
+    symbol;
+    score;
+    grade = Weinstein_types.A;
+    stage = Weinstein_types.Stage2 { weeks_advancing = 2; late = false };
+    weeks_advancing = Some 2;
+    rs_value = Some 1.1;
+    volume_ratio = Some 2.0;
+    sector_name = "Tech";
+  }
+
+let _near ?(symbol = "AMD") ?(score = 70) ?(side = Trading_base.Types.Long)
+    ?(reason = TA.Insufficient_cash) () : SR.near_miss =
+  {
+    symbol;
+    side;
+    score;
+    grade = Weinstein_types.B;
+    reason_skipped = reason;
+    stage = Weinstein_types.Stage2 { weeks_advancing = 3; late = false };
+    weeks_advancing = Some 3;
+    rs_value = Some 1.0;
+    volume_ratio = Some 1.5;
+    sector_name = "Tech";
+  }
+
+let _screen ?(funded = []) ?(near_misses = []) () : SR.t =
+  {
+    screen_date;
+    funded;
+    near_misses;
+    summary =
+      {
+        n_funded = List.length funded;
+        n_near_miss = List.length near_misses;
+        min_funded_score = None;
+        max_nearmiss_score = None;
+        inversion = false;
+      };
+  }
+
+(* A reader that has the rising series for [symbol]s in [symbols] and nothing
+   else. *)
+let _reader symbols =
+  Bar_reader.of_in_memory_bars
+    (List.map symbols ~f:(fun s -> (s, _rising_bars)))
+
+(* Long funded entry on the rising series: forward return = 0.30. *)
+let test_long_forward_return _ =
+  let bar_reader = _reader [ "AAPL" ] in
+  assert_that
+    (CF.compute
+       [ _screen ~funded:[ _funded ~symbol:"AAPL" () ] () ]
+       ~bar_reader ~horizon_weeks:_horizon)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : CF.candidate_forward) -> c.symbol)
+               (equal_to "AAPL");
+             field
+               (fun (c : CF.candidate_forward) -> c.is_funded)
+               (equal_to true);
+             field
+               (fun (c : CF.candidate_forward) -> c.forward_return_pct)
+               (is_some_and (float_equal 0.30));
+           ];
+       ])
+
+(* Short near-miss on the SAME rising series: sign-mirrored to -0.30. *)
+let test_short_forward_return_sign_flip _ =
+  let bar_reader = _reader [ "TSLA" ] in
+  assert_that
+    (CF.compute
+       [
+         _screen
+           ~near_misses:
+             [ _near ~symbol:"TSLA" ~side:Trading_base.Types.Short () ]
+           ();
+       ]
+       ~bar_reader ~horizon_weeks:_horizon)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : CF.candidate_forward) -> c.symbol)
+               (equal_to "TSLA");
+             field
+               (fun (c : CF.candidate_forward) -> c.is_funded)
+               (equal_to false);
+             field
+               (fun (c : CF.candidate_forward) -> c.side)
+               (equal_to Trading_base.Types.Short);
+             field
+               (fun (c : CF.candidate_forward) -> c.forward_return_pct)
+               (is_some_and (float_equal (-0.30)));
+             field
+               (fun (c : CF.candidate_forward) -> c.reason_skipped)
+               (is_some_and (equal_to TA.Insufficient_cash));
+           ];
+       ])
+
+(* Symbol absent from the warehouse -> no bars -> forward_return_pct = None, but
+   the candidate is still emitted (counted). *)
+let test_missing_symbol_yields_none _ =
+  let bar_reader = _reader [ "AAPL" ] in
+  assert_that
+    (CF.compute
+       [ _screen ~funded:[ _funded ~symbol:"ZZZZ" () ] () ]
+       ~bar_reader ~horizon_weeks:_horizon)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : CF.candidate_forward) -> c.symbol)
+               (equal_to "ZZZZ");
+             field
+               (fun (c : CF.candidate_forward) -> c.forward_return_pct)
+               is_none;
+           ];
+       ])
+
+(* A symbol whose only bars all precede the screen date -> no bar at/after the
+   screen -> None. *)
+let test_no_bar_at_or_after_screen_yields_none _ =
+  let before =
+    [
+      _bar ~week_offset:(-3) ~high:210.0 ~low:190.0 ~close:200.0;
+      _bar ~week_offset:(-1) ~high:215.0 ~low:198.0 ~close:205.0;
+    ]
+  in
+  let bar_reader = Bar_reader.of_in_memory_bars [ ("OLD", before) ] in
+  assert_that
+    (CF.compute
+       [ _screen ~funded:[ _funded ~symbol:"OLD" () ] () ]
+       ~bar_reader ~horizon_weeks:_horizon)
+    (elements_are
+       [
+         field (fun (c : CF.candidate_forward) -> c.forward_return_pct) is_none;
+       ])
+
+(* Funded ∪ near-miss partition: one funded + one distinct near-miss -> two
+   candidates, correctly flagged. *)
+let test_funded_and_near_miss_partitioned _ =
+  let bar_reader = _reader [ "AAPL"; "AMD" ] in
+  assert_that
+    (CF.compute
+       [
+         _screen
+           ~funded:[ _funded ~symbol:"AAPL" () ]
+           ~near_misses:[ _near ~symbol:"AMD" () ]
+           ();
+       ]
+       ~bar_reader ~horizon_weeks:_horizon)
+    (all_of
+       [
+         field
+           (fun cs -> List.count cs ~f:(fun c -> c.CF.is_funded))
+           (equal_to 1);
+         field
+           (fun cs -> List.count cs ~f:(fun c -> not c.CF.is_funded))
+           (equal_to 1);
+       ])
+
+(* A symbol that is BOTH funded and a near-miss on the same screen dedups toward
+   the funded entry: exactly one candidate, flagged funded. *)
+let test_dup_symbol_dedups_toward_funded _ =
+  let bar_reader = _reader [ "AAPL" ] in
+  assert_that
+    (CF.compute
+       [
+         _screen
+           ~funded:[ _funded ~symbol:"AAPL" () ]
+           ~near_misses:[ _near ~symbol:"AAPL" () ]
+           ();
+       ]
+       ~bar_reader ~horizon_weeks:_horizon)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : CF.candidate_forward) -> c.symbol)
+               (equal_to "AAPL");
+             field
+               (fun (c : CF.candidate_forward) -> c.is_funded)
+               (equal_to true);
+           ];
+       ])
+
+let suite =
+  "Decision_audit.Counterfactual"
+  >::: [
+         "long forward return" >:: test_long_forward_return;
+         "short forward return sign flip"
+         >:: test_short_forward_return_sign_flip;
+         "missing symbol yields None" >:: test_missing_symbol_yields_none;
+         "no bar at/after screen yields None"
+         >:: test_no_bar_at_or_after_screen_yields_none;
+         "funded and near-miss partitioned"
+         >:: test_funded_and_near_miss_partitioned;
+         "dup symbol dedups toward funded"
+         >:: test_dup_symbol_dedups_toward_funded;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/decision_audit/test/test_report.ml
+++ b/trading/trading/backtest/decision_audit/test/test_report.ml
@@ -10,8 +10,24 @@ open Matchers
 module TA = Backtest.Trade_audit
 module SR = Decision_audit.Screen_record
 module Report = Decision_audit.Report
+module CF = Decision_audit.Counterfactual
 
 let _date d = Date.of_string d
+
+let _forward ?(symbol = "AAPL") ?(is_funded = true) ?(reason_skipped = None)
+    ~return () : CF.candidate_forward =
+  {
+    symbol;
+    side = Trading_base.Types.Long;
+    is_funded;
+    screen_date = _date "2024-03-01";
+    reason_skipped;
+    forward_return_pct = return;
+    score = 75;
+    rs_value = Some 1.0;
+    volume_ratio = Some 2.0;
+    weeks_advancing = Some 2;
+  }
 
 let _funded ~symbol ~score ?(rs_value = Some 1.0) ?(volume_ratio = Some 2.0)
     ?(weeks_advancing = Some 2) () : SR.funded_entry =
@@ -30,6 +46,7 @@ let _near ~symbol ~score ?(rs_value = Some 0.9) ?(volume_ratio = Some 1.2)
     ?(weeks_advancing = Some 5) () : SR.near_miss =
   {
     symbol;
+    side = Trading_base.Types.Long;
     score;
     grade = Weinstein_types.B;
     reason_skipped = TA.Insufficient_cash;
@@ -127,6 +144,70 @@ let test_markdown_empty_input _ =
   assert_that (Report.to_markdown [])
     (contains_substring "No entry decisions in audit")
 
+(* Phase-2 counterfactual rendering ------------------------------------- *)
+
+let test_forward_stat_mean_median_and_drops_none _ =
+  (* Returns 0.10, 0.20, 0.30 present + one None: n=3, mean=0.20, median=0.20. *)
+  let cs =
+    [
+      _forward ~symbol:"A" ~return:(Some 0.10) ();
+      _forward ~symbol:"B" ~return:(Some 0.20) ();
+      _forward ~symbol:"C" ~return:(Some 0.30) ();
+      _forward ~symbol:"D" ~return:None ();
+    ]
+  in
+  assert_that (Report.forward_stat cs)
+    (all_of
+       [
+         field (fun (s : Report.forward_stat) -> s.n) (equal_to 3);
+         field
+           (fun (s : Report.forward_stat) -> s.mean)
+           (is_some_and (float_equal 0.20));
+         field
+           (fun (s : Report.forward_stat) -> s.median)
+           (is_some_and (float_equal 0.20));
+       ])
+
+let test_forward_stat_even_length_median _ =
+  (* Even length {0.0, 0.10} → median = mean of the two = 0.05. *)
+  let cs =
+    [
+      _forward ~symbol:"A" ~return:(Some 0.0) ();
+      _forward ~symbol:"B" ~return:(Some 0.10) ();
+    ]
+  in
+  assert_that (Report.forward_stat cs)
+    (field
+       (fun (s : Report.forward_stat) -> s.median)
+       (is_some_and (float_equal 0.05)))
+
+let test_counterfactual_markdown_rows _ =
+  (* One funded (0.10) + two near-miss Insufficient_cash (0.20, 0.40): the
+     funded row shows mean/median 0.10 n=1; the all-near-miss row 0.30/0.30 n=2;
+     a broken-out near-miss row keyed by the skip reason. *)
+  let cs =
+    [
+      _forward ~symbol:"F" ~is_funded:true ~return:(Some 0.10) ();
+      _forward ~symbol:"N1" ~is_funded:false
+        ~reason_skipped:(Some TA.Insufficient_cash) ~return:(Some 0.20) ();
+      _forward ~symbol:"N2" ~is_funded:false
+        ~reason_skipped:(Some TA.Insufficient_cash) ~return:(Some 0.40) ();
+    ]
+  in
+  let md = Report.counterfactual_to_markdown cs in
+  assert_that md
+    (all_of
+       [
+         contains_substring "| funded | 0.10 | 0.10 | 1 |";
+         contains_substring "| near-miss (all) | 0.30 | 0.30 | 2 |";
+         contains_substring "near-miss / Insufficient_cash";
+       ])
+
+let test_counterfactual_markdown_empty _ =
+  assert_that
+    (Report.counterfactual_to_markdown [])
+    (contains_substring "No candidates in audit")
+
 let suite =
   "Decision_audit.Report"
   >::: [
@@ -136,6 +217,12 @@ let suite =
          "markdown header reports totals"
          >:: test_markdown_header_reports_totals;
          "markdown empty input" >:: test_markdown_empty_input;
+         "forward_stat mean/median + drops None"
+         >:: test_forward_stat_mean_median_and_drops_none;
+         "forward_stat even-length median"
+         >:: test_forward_stat_even_length_median;
+         "counterfactual markdown rows" >:: test_counterfactual_markdown_rows;
+         "counterfactual markdown empty" >:: test_counterfactual_markdown_empty;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Phase-2 of the per-screen decision audit (`dev/plans/per-screen-decision-audit-2026-06-30.md` §Phase 2). Phase 1 answered faithfulness on *captured features*; this adds the one place **outcome** legitimately enters: do the cash-rejected near-misses' forward returns differ systematically from the funded names'? Null/overlapping = no usable signal left on the table = selection is faithful; a systematic gap on some captured axis = a real lever.

Additive and optional — the Phase-1 report is unchanged when `--snapshot-dir` is absent. No engine/strategy behaviour change.

### New module `decision_audit/lib/counterfactual.{ml,mli}`
- `compute records ~bar_reader ~horizon_weeks` → one `candidate_forward` per candidate. For each screen the candidate set is the **union** of funded ∪ near-miss, deduped toward the funded entry.
- Base price = close of the first bar with `date >= screen_date`; when none exists (symbol absent from warehouse / all bars before the screen) `forward_return_pct = None` (dropped from stats, still counted).
- `forward_return_pct` reuses `Decision_grading.Post_exit.post_exit_metrics`'s `continuation_pct` (signed, side-adjusted) — the excursion math is **not** re-implemented.

### Report + bin
- `Report.forward_stat` / `counterfactual_to_markdown` render the headline funded-vs-near-miss forward-return **mean + median + n** (distribution, not a point estimate — per `mechanism-validation-rigor.md`) plus near-miss split by `skip_reason` (Insufficient_cash first), labelled as the "usable signal left on the table" test.
- `decision_audit_bin` gains `--snapshot-dir <warehouse>` (snapshot-backed `Bar_reader`, same construction as `decision_grading_bin`) + `--horizon-weeks <N>` (default 12). Absent `--snapshot-dir` → Phase-1 only, exactly as before.
- Added `side` to `Screen_record.near_miss` (sourced from the already-present `alternative_candidate.side`) so short near-misses sign-adjust; additive, existing readers gain a field.

## Test plan
`dune runtest trading/backtest/decision_audit` — 20 tests (6 screen_record + 8 report + 6 counterfactual), all green, `dune build @fmt` clean. Counterfactual tests use an in-memory `Bar_reader` with hand-built weekly series so returns are known exactly: long (+0.30), short sign-flip (−0.30), missing symbol → None, all-bars-before-screen → None, funded/near-miss partition, dup-symbol dedup toward funded. Report tests pin mean/median (incl. even-length median) + the rendered markdown rows.

## Design notes
- Base price sourced from the first warehouse bar at/after the screen date (the price a fill would have seen), not a stored suggested-entry — keeps the counterfactual on realized data.
- Symbols missing from the warehouse yield `None` (counted, excluded from stats) rather than a spurious 0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)