### PR TITLE
docs+tool: live-generator prior_stage bug + stage_dump diagnostic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dev/experiments/bayesian-production-sweep-*/output-11knob*-parallel*/
 # Docker.raw. Created by .devcontainer/setup.sh's do_start. See
 # dev/plans/safe-sweep-infrastructure-2026-05-24.md.
 .sweep-output/
+
+# Live-generator prior-stage bug investigation scratch (2026-07-01) — regenerable
+trading/dev/experiments/weekly-cf/

--- a/dev/notes/live-generator-prior-stage-bug-2026-07-01.md
+++ b/dev/notes/live-generator-prior-stage-bug-2026-07-01.md
@@ -1,0 +1,118 @@
+# Live weekly-snapshot generator resets `weeks_advancing` — a stage-classification defect
+
+**Severity:** high — it changes *which stocks* the live weekly screener picks, not
+just their grade. **Scope:** live snapshot generator only; backtests are unaffected
+(they already chain the stage classifier). Found 2026-07-01 while auditing why every
+2026 weekly pick scores exactly 70.
+
+## The defect
+
+`Weekly_snapshot_generator._analyze_ticker` (`weekly_snapshot_generator.ml:63`)
+analyses each ticker with a **single** `Stock_analysis.analyze` call passing
+**`~prior_stage:None`**. The stage classifier uses `prior_stage` to *carry the
+running count of how long a stock has been in its current stage*. With `None`, it
+cannot know the history, so it **resets `weeks_advancing` to ~1 for every Stage-2
+stock** — the generator believes every advancer just broke out this week.
+
+### Evidence (2026-05-29 picks, proper chained vs the live single-call)
+
+| stock | chained classification (= backtest) | live single-call `prior=None` |
+|---|---|---|
+| AIP  | Stage2 **w44** | Stage2 **w1** |
+| ATRO | Stage2 **w45** | Stage2 **w1** |
+| AAON | Stage2 **w5**  | (labelled Early Stage2) |
+
+Under correct (prior-chained) classification the 20 picks of 2026-05-29 span
+**w1 → w45**. The live generator labelled **all 20** "Early Stage2". Verified with a
+`stage_dump` diagnostic that reuses `weinstein.stage`'s rolling classifier (the same
+one the backtest drives via `weinstein_trading_state.prior_stages`).
+
+## Why it matters — two consequences
+
+**1. Grade collapse.** `Screener_scoring._stage_long_signal`:
+`Stage2, weeks_advancing ≤ 4 → 15` ("Early Stage2"); `> 4 → 0`. With the reset,
+every advancer gets 15 → and with the other maxed signals lands at exactly 70 =
+grade A. Correctly classified, only genuinely-early names keep the 15; the ~13/20
+extended names lose it (→ 55 = grade B). The flat "20× A/70" is an artifact.
+
+**2. Admission pollution (the real problem).** The candidate gate itself,
+`Stock_analysis._initial_breakout_arm`, is `Stage2 {weeks_advancing} →
+weeks_advancing ≤ 4`. With the reset (all w1) **every** Stage-2 stock passes.
+Correctly classified, the w5–w45 names **fail the gate** — they should never be
+candidates. So the live weekly list is padded with **extended advancers** (AIP ~44
+weeks, ATRO ~45 weeks into Stage 2 ≈ 11 months, arguably near Stage-3 topping risk)
+that the strategy's *own rule* excludes. Of the 20 picks, ~13 shouldn't be there.
+
+The live picks are therefore **not** "20 fresh breakouts that happen to tie" — they
+are a few genuinely-early names buried in a pile of extended movers, all flattened
+to look identical because `weeks_advancing` is stuck at 1.
+
+## The fix
+
+Chain the stage classification in the generator, exactly as the backtest does. The
+generator already holds the full weekly bar history per ticker; it just needs to
+roll `Stage.classify` over the prefix (threading `prior_stage`) and feed the correct
+prior stage — with its accumulated count — into the `as_of` `analyze` call, instead
+of `None`. `Stage.classify` is cheap, so the extra pass is cheap.
+
+Properties:
+- **Backtests unaffected** — they already chain via `trading_state`. This is purely
+  a live-generator fidelity fix.
+- **Independent** of the coarse-bucket / continuous-RS scoring discussion (that is
+  about resolution *within* a legitimate tie; this is about the tie being fake).
+- Highest-value of the live-picks threads (vs #1782 display order, vs continuous-RS
+  scoring): it changes the *candidate set*, not just presentation.
+
+## Verification — IMPLEMENTED + CONFIRMED (2026-07-01)
+
+Fix implemented in `_analyze_ticker` (`_chained_prior_stage` rolls `Stage.classify`
+over the weekly prefix and feeds the chained prior into `analyze`). Re-ran
+`generate_weekly_snapshot` on the 50 pick symbols at `--as-of 2026-05-29`, before vs
+after (reduced data — no index/sector bars, so scores are lower, but the
+`weeks_advancing` / admission effect is exact):
+
+| | BEFORE (prior=None) | AFTER (chained) |
+|---|---|---|
+| candidates admitted | **22** | **10** |
+| labelling | all "Early Stage2" | genuinely-early only |
+
+**15 names dropped** — all extended advancers the `≤4-week` gate should reject, with
+their *true* (chained) `weeks_advancing` at 05-29:
+`AIP w44, ATRO w45, AESI w18, AGYS w18, ATOM w14, BAND w12, AXTA w10, BLBD w9,
+AOSL w7, AUDC w7` + the w5 edge cases `AAON ACMR ATKR BB BLDP`. Survivors were the
+w≤4 breakouts (ADUR AEVA AGPU ALMU AMBA APPS BLZE BOOM CCSI CLFD). The corrected
+`weeks_advancing` matches the `stage_dump` chained reference exactly — the fix is not
+a blanket over-count, it's correct.
+
+### Two follow-on findings the fix surfaces
+
+1. **2 generator tests encoded the buggy behavior.**
+   `test_weekly_snapshot_generator`'s "breakout AAPL is a long candidate" (+1 more)
+   expect AAPL admitted, but their synthetic breakout sits **5–8 weeks** before
+   `as_of` (inside the 8-week breakout-event window). Under `prior=None` that reset
+   to w1 and passed; under correct chaining it's `weeks_advancing > 4` and the `≤4`
+   gate rejects it. The tests must be updated — ideally by making the synthetic
+   breakout genuinely recent (≤4 weeks pre-`as_of`) so they assert the *correct*
+   fresh-breakout path.
+
+2. **A real tuning tension: `≤4` early-gate vs the 8-week breakout-event window.**
+   The breakout-event lookback is 8 weeks, but `_initial_breakout_arm` admits
+   `weeks_advancing ≤ 4`. While the classifier was broken, this never mattered (all
+   reset to w1). Now that it works, breakouts 5–8 weeks old are inside the event
+   window but rejected by the early gate. Whether `≤4` is the right threshold — or
+   should align with the 8-week window — is a **separate tuning decision** the fix
+   exposes but does not resolve. The fix makes the *configured* gate actually bite;
+   the *value* of the gate is now a live question.
+
+## Status / decision
+
+Fix is implemented + validated locally. Because it changes live candidate admission
+by ~55%, it is surfaced as a **decision item** rather than silently merged (per the
+repo's "propose strategy changes as decision items" convention). To land: update the
+2 tests to the corrected path + pin a `weeks_advancing`-chaining test, then PR through
+qc-behavioral (domain faithfulness) + CI. The `≤4`-vs-8-week tuning question is a
+follow-up, not part of the correctness fix.
+
+Diagnostic tool: `analysis/scripts/stage_dump/` (reuses `weinstein.stage` rolling
+classification; the same one the backtest drives). Committed as a reusable
+stage-timeline inspector.

--- a/trading/analysis/scripts/stage_dump/dune
+++ b/trading/analysis/scripts/stage_dump/dune
@@ -1,0 +1,13 @@
+(executable
+ (name stage_dump)
+ (libraries
+  core
+  types
+  csv
+  indicators.time_period
+  weinstein.stage
+  fpath
+  weinstein.types
+  status)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/analysis/scripts/stage_dump/stage_dump.ml
+++ b/trading/analysis/scripts/stage_dump/stage_dump.ml
@@ -1,0 +1,60 @@
+open Core
+
+(* stage_dump <data_dir> <symbol> <end_date> <from_date>
+
+   Prints the rolling Weinstein stage per week for [symbol], PRIOR-CHAINED (the
+   correct classification the backtest drives via trading_state, and the one the
+   live weekly-snapshot generator historically got wrong by passing
+   prior_stage:None — see dev/notes/live-generator-prior-stage-bug-2026-07-01.md).
+
+   For each week >= [from_date] it prints:
+     <date> <prev_stage>-><stage> w<weeks_in_stage> [<== TRANSITION]
+   A TRANSITION marks a week whose stage differs from the prior week's. *)
+
+let stage_label = function
+  | Weinstein_types.Stage1 _ -> "Stage1"
+  | Weinstein_types.Stage2 _ -> "Stage2"
+  | Weinstein_types.Stage3 _ -> "Stage3"
+  | Weinstein_types.Stage4 _ -> "Stage4"
+
+let stage_weeks = function
+  | Weinstein_types.Stage1 { weeks_in_base } -> weeks_in_base
+  | Weinstein_types.Stage2 { weeks_advancing; _ } -> weeks_advancing
+  | Weinstein_types.Stage3 { weeks_topping } -> weeks_topping
+  | Weinstein_types.Stage4 { weeks_declining } -> weeks_declining
+
+let load_weekly ~data_dir ~symbol ~end_date =
+  let result =
+    let open Result.Let_syntax in
+    let%bind storage =
+      Csv.Csv_storage.create ~data_dir:(Fpath.v data_dir) symbol
+    in
+    let%map daily = Csv.Csv_storage.get storage ~end_date () in
+    Time_period.Conversion.daily_to_weekly ~include_partial_week:false daily
+  in
+  match result with Ok w -> w | Error e -> failwith (Status.show e)
+
+let () =
+  let argv = Sys.get_argv () in
+  let data_dir = argv.(1) and symbol = argv.(2) in
+  let end_date = Date.of_string argv.(3)
+  and from_date = Date.of_string argv.(4) in
+  let arr = Array.of_list (load_weekly ~data_dir ~symbol ~end_date) in
+  let n = Array.length arr in
+  let cfg = Stage.default_config in
+  let prior = ref None in
+  for i = 0 to n - 1 do
+    let bars = Array.to_list (Array.sub arr ~pos:0 ~len:(i + 1)) in
+    let r = Stage.classify ~config:cfg ~bars ~prior_stage:!prior in
+    let d = arr.(i).Types.Daily_price.date in
+    (if Date.( >= ) d from_date then
+       let cur = stage_label r.stage in
+       let prev = Option.value_map !prior ~default:"-" ~f:stage_label in
+       let fresh =
+         if String.(prev <> "-") && String.(prev <> cur) then "  <== TRANSITION"
+         else ""
+       in
+       printf "%s %s->%s w%d%s\n" (Date.to_string d) prev cur
+         (stage_weeks r.stage) fresh);
+    prior := Some r.stage
+  done


### PR DESCRIPTION
## Finding
The live weekly-snapshot generator (`weekly_snapshot_generator.ml:63`) passes `prior_stage:None`, so `Stage.classify` **resets `weeks_advancing` to ~1 for every Stage-2 stock**. Consequences: (1) grades collapse (all → 'Early Stage2' → same score), and (2) **admission pollution** — the `≤4-week` early-breakout gate never bites, so the live picks are ~55% *extended* advancers (AIP ~44wk, ATRO ~45wk ≈ 11 months in) the strategy's own rule should reject.

## Validated fix (not in this PR — surfaced as a decision)
Implemented chained classification in the generator + re-ran on the 50 pick symbols at as-of 2026-05-29: candidates **22 → 10**, dropping exactly the w5–w45 extended names; survivors are the genuinely-early breakouts. Corrected `weeks_advancing` matches the `stage_dump` reference exactly. The fix is **not** included here because it changes live admission ~55%, requires updating 2 tests that encode the buggy behavior, and exposes a `≤4`-gate-vs-8-week-event-window tuning question — all a decision item.

## This PR
- `dev/notes/live-generator-prior-stage-bug-2026-07-01.md` — full analysis + before/after.
- `analysis/scripts/stage_dump/` — a prior-chained stage-timeline inspector (the diagnostic used).
- `.gitignore` — ignore the regenerable investigation scratch dir.

Backtests are unaffected (they already chain via `trading_state`). Pure docs + read-only diagnostic tool; no domain/strategy logic changes.