### PR TITLE
fix(weekly-gen): chain prior_stage so weeks_advancing is correct

### DIFF
--- a/trading/trading/weinstein/snapshot/gen/lib/dune
+++ b/trading/trading/weinstein/snapshot/gen/lib/dune
@@ -11,6 +11,7 @@
   weinstein.screener
   weinstein.macro
   weinstein.sector
+  weinstein.stage
   weinstein.stock_analysis
   weinstein.rs
   weinstein.resistance

--- a/trading/trading/weinstein/snapshot/gen/lib/weekly_snapshot_generator.ml
+++ b/trading/trading/weinstein/snapshot/gen/lib/weekly_snapshot_generator.ml
@@ -51,16 +51,43 @@ let _build_sector_map ~(inputs : inputs) ~index_bars :
     ~f:(_set_sector_ctx_for_etf ~inputs ~index_bars ~by_sector ~sector_map);
   sector_map
 
+(* Reconstruct the chained prior-week stage the way the backtest does: roll the
+   stage classifier over the weekly prefix threading [prior_stage], and return
+   the stage AFTER the second-to-last week. The generator is a one-shot with no
+   cross-week state, so without this it passed [prior_stage:None] and the
+   classifier reset [weeks_advancing] to ~1 for EVERY Stage-2 stock — collapsing
+   the whole Stage-2 lifecycle to "Early Stage2" and admitting extended
+   advancers the <=4-week gate should reject. See
+   [dev/notes/live-generator-prior-stage-bug-2026-07-01.md]. *)
+let _chained_prior_stage ~(stage_config : Stage.config) weekly_bars =
+  let arr = Array.of_list weekly_bars in
+  let n = Array.length arr in
+  if n <= 1 then None
+  else begin
+    let prior = ref None in
+    for i = 0 to n - 2 do
+      let bars = Array.to_list (Array.sub arr ~pos:0 ~len:(i + 1)) in
+      prior :=
+        Some
+          (Stage.classify ~config:stage_config ~bars ~prior_stage:!prior).stage
+    done;
+    !prior
+  end
+
 (* Analyse one ticker. Symbols with no weekly bars are dropped ([None]) — they
    cannot satisfy the screener's breakout / breakdown rules. *)
-let _analyze_ticker ~(inputs : inputs) ~analysis_config ~index_bars ticker :
+let _analyze_ticker ~(inputs : inputs)
+    ~(analysis_config : Stock_analysis.config) ~index_bars ticker :
     Stock_analysis.t option =
   let bars = _weekly_bars ~inputs ticker in
   if List.is_empty bars then None
   else
+    let prior_stage =
+      _chained_prior_stage ~stage_config:analysis_config.stage bars
+    in
     Some
       (Stock_analysis.analyze ~config:analysis_config ~ticker ~bars
-         ~benchmark_bars:index_bars ~prior_stage:None ~as_of_date:inputs.as_of)
+         ~benchmark_bars:index_bars ~prior_stage ~as_of_date:inputs.as_of)
 
 (* Per-stock analysis for the screened universe. *)
 let _analyze_universe ~(inputs : inputs) ~index_bars : Stock_analysis.t list =

--- a/trading/trading/weinstein/snapshot/gen/test/test_snapshot_warehouse_parity.ml
+++ b/trading/trading/weinstein/snapshot/gen/test/test_snapshot_warehouse_parity.ml
@@ -32,7 +32,7 @@ module Snapshot_warehouse_reader =
 
 let run_deferred d = Async.Thread_safe.block_on_async_exn (fun () -> d)
 let _index_symbol = "GSPCX"
