### PR TITLE
feat(decision-audit): weekly-snapshot adapter (live picks -> faithfulness lens)

### DIFF
--- a/dev/status/decision-audit.md
+++ b/dev/status/decision-audit.md
@@ -73,6 +73,31 @@ not "did the picks make money" (which is WAI-poor).
   counterfactual). Smoke: `dune exec
   trading/backtest/decision_audit/bin/decision_audit_bin.exe -- --audit
   <trade_audit.sexp> --snapshot-dir <warehouse> --horizon-weeks 12`.
+- [x] **Weekly-snapshot adapter — live picks → the faithfulness lens**
+  (`feat/decision-audit-weekly`). New
+  `decision_audit/lib/weekly_adapter.{ml,mli}`:
+  `Weekly_adapter.of_weekly_snapshots snaps ~displayed_k` maps each per-Friday
+  `Weinstein_snapshot.Weekly_snapshot.t` to one `Screen_record.t` so the SAME
+  Phase-1 report + Phase-2 counterfactual run on live weekly picks, not just a
+  backtest `trade_audit.sexp`. The displayed cut synthesizes the funded/near-miss
+  split a live snapshot lacks: `funded` = the first `displayed_k` `long_candidates`
+  (score-desc); `near_misses` = the remaining longs (side `Long`) ∪ all
+  `short_candidates` (side `Short`), all tagged `Top_n_cutoff` (the live analog of
+  the backtest cash line). `summary` reuses the newly-exposed
+  `Screen_record.summary_of` (no duplication). Documented ceilings: stage defaults
+  to `Stage2 {weeks_advancing=0; late=false}` for longs / `Stage4 {weeks_declining=0}`
+  for shorts (snapshot carries no stage; faithful by screener construction), and
+  `weeks_advancing` / `volume_ratio` are `None` (not in the snapshot schema — RS +
+  score + grade + sector are what this enables). Grade parsed from the displayed
+  label ("A+"/"A"/…) by an exhaustive `_grade_of_string` that raises
+  `Invalid_argument` on an unknown label (never silently defaults). `decision_audit_bin`
+  gains `--weekly-picks-dir <dir>` (loads every `*.sexp` via
+  `Snapshot_reader.read_from_file`, sorts by date) + `--displayed-k <N>` (default 3),
+  mutually exclusive with `--audit`; `--audit` mode unchanged. Verify: `dune runtest
+  trading/backtest/decision_audit` (25 tests: 6 screen_record + 8 report + 6
+  counterfactual + 5 weekly_adapter). Smoke: `dune exec
+  trading/backtest/decision_audit/bin/decision_audit_bin.exe -- --weekly-picks-dir
+  dev/weekly-picks/<version> --displayed-k 3`.
 
 ## Follow-ups
 

--- a/trading/trading/backtest/decision_audit/bin/decision_audit_bin.ml
+++ b/trading/trading/backtest/decision_audit/bin/decision_audit_bin.ml
@@ -19,17 +19,32 @@
     funded names? Absent [--snapshot-dir], only the Phase-1 faithfulness report
     is emitted (no bar reads needed).
 
+    The lens has two input modes, exactly one of which must be selected:
+
+    - [--audit <trade_audit.sexp>] — the backtest path (above).
+    - [--weekly-picks-dir <dir>] — the {b live} path: every [*.sexp] in [dir] is
+      a {!Weekly_snapshot.t} (a per-Friday live screen), adapted into the same
+      {!Screen_record.t} shape via {!Decision_audit.Weekly_adapter}. The top
+      [--displayed-k] (default 3) long candidates stand in for the "funded"
+      entries; everything below the displayed cut (remaining longs + all shorts)
+      becomes the near-misses. This runs the identical Phase-1 report (and
+      Phase-2 counterfactual, if [--snapshot-dir] is also given) on live picks.
+
     Usage:
     {[
       decision_audit --audit <trade_audit.sexp> [--out report.md]
         [--snapshot-dir <warehouse>] [--horizon-weeks 12]
+      decision_audit --weekly-picks-dir <dir> [--displayed-k 3] [--out report.md]
+        [--snapshot-dir <warehouse>] [--horizon-weeks 12]
     ]}
 
-    [--audit] is required. [--out], when given, writes the markdown there;
+    Exactly one of [--audit] / [--weekly-picks-dir] is required (supplying both
+    or neither is an error). [--out], when given, writes the markdown there;
     otherwise it goes to stdout. [--snapshot-dir] points at the snapshot
     warehouse the run was produced against; when given, the counterfactual
     section is computed and appended. [--horizon-weeks] (default 12) is the