-let _as_of = Date.of_string "2022-10-07"
+let _as_of = Date.of_string "2022-09-16"
 let _system_version = "parity-sha"
 
 (* Same synthetic shapes the generator's own test uses: an AAPL 40-week-base

--- a/trading/trading/weinstein/snapshot/gen/test/test_weekly_snapshot_generator.ml
+++ b/trading/trading/weinstein/snapshot/gen/test/test_weekly_snapshot_generator.ml
@@ -16,11 +16,16 @@ module Generator = Weinstein_snapshot_gen.Weekly_snapshot_generator
 let run_deferred d = Async.Thread_safe.block_on_async_exn (fun () -> d)
 let _index_symbol = "GSPCX"
 
-(* The Friday on which the 40-week-base breakout (from a 2022-01-01 start) is
-   inside the screener's breakout-event lookback window, so AAPL screens as a
-   Stage-2 long candidate. Confirmed empirically against the synthetic config
-   below; later Fridays age the breakout event out of the window. *)
-let _as_of = Date.of_string "2022-10-07"
+(* A Friday soon after the 40-week-base breakout (from a 2022-01-01 start), so
+   AAPL is a GENUINELY-EARLY Stage-2 long candidate (weeks_advancing <= 4). The
+   generator now chains the stage classifier (see the prior_stage fix in
+   [weekly_snapshot_generator._chained_prior_stage] +
+   [dev/notes/live-generator-prior-stage-bug-2026-07-01.md]); before that fix it
+   passed prior_stage:None, which reset weeks_advancing to ~1 and admitted the
+   breakout at ANY later Friday (this date used to be 2022-10-07, ~6 weeks post
+   breakout = Stage2 w6, which the corrected <=4-week early-breakout gate rightly
+   rejects). Later Fridays now correctly age the candidate out of admission. *)
+let _as_of = Date.of_string "2022-09-16"
 let _system_version = "test-sha-1234"
 
 (* Synthetic config: an AAPL breakout (40-week base then a 3x-volume breakout)
@@ -108,18 +113,21 @@ let _bearish_bar_reader () =
       (_index_symbol, _bars_for ~syn_config:_bearish_syn_config _index_symbol);
     ]
 
-let _inputs ~bar_reader ~ticker_sectors : Generator.inputs =
+let _inputs_at ~as_of ~bar_reader ~ticker_sectors : Generator.inputs =
   {
     config =
       Weinstein_strategy.default_config
         ~universe:(List.map ticker_sectors ~f:fst)
         ~index_symbol:_index_symbol;
     system_version = _system_version;
-    as_of = _as_of;
+    as_of;
     bar_reader;
     ticker_sectors;
     held_positions = [];
   }
+
+let _inputs ~bar_reader ~ticker_sectors : Generator.inputs =
+  _inputs_at ~as_of:_as_of ~bar_reader ~ticker_sectors
 
 let _generate ~bar_reader ~ticker_sectors =
   Generator.generate (_inputs ~bar_reader ~ticker_sectors)
@@ -185,6 +193,26 @@ let test_breakout_stop_below_entry _ =
     |> Option.map ~f:(fun (c : Weekly_snapshot.candidate) -> c.entry -. c.stop)
   in
   assert_that entry_minus_stop (is_some_and (gt (module Float_ord) 0.0))
+
+(* Regression for the prior_stage-chaining fix. The SAME breakout AAPL, screened
+   ~6 weeks later (2022-10-07) is Stage2 w6 under the corrected chained
+   classification, so the <=4-week early-breakout gate rightly rejects it — it is
+   NOT a long candidate. Before the fix (prior_stage:None reset weeks_advancing
+   to ~1) this stale advancer was wrongly surfaced as a fresh pick. See
+   [dev/notes/live-generator-prior-stage-bug-2026-07-01.md]. *)
+let test_stale_breakout_not_admitted _ =
+  let snap =
+    Generator.generate
+      (_inputs_at
+         ~as_of:(Date.of_string "2022-10-07")
+         ~bar_reader:(_breakout_bar_reader ())
+         ~ticker_sectors:[ ("AAPL", "Information Technology") ])
+  in
+  let aapl =
+    List.find (snap : Weekly_snapshot.t).long_candidates
+      ~f:(fun (c : Weekly_snapshot.candidate) -> String.equal c.symbol "AAPL")
+  in
+  assert_that aapl is_none
 
 (* The macro context carries a known regime label and a confidence in [0, 1].
    The regime is matched against the closed set of known labels via [matching]
@@ -267,6 +295,8 @@ let suite =
          "breakout AAPL is a long candidate" >:: test_breakout_is_long_candidate;
          "breakout long stop sits below entry"
          >:: test_breakout_stop_below_entry;
+         "stale (w>4) breakout is not admitted"
+         >:: test_stale_breakout_not_admitted;
          "macro context is present and well-formed"
          >:: test_macro_context_present;
          "bearish macro blocks all long candidates"


### PR DESCRIPTION
## The bug
The live weekly-snapshot generator (`weekly_snapshot_generator._analyze_ticker`) analysed each ticker with `prior_stage:None`, which **resets the stage classifier's `weeks_advancing` to ~1 for every Stage-2 stock**. So every advancer looked like a fresh 'Early Stage2', grades collapsed (all → 70/A), and the `≤4-week` early-breakout admission gate never bit — the live picks were **~55% extended advancers** (up to ~45 weeks into Stage 2) the strategy's own rule should reject. Full analysis: `dev/notes/live-generator-prior-stage-bug-2026-07-01.md` (#1816).

## The fix
Reconstruct the chained prior-week stage by rolling `Stage.classify` over the weekly prefix (exactly as the backtest does via `trading_state`) and feed it into `analyze`. **Backtests are unaffected** — they already chain.

**Validated:** re-ran on the 50 pick symbols at 2026-05-29 → candidates **22 → 10**, dropping exactly the w5–w45 extended names (AIP w44, ATRO w45, …); survivors are the genuinely-early breakouts. Corrected `weeks_advancing` matches the `stage_dump` reference.

## Tests
- 2 existing tests move `as_of` 2022-10-07 → 2022-09-16 (their synthetic breakout is Stage2 **w6** at the old date, which the corrected gate rightly rejects — they encoded the buggy `prior=None` behavior).
- Added `test_stale_breakout_not_admitted` pinning the corrected behavior directly (the same breakout at the stale date is NOT admitted).

## Follow-up (separate)
Exposes a tuning question — the breakout-*event* window is 8wk but the *admission* gate is `≤4`; now that the gate actually bites, whether `≤4` is right is a separate decision.