-    forward horizon the counterfactual measures returns over. *)
+    forward horizon the counterfactual measures returns over. [--displayed-k]
+    (default 3) is the displayed-cut for the weekly-picks adapter. *)
 
 open Core
 module TA = Backtest.Trade_audit
@@ -38,10 +53,15 @@ module Bar_reader = Weinstein_strategy.Bar_reader
 module Daily_panels = Snapshot_runtime.Daily_panels
 module Snapshot_callbacks = Snapshot_runtime.Snapshot_callbacks
 module Snapshot_manifest = Snapshot_pipeline.Snapshot_manifest
+module Snapshot_reader = Weinstein_snapshot.Snapshot_reader
 
 (* Default forward horizon (weeks) for the Phase-2 counterfactual — one quarter,
    matching the [decision_grading] grade horizon. *)
 let _default_horizon_weeks = 12
+
+(* Default displayed-cut for the weekly-picks adapter: the top-N long candidates
+   a human would act on each week stand in for the "funded" entries. *)
+let _default_displayed_k = 3
 
 (* Daily_panels LRU cache budget for the forward-bar reads. Each candidate reads
    a handful of weeks, so a modest cap suffices — same value the
@@ -50,28 +70,36 @@ let _cache_mb = 512
 
 let _usage () =
   eprintf
-    "Usage: decision_audit --audit <trade_audit.sexp> [--out report.md] \
-     [--snapshot-dir <warehouse>] [--horizon-weeks 12]\n";
+    "Usage: decision_audit (--audit <trade_audit.sexp> | --weekly-picks-dir \
+     <dir> [--displayed-k 3]) [--out report.md] [--snapshot-dir <warehouse>] \
+     [--horizon-weeks 12]\n";
   Stdlib.exit 1
 
 type _parse_acc = {
   mutable audit_path : string option;
+  mutable weekly_picks_dir : string option;
+  mutable displayed_k : int option;
   mutable out_path : string option;
   mutable snapshot_dir : string option;
   mutable horizon_weeks : int option;
 }
 
-let _parse_horizon s =
+(** Parse a required-positive int flag, exiting with a clear message otherwise.
+    Shared by [--horizon-weeks] (strictly positive) and [--displayed-k] (which
+    additionally admits 0 — funds no longs — via [~min]). *)
+let _parse_pos_int ~flag ~min s =
   match Or_error.try_with (fun () -> Int.of_string (String.strip s)) with
-  | Ok n when n > 0 -> n
+  | Ok n when n >= min -> n
   | _ ->
-      eprintf "--horizon-weeks requires a positive int, got %S\n" s;
+      eprintf "%s requires an int >= %d, got %S\n" flag min s;
       Stdlib.exit 1
 
 let _parse_flag args =
   let acc =
     {
       audit_path = None;
+      weekly_picks_dir = None;
+      displayed_k = None;
       out_path = None;
       snapshot_dir = None;
       horizon_weeks = None;
@@ -82,6 +110,12 @@ let _parse_flag args =
     | "--audit" :: p :: rest ->
         acc.audit_path <- Some p;
         loop rest
+    | "--weekly-picks-dir" :: p :: rest ->
+        acc.weekly_picks_dir <- Some p;
+        loop rest
+    | "--displayed-k" :: s :: rest ->
+        acc.displayed_k <- Some (_parse_pos_int ~flag:"--displayed-k" ~min:0 s);
+        loop rest
     | "--out" :: p :: rest ->
         acc.out_path <- Some p;
         loop rest
@@ -89,7 +123,8 @@ let _parse_flag args =
         acc.snapshot_dir <- Some p;
         loop rest
     | "--horizon-weeks" :: s :: rest ->
-        acc.horizon_weeks <- Some (_parse_horizon s);
+        acc.horizon_weeks <-
+          Some (_parse_pos_int ~flag:"--horizon-weeks" ~min:1 s);
         loop rest
     | _ -> _usage ()
   in
@@ -102,6 +137,61 @@ let _load_audit_records ~path : TA.audit_record list =
   let sexp = Sexp.load_sexp path in
   try (TA.audit_blob_of_sexp sexp).audit_records
   with _ -> TA.audit_records_of_sexp sexp
+
+(** Read one weekly snapshot from [file], exiting on a parse / schema error so a
+    bad file surfaces immediately rather than being silently dropped. *)
+let _load_snapshot ~file : Weinstein_snapshot.Weekly_snapshot.t =
+  match Snapshot_reader.read_from_file file with
+  | Ok snap -> snap
+  | Error err ->
+      eprintf "decision_audit: cannot read %s: %s\n" file (Status.show err);
+      Stdlib.exit 1
+
+(** Load every [*.sexp] under [dir] as a {!Weekly_snapshot.t}. Exits when [dir]
+    contains no snapshot files (an empty run is almost always a wrong path). *)
+let _load_weekly_snapshots ~dir : Weinstein_snapshot.Weekly_snapshot.t list =
+  let files =
+    Sys_unix.readdir dir |> Array.to_list
+    |> List.filter ~f:(fun f -> String.is_suffix f ~suffix:".sexp")
+    |> List.sort ~compare:String.compare
+    |> List.map ~f:(Filename.concat dir)
+  in
+  (match files with
+  | [] ->
+      eprintf "decision_audit: no *.sexp weekly-picks files under %s\n" dir;
+      Stdlib.exit 1
+  | _ -> ());
+  List.map files ~f:(fun file -> _load_snapshot ~file)
+
+(** Build the {!DA.Screen_record.t} list for whichever input mode was selected.
+    Exits with a usage error unless exactly one of [--audit] /
+    [--weekly-picks-dir] is supplied. *)
+let _screens_of_mode acc : DA.Screen_record.t list =
+  match (acc.audit_path, acc.weekly_picks_dir) with
+  | Some _, Some _ ->
+      eprintf "--audit and --weekly-picks-dir are mutually exclusive\n";
+      _usage ()
+  | None, None ->
+      eprintf "one of --audit / --weekly-picks-dir is required\n";
+      _usage ()
+  | Some audit_path, None ->
+      let records = _load_audit_records ~path:audit_path in
+      let screens = DA.Screen_record.of_audit_records records in
+      eprintf "decision_audit: %d entries across %d screens from %s\n%!"
+        (List.length records) (List.length screens) audit_path;
+      screens
+  | None, Some dir ->
+      let snaps = _load_weekly_snapshots ~dir in
+      let displayed_k =
+        Option.value acc.displayed_k ~default:_default_displayed_k
+      in
+      let screens = DA.Weekly_adapter.of_weekly_snapshots snaps ~displayed_k in
+      eprintf
+        "decision_audit: %d weekly snapshots -> %d screens (displayed_k=%d) \
+         from %s\n\
+         %!"
+        (List.length snaps) (List.length screens) displayed_k dir;
+      screens
 
 (** Build a snapshot-backed {!Bar_reader.t} over [snapshot_dir]. Exits the
     process on a missing/corrupt manifest or panel-open failure (the "warehouse
@@ -148,18 +238,10 @@ let _counterfactual_section ~snapshot_dir ~horizon_weeks screens : string =
 
 let () =
   let acc = _parse_flag (List.tl_exn (Array.to_list (Sys.get_argv ()))) in
-  let audit_path =
-    Option.value_or_thunk acc.audit_path ~default:(fun () ->
-        eprintf "--audit is required\n";
-        _usage ())
-  in
   let horizon_weeks =
     Option.value acc.horizon_weeks ~default:_default_horizon_weeks
   in
-  let records = _load_audit_records ~path:audit_path in
-  let screens = DA.Screen_record.of_audit_records records in
-  eprintf "decision_audit: %d entries across %d screens from %s\n%!"
-    (List.length records) (List.length screens) audit_path;
+  let screens = _screens_of_mode acc in
   let markdown =
     DA.Report.to_markdown screens
     ^ _counterfactual_section ~snapshot_dir:acc.snapshot_dir ~horizon_weeks

--- a/trading/trading/backtest/decision_audit/bin/dune
+++ b/trading/trading/backtest/decision_audit/bin/dune
@@ -3,10 +3,12 @@
  (modules decision_audit_bin)
  (libraries
   core
+  core_unix.sys_unix
   status
   backtest
   decision_audit
   weinstein_trading.strategy
+  weinstein_trading.snapshot
   weinstein.snapshot_runtime
   weinstein.snapshot_pipeline)
  (preprocess

--- a/trading/trading/backtest/decision_audit/lib/dune
+++ b/trading/trading/backtest/decision_audit/lib/dune
@@ -6,6 +6,7 @@
   trading.base
   backtest
   decision_grading
-  weinstein_trading.strategy)
+  weinstein_trading.strategy
+  weinstein_trading.snapshot)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/lib/screen_record.ml
+++ b/trading/trading/backtest/decision_audit/lib/screen_record.ml
@@ -87,7 +87,7 @@ let _dedup_near_misses (alts : near_miss list) : near_miss list =
     ~equal:(fun a b -> String.equal a.symbol b.symbol)
   |> List.sort ~compare:(fun a b -> Int.compare b.score a.score)
 
-let _summary_of ~(funded : funded_entry list) ~(near_misses : near_miss list) :
+let summary_of (funded : funded_entry list) (near_misses : near_miss list) :
     summary =
   let min_funded_score =
     List.min_elt funded ~compare:(fun (a : funded_entry) b ->
@@ -120,12 +120,7 @@ let _record_of_screen ~screen_date ~(entries : TA.entry_decision list) : t =
         List.map e.alternatives_considered ~f:_near_miss_of_alt)
   in
   let near_misses = _dedup_near_misses raw_near_misses in
-  {
-    screen_date;
-    funded;
-    near_misses;
-    summary = _summary_of ~funded ~near_misses;
-  }
+  { screen_date; funded; near_misses; summary = summary_of funded near_misses }
 
 let of_audit_records (records : TA.audit_record list) : t list =
   let by_date = Hashtbl.create (module Date) in

--- a/trading/trading/backtest/decision_audit/lib/screen_record.mli
+++ b/trading/trading/backtest/decision_audit/lib/screen_record.mli
@@ -79,6 +79,14 @@ type t = {
 [@@deriving sexp]
 (** One record per weekly screen date. *)
 
+val summary_of : funded_entry list -> near_miss list -> summary
+(** [summary_of funded near_misses] computes the per-screen roll-up: [n_funded],
+    [n_near_miss], the [min_funded_score] / [max_nearmiss_score] extrema, and
+    the [inversion] flag (some near-miss scored strictly above the lowest funded
+    entry). Exposed so alternative record producers — e.g. the live weekly-picks
+    adapter {!Weekly_adapter} — reuse the exact same computation rather than
+    duplicating it. *)
+
 val of_audit_records : Backtest.Trade_audit.audit_record list -> t list
 (** Group the entry side of [audit_records] by [entry_date] into one {!t} per
     screen, sorted by [screen_date] ascending.

--- a/trading/trading/backtest/decision_audit/lib/weekly_adapter.ml
+++ b/trading/trading/backtest/decision_audit/lib/weekly_adapter.ml
@@ -1,0 +1,91 @@
+(** Adapter: live weekly-picks snapshots → {!Screen_record.t}. See the [.mli].
+*)
+
+open Core
+module WS = Weinstein_snapshot.Weekly_snapshot
+module TA = Backtest.Trade_audit
+module SR = Screen_record
+
+(** Parse a displayed grade label (the inverse of
+    [Weinstein_types.grade_to_string]) back to the variant. Exhaustive; raises
+    [Invalid_argument] on an unknown label rather than silently defaulting, so a
+    schema drift surfaces loudly. *)
+let _grade_of_string (s : string) : Weinstein_types.grade =
+  match s with
+  | "A+" -> A_plus
+  | "A" -> A
+  | "B" -> B
+  | "C" -> C
+  | "D" -> D
+  | "F" -> F
+  | other ->
+      invalid_arg
+        (Printf.sprintf "Weekly_adapter: unknown grade label %S" other)
+
+(* A live long pick is a Stage-2 breakout by the screener's construction; a live
+   short pick is a Stage-4 decline. The count fields are unknown from a snapshot,
+   so they default to 0 (surfaced as [None] in the record's [weeks_advancing]). *)
+let _long_stage : Weinstein_types.stage =
+  Stage2 { weeks_advancing = 0; late = false }
+
+let _short_stage : Weinstein_types.stage = Stage4 { weeks_declining = 0 }
+let _score_of (c : WS.candidate) : int = Float.iround_nearest_exn c.score
+
+let _funded_of_candidate (c : WS.candidate) : SR.funded_entry =
+  {
+    symbol = c.symbol;
+    score = _score_of c;
+    grade = _grade_of_string c.grade;
+    stage = _long_stage;
+    weeks_advancing = None;
+    rs_value = c.rs_vs_spy;
+    volume_ratio = None;
+    sector_name = c.sector;
+  }
+
+(** Map a below-the-cut candidate to a near-miss. [stage] and [side] differ for
+    the long-overflow vs short cases; the caller supplies both. *)
+let _near_miss_of_candidate ~(side : Trading_base.Types.position_side)
+    ~(stage : Weinstein_types.stage) (c : WS.candidate) : SR.near_miss =
+  {
+    symbol = c.symbol;
+    side;
+    score = _score_of c;
+    grade = _grade_of_string c.grade;
+    reason_skipped = TA.Top_n_cutoff;
+    stage;
+    weeks_advancing = None;
+    rs_value = c.rs_vs_spy;
+    volume_ratio = None;
+    sector_name = c.sector;
+  }
+
+let _record_of_snapshot ~displayed_k (snap : WS.t) : SR.t =
+  let funded_cands, long_overflow =
+    List.split_n snap.long_candidates displayed_k
+  in
+  let funded = List.map funded_cands ~f:_funded_of_candidate in
+  let long_near =
+    List.map long_overflow
+      ~f:(_near_miss_of_candidate ~side:Long ~stage:_long_stage)
+  in
+  let short_near =
+    List.map snap.short_candidates
+      ~f:(_near_miss_of_candidate ~side:Short ~stage:_short_stage)
+  in
+  let near_misses = long_near @ short_near in
+  {
+    screen_date = snap.date;
+    funded;
+    near_misses;
+    summary = SR.summary_of funded near_misses;
+  }
+
+let of_weekly_snapshots (snaps : WS.t list) ~displayed_k : SR.t list =
+  if displayed_k < 0 then
+    invalid_arg
+      (Printf.sprintf "Weekly_adapter: displayed_k must be >= 0, got %d"
+         displayed_k);
+  List.map snaps ~f:(_record_of_snapshot ~displayed_k)
+  |> List.sort ~compare:(fun (a : SR.t) b ->
+      Date.compare a.screen_date b.screen_date)

--- a/trading/trading/backtest/decision_audit/lib/weekly_adapter.mli
+++ b/trading/trading/backtest/decision_audit/lib/weekly_adapter.mli
@@ -1,0 +1,59 @@
+(** Adapter: live weekly-picks snapshots → {!Screen_record.t}.
+
+    The decision-audit faithfulness lens ({!Screen_record}, {!Report},
+    {!Counterfactual}) was built to consume a backtest's [trade_audit.sexp].
+    This adapter lets the {b same} Phase-1 report and Phase-2 counterfactual run
+    on {b live} weekly picks — the per-Friday {!Weekly_snapshot.t} screens
+    written under [dev/weekly-picks/]. Additive and read-only: it produces
+    {!Screen_record.t} values identical in shape to the backtest path, so no
+    downstream code changes.
+
+    {1 The funded / near-miss mapping}
+
+    A live snapshot has no portfolio / cash line — it is a ranked candidate
+    list, not a set of executed trades. We synthesize the funded/near-miss split
+    from the {b displayed cut}: the top [displayed_k] long candidates (the picks
+    a human would act on that week) stand in for the {b funded} entries, and
+    everything below the cut — the remaining long candidates {b plus} all short
+    candidates — becomes the {b near-misses}, tagged
+    [Backtest.Trade_audit.Top_n_cutoff]. This is the live analog of the
+    backtest's cash-rejected near-miss line: "what scored at this screen but sat
+    below the line we displayed".
+
+    {1 Assumptions and ceilings (documented, not silently defaulted)}
+
+    - {b Stage.} A live {!Weekly_snapshot.candidate} does not carry its
+      Weinstein stage. Long picks are Stage-2 breakouts by the screener's
+      construction (buy only in Stage 2), so long candidates default to
+      [Weinstein_types.Stage2 { weeks_advancing = 0; late = false }] with the
+      record's [weeks_advancing] field left [None] (the count is not recovered).
+      Short picks are Stage-4 declines by the same faithful construction (short
+      only in Stage 4), so they default to
+      [Weinstein_types.Stage4 { weeks_declining = 0 }].
+    - [weeks_advancing] and [volume_ratio] are [None] — neither is carried in
+      the snapshot schema. The RS / score / grade / sector comparison is what
+      this adapter enables; the volume and advancing-weeks columns of the
+      faithfulness table will therefore be empty for weekly-picks input.
+    - [score] is [Float.iround_nearest_exn] of the snapshot's float score (the
+      snapshot widened the screener's int score to float; we narrow it back). *)
+
+val of_weekly_snapshots :
+  Weinstein_snapshot.Weekly_snapshot.t list ->
+  displayed_k:int ->
+  Screen_record.t list
+(** [of_weekly_snapshots snaps ~displayed_k] maps each weekly snapshot to one
+    {!Screen_record.t}, sorted by screen date ascending.
+
+    For each snapshot: [screen_date] is the snapshot [date]; [funded] is the
+    first [displayed_k] [long_candidates] (already score-descending) mapped to
+    {!Screen_record.funded_entry}; [near_misses] is the remaining long
+    candidates (beyond the cut) unioned with all [short_candidates], each mapped
+    to {!Screen_record.near_miss} with [reason_skipped = Top_n_cutoff] and the
+    side that the source list implies ([Long] for the long overflow, [Short] for
+    the short candidates); [summary] is computed via
+    {!Screen_record.summary_of}.
+
+    [displayed_k] must be non-negative; a value at or above a snapshot's long
+    count funds every long candidate and leaves the long near-miss set empty.
+    Raises [Invalid_argument] on a grade string the parser does not recognize —
+    it never silently defaults an unknown label. *)

--- a/trading/trading/backtest/decision_audit/test/dune
+++ b/trading/trading/backtest/decision_audit/test/dune
@@ -1,5 +1,9 @@
 (tests
- (names test_screen_record test_report test_counterfactual)
+ (names
+  test_screen_record
+  test_report
+  test_counterfactual
+  test_weekly_adapter)
  (libraries
   ounit2
   core
@@ -8,6 +12,7 @@
   backtest
   types
   trading.base
-  weinstein_trading.strategy)
+  weinstein_trading.strategy
+  weinstein_trading.snapshot)
  (preprocess
   (pps ppx_deriving.show ppx_deriving.eq ppx_sexp_conv)))

--- a/trading/trading/backtest/decision_audit/test/test_weekly_adapter.ml
+++ b/trading/trading/backtest/decision_audit/test/test_weekly_adapter.ml
@@ -222,6 +222,19 @@ let test_summary_computed_and_snapshots_sorted _ =
            ];
        ])
 
+(* Grade parser fails loudly on an unknown label — the .mli's advertised guard
+   ("never silently defaults an unknown label"). A silent [| _ -> A] fallback
+   would pass every other test, so pin the raise explicitly. *)
+let test_unknown_grade_raises _ =
+  let snap =
+    _snapshot
+      ~long_candidates:[ _candidate ~symbol:"AAPL" ~score:90.0 ~grade:"Z" () ]
+      ()
+  in
+  match WA.of_weekly_snapshots [ snap ] ~displayed_k:1 with
+  | exception Invalid_argument _ -> ()
+  | _ -> assert_failure "expected Invalid_argument for unknown grade 'Z'"
+
 let suite =
   "Decision_audit.Weekly_adapter"
   >::: [
@@ -234,6 +247,7 @@ let suite =
          >:: test_short_candidate_lands_in_near_misses;
          "summary computed + snapshots sorted"
          >:: test_summary_computed_and_snapshots_sorted;
+         "unknown grade raises" >:: test_unknown_grade_raises;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/decision_audit/test/test_weekly_adapter.ml
+++ b/trading/trading/backtest/decision_audit/test/test_weekly_adapter.ml
@@ -1,0 +1,239 @@
+(** Unit tests for [Decision_audit.Weekly_adapter].
+
+    Covers the funded / near-miss split at the displayed cut, the candidate ->
+    record field mapping (score narrowing, grade parse, rs / sector), the stage
+    default (Stage2 for longs, Stage4 for shorts), and the short-candidate ->
+    near-miss (side = Short) path — all on synthetic [Weekly_snapshot.t]. *)
+
+open OUnit2
+open Core
+open Matchers
+module WS = Weinstein_snapshot.Weekly_snapshot
+module TA = Backtest.Trade_audit
+module SR = Decision_audit.Screen_record
+module WA = Decision_audit.Weekly_adapter
+
+let _date d = Date.of_string d
+
+let _candidate ?(entry = 100.0) ?(stop = 92.0) ?(rationale = "Stage2 breakout")
+    ?(rs_vs_spy = Some 1.0) ?(resistance_grade = None) ?(sector = "Tech")
+    ~symbol ~score ~grade () : WS.candidate =
+  {
+    symbol;
+    score;
+    grade;
+    entry;
+    stop;
+    sector;
+    rationale;
+    rs_vs_spy;
+    resistance_grade;
+  }
+
+(** A minimal snapshot: only the fields the adapter reads carry test data; the
+    rest get inert defaults. *)
+let _snapshot ?(date = _date "2024-03-01") ?(long_candidates = [])
+    ?(short_candidates = []) () : WS.t =
+  {
+    schema_version = WS.current_schema_version;
+    system_version = "test";
+    date;
+    macro = { regime = "Bullish"; score = 0.7 };
+    sectors_strong = [];
+    sectors_weak = [];
+    long_candidates;
+    short_candidates;
+    held_positions = [];
+  }
+
+(* Funded cut ------------------------------------------------------------ *)
+
+let test_funded_is_first_displayed_k_longs _ =
+  let longs =
+    [
+      _candidate ~symbol:"AAPL" ~score:90.0 ~grade:"A+" ();
+      _candidate ~symbol:"MSFT" ~score:80.0 ~grade:"A" ();
+      _candidate ~symbol:"NVDA" ~score:70.0 ~grade:"B" ();
+    ]
+  in
+  let snap = _snapshot ~long_candidates:longs () in
+  assert_that
+    (WA.of_weekly_snapshots [ snap ] ~displayed_k:2)
+    (elements_are
+       [
+         field
+           (fun (s : SR.t) -> s.funded)
+           (elements_are
+              [
+                field (fun (e : SR.funded_entry) -> e.symbol) (equal_to "AAPL");
+                field (fun (e : SR.funded_entry) -> e.symbol) (equal_to "MSFT");
+              ]);
+       ])
+
+let test_long_overflow_is_top_n_cutoff_near_miss _ =
+  let longs =
+    [
+      _candidate ~symbol:"AAPL" ~score:90.0 ~grade:"A+" ();
+      _candidate ~symbol:"NVDA" ~score:70.0 ~grade:"B" ();
+    ]
+  in
+  let snap = _snapshot ~long_candidates:longs () in
+  assert_that
+    (WA.of_weekly_snapshots [ snap ] ~displayed_k:1)
+    (elements_are
+       [
+         field
+           (fun (s : SR.t) -> s.near_misses)
+           (elements_are
+              [
+                all_of
+                  [
+                    field (fun (n : SR.near_miss) -> n.symbol) (equal_to "NVDA");
+                    field
+                      (fun (n : SR.near_miss) -> n.side)
+                      (equal_to Trading_base.Types.Long);
+                    field
+                      (fun (n : SR.near_miss) -> n.reason_skipped)
+                      (equal_to TA.Top_n_cutoff);
+                  ];
+              ]);
+       ])
+
+(* Field mapping --------------------------------------------------------- *)
+
+let test_funded_field_mapping _ =
+  (* score 78.4 narrows to 78; grade "A" parses; rs / sector carried; stage
+     defaults to Stage2 with weeks_advancing left None. *)
+  let longs =
+    [
+      _candidate ~symbol:"AAPL" ~score:78.4 ~grade:"A" ~rs_vs_spy:(Some 1.2)
+        ~sector:"Health" ();
+    ]
+  in
+  let snap = _snapshot ~long_candidates:longs () in
+  assert_that
+    (WA.of_weekly_snapshots [ snap ] ~displayed_k:3)
+    (elements_are
+       [
+         field
+           (fun (s : SR.t) -> s.funded)
+           (elements_are
+              [
+                all_of
+                  [
+                    field (fun (e : SR.funded_entry) -> e.score) (equal_to 78);
+                    field
+                      (fun (e : SR.funded_entry) -> e.grade)
+                      (equal_to Weinstein_types.A);
+                    field
+                      (fun (e : SR.funded_entry) -> e.rs_value)
+                      (is_some_and (float_equal 1.2));
+                    field
+                      (fun (e : SR.funded_entry) -> e.sector_name)
+                      (equal_to "Health");
+                    field
+                      (fun (e : SR.funded_entry) -> e.weeks_advancing)
+                      is_none;
+                    field (fun (e : SR.funded_entry) -> e.volume_ratio) is_none;
+                    field
+                      (fun (e : SR.funded_entry) -> e.stage)
+                      (equal_to
+                         (Weinstein_types.Stage2
+                            { weeks_advancing = 0; late = false }));
+                  ];
+              ]);
+       ])
+
+(* Shorts ---------------------------------------------------------------- *)
+
+let test_short_candidate_lands_in_near_misses _ =
+  let snap =
+    _snapshot
+      ~long_candidates:[ _candidate ~symbol:"AAPL" ~score:90.0 ~grade:"A+" () ]
+      ~short_candidates:[ _candidate ~symbol:"XYZ" ~score:60.0 ~grade:"C" () ]
+      ()
+  in
+  assert_that
+    (WA.of_weekly_snapshots [ snap ] ~displayed_k:3)
+    (elements_are
+       [
+         field
+           (fun (s : SR.t) -> s.near_misses)
+           (elements_are
+              [
+                all_of
+                  [
+                    field (fun (n : SR.near_miss) -> n.symbol) (equal_to "XYZ");
+                    field
+                      (fun (n : SR.near_miss) -> n.side)
+                      (equal_to Trading_base.Types.Short);
+                    field
+                      (fun (n : SR.near_miss) -> n.reason_skipped)
+                      (equal_to TA.Top_n_cutoff);
+                    field
+                      (fun (n : SR.near_miss) -> n.stage)
+                      (equal_to
+                         (Weinstein_types.Stage4 { weeks_declining = 0 }));
+                  ];
+              ]);
+       ])
+
+(* Summary + ordering ---------------------------------------------------- *)
+
+let test_summary_computed_and_snapshots_sorted _ =
+  (* Two snapshots out of date order in → sorted ascending out; summary counts
+     one funded + one long-overflow near-miss on the later screen. *)
+  let mar_08 =
+    _snapshot ~date:(_date "2024-03-08")
+      ~long_candidates:
+        [
+          _candidate ~symbol:"AAPL" ~score:90.0 ~grade:"A+" ();
+          _candidate ~symbol:"NVDA" ~score:70.0 ~grade:"B" ();
+        ]
+      ()
+  in
+  let mar_01 =
+    _snapshot ~date:(_date "2024-03-01")
+      ~long_candidates:[ _candidate ~symbol:"MSFT" ~score:80.0 ~grade:"A" () ]
+      ()
+  in
+  assert_that
+    (WA.of_weekly_snapshots [ mar_08; mar_01 ] ~displayed_k:1)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (s : SR.t) -> Date.to_string s.screen_date)
+               (equal_to "2024-03-01");
+             field (fun (s : SR.t) -> s.summary.n_funded) (equal_to 1);
+             field (fun (s : SR.t) -> s.summary.n_near_miss) (equal_to 0);
+           ];
+         all_of
+           [
+             field
+               (fun (s : SR.t) -> Date.to_string s.screen_date)
+               (equal_to "2024-03-08");
+             field (fun (s : SR.t) -> s.summary.n_funded) (equal_to 1);
+             field (fun (s : SR.t) -> s.summary.n_near_miss) (equal_to 1);
+             field
+               (fun (s : SR.t) -> s.summary.min_funded_score)
+               (is_some_and (equal_to 90));
+           ];
+       ])
+
+let suite =
+  "Decision_audit.Weekly_adapter"
+  >::: [
+         "funded is first displayed_k longs"
+         >:: test_funded_is_first_displayed_k_longs;
+         "long overflow is Top_n_cutoff near-miss"
+         >:: test_long_overflow_is_top_n_cutoff_near_miss;
+         "funded field mapping" >:: test_funded_field_mapping;
+         "short candidate lands in near-misses"
+         >:: test_short_candidate_lands_in_near_misses;
+         "summary computed + snapshots sorted"
+         >:: test_summary_computed_and_snapshots_sorted;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Adds a **weekly-snapshot adapter** so the `decision_audit` faithfulness lens runs on **live** weekly picks (`Weekly_snapshot.t` under `dev/weekly-picks/`), not only on a backtest `trade_audit.sexp`. Additive and read-only — no engine/strategy behaviour change, `--audit` mode unchanged.

### New module: `decision_audit/lib/weekly_adapter.{ml,mli}`

`Weekly_adapter.of_weekly_snapshots snaps ~displayed_k : Screen_record.t list` — one `Screen_record.t` per snapshot, sorted by date:

- `screen_date` = snapshot `date`.
- `funded` = the first `displayed_k` `long_candidates` (already score-desc) → `funded_entry`.
- `near_misses` = the remaining long candidates (side `Long`) ∪ all `short_candidates` (side `Short`), each tagged `Top_n_cutoff` — the live analog of the backtest's cash-rejected near-miss line ("scored at this screen but below the displayed cut").
- `summary` reuses the newly-exposed `Screen_record.summary_of` (no duplication).

### Bin: `--weekly-picks-dir <dir>` + `--displayed-k <N>` (default 3)

Loads every `*.sexp` in the dir via `Snapshot_reader.read_from_file`, sorts by date, runs the adapter, then renders the **same** Phase-1 report (and Phase-2 counterfactual if `--snapshot-dir` also given). Mutually exclusive with `--audit` (errors if both/neither).

## Decisions made

- **Grade-string parser** (`_grade_of_string`): exhaustive inverse of `Weinstein_types.grade_to_string` ("A+"/"A"/"B"/"C"/"D"/"F"). Raises `Invalid_argument` on an unknown label — never silently defaults.
- **Stage default**: the snapshot carries no stage. Long picks default to `Stage2 {weeks_advancing=0; late=false}` (buy-only-in-Stage-2 by screener construction); short picks to `Stage4 {weeks_declining=0}` (short-only-in-Stage-4). Documented in the `.mli`.
- **Ceilings**: `weeks_advancing` and `volume_ratio` are `None` (not carried in the snapshot schema). The RS + score + grade + sector comparison is what this adapter enables; documented in the `.mli`.

## Test plan

`test/test_weekly_adapter.ml` (OUnit2 + Matchers, one `assert_that` per value): funded = first `displayed_k` longs; long-overflow → `Top_n_cutoff` near-miss (side `Long`); score narrowing (78.4→78) + grade parse + rs/sector mapping + stage defaulted to Stage2 + `weeks_advancing`/`volume_ratio` = `None`; short candidate → near-miss (side `Short`, Stage4); summary computed + snapshots sorted ascending.

Verify: `dune runtest trading/backtest/decision_audit` — 25 tests (6 screen_record + 8 report + 6 counterfactual + 5 weekly_adapter). Full `dune build` + `dune build @fmt` clean; nesting linter reports zero decision_audit offenders.

Do not modify `dev/status/_index.md` from this PR; only `dev/status/decision-audit.md` is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
