### PR TITLE
feat(weekly-report): configurable display cap + tie-honesty note (P0 #1782)

### DIFF
--- a/dev/weekly-picks/5a2689cb4/2026-01-02.md
+++ b/dev/weekly-picks/5a2689cb4/2026-01-02.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Information Technology
 - Materials
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | CMP | A+ | 85.00 | $22.80 | $20.98 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | MLAB | A+ | 85.00 | $155.90 | $143.43 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | TECX | A+ | 85.00 | $61.38 | $56.47 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | TTC | A+ | 85.00 | $87.90 | $80.87 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | AFRM | A | 75.00 | $100.50 | $92.46 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 9 | BA | A | 75.00 | $243.90 | $224.39 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 10 | CCL | A | 75.00 | $32.96 | $30.32 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Clean overhead; Strong sector |
+
+_13 lower-scored candidates not shown._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-01-09.md
+++ b/dev/weekly-picks/5a2689cb4/2026-01-09.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Information Technology
 - Materials
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | CVLG | A+ | 85.00 | $29.62 | $27.25 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | TROX | A+ | 85.00 | $10.65 | $9.80 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | UMAC | A+ | 85.00 | $17.57 | $16.16 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | ALMU | A | 75.00 | $26.01 | $23.93 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 8 | BALL | A | 75.00 | $60.59 | $55.74 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 9 | CAPL | A | 75.00 | $25.86 | $23.79 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 10 | EIG | A | 75.00 | $52.55 | $48.35 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 6 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-01-16.md
+++ b/dev/weekly-picks/5a2689cb4/2026-01-16.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Information Technology
 - Materials
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | BCPC | A+ | 85.00 | $178.29 | $164.03 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | HSAI | A+ | 85.00 | $31.00 | $28.52 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | MAIN | A+ | 85.00 | $68.11 | $62.66 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | RH | A+ | 85.00 | $439.17 | $404.04 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | SAIC | A+ | 85.00 | $124.73 | $114.75 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 9 | TDG | A+ | 85.00 | $1631.95 | $1501.39 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 10 | WLFC | A+ | 85.00 | $212.05 | $195.09 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 4 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-01-23.md
+++ b/dev/weekly-picks/5a2689cb4/2026-01-23.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Information Technology
 - Materials
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | ANL | A+ | 85.00 | $2.76 | $2.54 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | CAVA | A+ | 85.00 | $145.21 | $133.59 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | FNKO | A+ | 85.00 | $14.35 | $13.20 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | IPI | A+ | 85.00 | $39.21 | $36.07 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | PPG | A+ | 85.00 | $121.51 | $111.79 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 9 | RBA | A+ | 85.00 | $120.18 | $110.57 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 10 | RCAT | A+ | 85.00 | $16.78 | $15.44 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
+
+_13 more candidates not shown; 10 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-01-30.md
+++ b/dev/weekly-picks/5a2689cb4/2026-01-30.md
@@ -16,7 +16,7 @@ System version: `5a2689cb4`
 - Information Technology
 - Materials
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | ADTN | A+ | 85.00 | $12.50 | $11.50 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -26,9 +26,8 @@ System version: `5a2689cb4`
 | 5 | AOS | A+ | 85.00 | $77.70 | $71.48 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | ASC | A+ | 85.00 | $13.63 | $12.54 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | AVT | A+ | 85.00 | $57.53 | $52.93 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 8 | CC | A+ | 85.00 | $18.56 | $17.08 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 9 | CCS | A+ | 85.00 | $75.39 | $69.36 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 10 | CDLR | A+ | 85.00 | $22.72 | $20.90 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
+
+_13 more candidates not shown; 13 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-02-06.md
+++ b/dev/weekly-picks/5a2689cb4/2026-02-06.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Information Technology
 - Materials
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | ALTG | A+ | 85.00 | $9.03 | $8.31 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | CON | A+ | 85.00 | $24.11 | $22.18 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | CSL | A+ | 85.00 | $438.10 | $403.05 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | DNOW | A+ | 85.00 | $17.92 | $16.49 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | GRVY | A+ | 85.00 | $70.35 | $64.72 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 9 | IPGP | A+ | 85.00 | $92.67 | $85.26 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 10 | LGIH | A+ | 85.00 | $85.36 | $78.53 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 11 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-02-13.md
+++ b/dev/weekly-picks/5a2689cb4/2026-02-13.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Materials
 - Real Estate
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | AIN | A+ | 85.00 | $81.44 | $74.92 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | IP | A+ | 85.00 | $57.36 | $52.77 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | KARO | A+ | 85.00 | $63.68 | $58.59 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | LNN | A+ | 85.00 | $151.71 | $139.57 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | LYTS | A+ | 85.00 | $24.28 | $22.34 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 9 | PG | A+ | 85.00 | $180.89 | $166.42 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 10 | APD | A | 75.00 | $323.08 | $297.23 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 2 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-02-20.md
+++ b/dev/weekly-picks/5a2689cb4/2026-02-20.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | APOG | A+ | 85.00 | $50.24 | $46.22 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | DXCM | A+ | 85.00 | $90.43 | $83.20 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | EPC | A+ | 85.00 | $33.12 | $30.47 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | GLP | A+ | 85.00 | $58.40 | $53.73 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | IIIN | A+ | 85.00 | $41.85 | $38.50 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 9 | MSM | A+ | 85.00 | $94.78 | $87.20 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 10 | MTDR | A+ | 85.00 | $54.11 | $49.78 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 6 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |

--- a/dev/weekly-picks/5a2689cb4/2026-02-27.md
+++ b/dev/weekly-picks/5a2689cb4/2026-02-27.md
@@ -14,7 +14,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | ANIK | A+ | 85.00 | $17.23 | $15.85 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -24,9 +24,8 @@ System version: `5a2689cb4`
 | 5 | ESEA | A+ | 85.00 | $66.33 | $61.02 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
 | 6 | LII | A+ | 85.00 | $692.89 | $637.46 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | LMAT | A+ | 85.00 | $101.47 | $93.35 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 8 | MKC | A+ | 85.00 | $86.67 | $79.74 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 9 | OTIS | A+ | 85.00 | $107.36 | $98.77 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 10 | RPM | A+ | 85.00 | $129.77 | $119.39 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 6 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
@@ -36,6 +35,8 @@ System version: `5a2689cb4`
 | 3 | NIQ | C | 50.00 | $20.49 | $22.13 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below |
 | 4 | TDIC | C | 50.00 | $7.94 | $8.58 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below |
 | 5 | WYFI | C | 45.00 | $40.95 | $44.23 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below |
+
+_2 lower-scored candidates not shown._
 
 ## Held positions
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-03-06.md
+++ b/dev/weekly-picks/5a2689cb4/2026-03-06.md
@@ -14,7 +14,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | ASIX | A+ | 85.00 | $25.66 | $23.61 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -24,9 +24,8 @@ System version: `5a2689cb4`
 | 5 | EPSN | A | 75.00 | $8.54 | $7.86 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
 | 6 | LUXE | A | 75.00 | $10.94 | $10.06 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead |
 | 7 | OOMA | A | 75.00 | $14.05 | $12.93 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead |
-| 8 | PDYN | A | 75.00 | $13.06 | $12.02 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 9 | RDY | A | 75.00 | $16.25 | $14.95 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 10 | AIN | A | 70.00 | $75.54 | $69.50 | 8.0% | Early Stage2; Strong volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 2 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
@@ -36,6 +35,8 @@ System version: `5a2689cb4`
 | 3 | ARX | C | 50.00 | $31.34 | $33.85 | -8.0% | Early Stage4; Adequate breakdown volume; Clean support below; Weak sector |
 | 4 | NIQ | C | 50.00 | $20.49 | $22.13 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below |
 | 5 | RAL | C | 50.00 | $55.36 | $59.79 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below |
+
+_5 more candidates not shown; 1 tie the cutoff score (50.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Held positions
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-03-13.md
+++ b/dev/weekly-picks/5a2689cb4/2026-03-13.md
@@ -14,7 +14,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 (none)
 
 ## Short candidates (top 5)
@@ -25,6 +25,8 @@ System version: `5a2689cb4`
 | 3 | MIAX | B | 55.00 | $51.63 | $55.76 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below; Weak sector |
 | 4 | RAL | C | 50.00 | $55.36 | $59.79 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below |
 | 5 | AXIL | C | 45.00 | $10.30 | $11.12 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below |
+
+_3 more candidates not shown; 2 tie the cutoff score (45.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Held positions
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-03-20.md
+++ b/dev/weekly-picks/5a2689cb4/2026-03-20.md
@@ -13,7 +13,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 (none)
 
 ## Short candidates (top 5)
@@ -24,6 +24,8 @@ System version: `5a2689cb4`
 | 3 | AMBQ | B | 55.00 | $52.02 | $56.18 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below; Weak sector |
 | 4 | AXIL | B | 55.00 | $10.30 | $11.12 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below; Weak sector |
 | 5 | CHYM | B | 55.00 | $45.16 | $48.77 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below; Weak sector |
+
+_4 more candidates not shown; 2 tie the cutoff score (55.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Held positions
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-03-27.md
+++ b/dev/weekly-picks/5a2689cb4/2026-03-27.md
@@ -12,7 +12,7 @@ System version: `5a2689cb4`
 - Materials
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 (none)
 
 ## Short candidates (top 5)
@@ -23,6 +23,8 @@ System version: `5a2689cb4`
 | 3 | BLSH | B | 60.00 | $118.59 | $128.08 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below; Weak sector |
 | 4 | AMBQ | B | 55.00 | $52.02 | $56.18 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below; Weak sector |
 | 5 | MIAX | B | 55.00 | $51.63 | $55.76 | -8.0% | Early Stage4; Adequate breakdown volume; Virgin support below; Weak sector |
+
+_1 lower-scored candidate not shown._
 
 ## Held positions
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-04-03.md
+++ b/dev/weekly-picks/5a2689cb4/2026-04-03.md
@@ -11,7 +11,7 @@ System version: `5a2689cb4`
 - Materials
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 (none)
 
 ## Short candidates (top 5)
@@ -22,6 +22,8 @@ System version: `5a2689cb4`
 | 3 | JCAP | B | 65.00 | $23.92 | $25.83 | -8.0% | Early Stage4; Strong breakdown volume; Virgin support below; Weak sector |
 | 4 | FIGR | B | 60.00 | $78.39 | $84.66 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below; Weak sector |
 | 5 | KLAR | B | 60.00 | $57.49 | $62.09 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below; Weak sector |
+
+_5 lower-scored candidates not shown._
 
 ## Held positions
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-04-10.md
+++ b/dev/weekly-picks/5a2689cb4/2026-04-10.md
@@ -11,7 +11,7 @@ System version: `5a2689cb4`
 - Materials
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 (none)
 
 ## Short candidates (top 5)
@@ -22,6 +22,8 @@ System version: `5a2689cb4`
 | 3 | FIGR | B | 60.00 | $78.39 | $84.66 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below; Weak sector |
 | 4 | KLAR | B | 60.00 | $57.49 | $62.09 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below; Weak sector |
 | 5 | STUB | B | 60.00 | $28.03 | $30.27 | -8.0% | Early Stage4; Strong breakdown volume; Clean support below; Weak sector |
+
+_4 lower-scored candidates not shown._
 
 ## Held positions
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-04-17.md
+++ b/dev/weekly-picks/5a2689cb4/2026-04-17.md
@@ -12,7 +12,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | USLM | A+ | 85.00 | $138.65 | $127.56 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
@@ -22,9 +22,8 @@ System version: `5a2689cb4`
 | 5 | BBCP | A | 70.00 | $7.84 | $7.21 | 8.0% | Early Stage2; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | CAR | A | 70.00 | $213.87 | $196.76 | 8.0% | Early Stage2; Strong volume; RS positive; Clean overhead; Strong sector |
 | 7 | CXW | A | 70.00 | $23.66 | $21.77 | 8.0% | Early Stage2; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | FCN | A | 70.00 | $184.64 | $169.87 | 8.0% | Early Stage2; Strong volume; RS positive; Clean overhead; Strong sector |
-| 9 | KRNT | A | 70.00 | $23.60 | $21.71 | 8.0% | Early Stage2; Strong volume; RS positive; Virgin territory; Strong sector |
-| 10 | LNZA | A | 70.00 | $31.66 | $29.13 | 8.0% | Early Stage2; Strong volume; RS positive; Clean overhead; Strong sector |
+
+_13 more candidates not shown; 6 tie the cutoff score (70.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-04-24.md
+++ b/dev/weekly-picks/5a2689cb4/2026-04-24.md
@@ -12,7 +12,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | HWKN | A+ | 85.00 | $187.08 | $172.11 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -22,9 +22,8 @@ System version: `5a2689cb4`
 | 5 | DAL | A | 75.00 | $76.77 | $70.63 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
 | 6 | MCRI | A | 75.00 | $114.45 | $105.29 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead |
 | 7 | OFLX | A | 75.00 | $38.11 | $35.06 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 8 | PENN | A | 75.00 | $20.71 | $19.05 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 9 | AIT | A | 70.00 | $298.18 | $274.33 | 8.0% | Early Stage2; Strong volume; RS positive; Clean overhead; Strong sector |
-| 10 | BBCP | A | 70.00 | $7.84 | $7.21 | 8.0% | Early Stage2; Strong volume; RS positive; Clean overhead; Strong sector |
+
+_13 more candidates not shown; 1 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-05-01.md
+++ b/dev/weekly-picks/5a2689cb4/2026-05-01.md
@@ -14,7 +14,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | ATKR | A+ | 85.00 | $80.46 | $74.02 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -24,9 +24,8 @@ System version: `5a2689cb4`
 | 5 | KFRC | A+ | 85.00 | $47.72 | $43.90 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
 | 6 | MTRX | A+ | 85.00 | $16.19 | $14.89 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | NSSC | A+ | 85.00 | $48.36 | $44.49 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | NVTS | A+ | 85.00 | $17.88 | $16.45 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 9 | RMBS | A+ | 85.00 | $136.43 | $125.52 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 10 | SANM | A+ | 85.00 | $186.22 | $171.32 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
+
+_13 more candidates not shown; 5 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-05-08.md
+++ b/dev/weekly-picks/5a2689cb4/2026-05-08.md
@@ -15,7 +15,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | DLO | A+ | 85.00 | $16.86 | $15.51 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -25,9 +25,8 @@ System version: `5a2689cb4`
 | 5 | PLUS | A+ | 85.00 | $94.45 | $86.89 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | SPCB | A+ | 85.00 | $13.64 | $12.55 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | TWIN | A+ | 85.00 | $19.73 | $18.15 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
-| 8 | USAR | A+ | 85.00 | $44.20 | $40.66 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 9 | VC | A+ | 85.00 | $129.75 | $119.37 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 10 | AGM | A | 75.00 | $211.69 | $194.75 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
+
+_13 more candidates not shown; 2 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-05-15.md
+++ b/dev/weekly-picks/5a2689cb4/2026-05-15.md
@@ -14,7 +14,7 @@ System version: `5a2689cb4`
 - Real Estate
 - Utilities
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | AEVA | A+ | 85.00 | $38.99 | $35.87 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -24,9 +24,8 @@ System version: `5a2689cb4`
 | 5 | CRWD | A | 75.00 | $569.73 | $524.15 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Clean overhead; Strong sector |
 | 6 | FCEL | A | 75.00 | $12.05 | $11.09 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Clean overhead; Strong sector |
 | 7 | IOSP | A | 75.00 | $92.60 | $85.19 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 8 | KDP | A | 75.00 | $36.12 | $33.23 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 9 | KYIV | A | 75.00 | $16.56 | $15.24 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 10 | LTH | A | 75.00 | $30.95 | $28.47 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead |
+
+_13 more candidates not shown; 7 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-05-22.md
+++ b/dev/weekly-picks/5a2689cb4/2026-05-22.md
@@ -13,7 +13,7 @@ System version: `5a2689cb4`
 - Materials
 - Real Estate
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | BOOM | A+ | 85.00 | $9.25 | $8.51 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -23,9 +23,8 @@ System version: `5a2689cb4`
 | 5 | RSKD | A+ | 85.00 | $5.71 | $5.25 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | FGMC | A | 75.00 | $10.30 | $9.48 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead |
 | 7 | FROG | A | 75.00 | $70.78 | $65.12 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Clean overhead; Strong sector |
-| 8 | MRCY | A | 75.00 | $104.36 | $96.01 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 9 | PII | A | 75.00 | $75.63 | $69.58 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 10 | RAL | A | 75.00 | $57.31 | $52.73 | 8.0% | Stage1→Stage2 breakout; Strong volume; Clean overhead; Strong sector |
+
+_13 more candidates not shown; 8 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-05-29.md
+++ b/dev/weekly-picks/5a2689cb4/2026-05-29.md
@@ -13,7 +13,7 @@ System version: `5a2689cb4`
 - Materials
 - Real Estate
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | INOD | A+ | 85.00 | $94.32 | $86.77 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Clean overhead; Strong sector |
@@ -23,9 +23,8 @@ System version: `5a2689cb4`
 | 5 | PRTH | A+ | 85.00 | $8.93 | $8.22 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | QUBT | A+ | 85.00 | $25.97 | $23.89 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | SMCI | A+ | 85.00 | $62.67 | $57.66 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | DBX | A | 75.00 | $32.56 | $29.96 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 9 | PFGC | A | 75.00 | $109.60 | $100.83 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 10 | RDVT | A | 75.00 | $64.46 | $59.30 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
+
+_13 lower-scored candidates not shown._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-06-05.md
+++ b/dev/weekly-picks/5a2689cb4/2026-06-05.md
@@ -13,7 +13,7 @@ System version: `5a2689cb4`
 - Materials
 - Real Estate
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | ASPI | A+ | 85.00 | $14.56 | $13.40 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -23,9 +23,8 @@ System version: `5a2689cb4`
 | 5 | CLF | A | 75.00 | $16.78 | $15.44 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
 | 6 | CPA | A | 75.00 | $157.19 | $144.61 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
 | 7 | DT | A | 75.00 | $57.84 | $53.21 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 8 | MIDD | A | 75.00 | $170.29 | $156.67 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 9 | NMAX | A | 75.00 | $16.06 | $14.78 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 10 | NUAI | A | 75.00 | $9.49 | $8.73 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 7 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-06-12.md
+++ b/dev/weekly-picks/5a2689cb4/2026-06-12.md
@@ -13,7 +13,7 @@ System version: `5a2689cb4`
 - Materials
 - Real Estate
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | AAL | A+ | 85.00 | $16.58 | $15.25 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -23,9 +23,8 @@ System version: `5a2689cb4`
 | 5 | BIRK | A | 75.00 | $53.80 | $49.50 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
 | 6 | BOC | A | 75.00 | $14.56 | $13.40 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
 | 7 | GE | A | 75.00 | $350.22 | $322.20 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 8 | LAKE | A | 75.00 | $18.09 | $16.64 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 9 | RNAC | A | 75.00 | $15.65 | $14.40 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 10 | RVTY | A | 75.00 | $118.89 | $109.38 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
+
+_13 more candidates not shown; 6 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-06-19.md
+++ b/dev/weekly-picks/5a2689cb4/2026-06-19.md
@@ -13,7 +13,7 @@ System version: `5a2689cb4`
 - Materials
 - Real Estate
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | BRC | A+ | 85.00 | $99.79 | $91.81 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -23,9 +23,8 @@ System version: `5a2689cb4`
 | 5 | CHA | A | 75.00 | $29.25 | $26.91 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
 | 6 | CLPT | A | 75.00 | $30.25 | $27.83 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
 | 7 | ELAN | A | 75.00 | $27.86 | $25.63 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory |
-| 8 | EXP | A | 75.00 | $244.86 | $225.27 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 9 | HEI | A | 75.00 | $363.50 | $334.42 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
-| 10 | HRI | A | 75.00 | $189.29 | $174.15 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 12 tie the cutoff score (75.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/dev/weekly-picks/5a2689cb4/2026-06-26.md
+++ b/dev/weekly-picks/5a2689cb4/2026-06-26.md
@@ -14,7 +14,7 @@ System version: `5a2689cb4`
 - Materials
 - Real Estate
 
-## Long candidates (top 10)
+## Long candidates (top 7)
 | Rank | Symbol | Grade | Score | Entry | Stop | Risk % | Rationale |
 |---|---|---|---|---|---|---|---|
 | 1 | BMRC | A+ | 85.00 | $28.62 | $26.33 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
@@ -24,9 +24,8 @@ System version: `5a2689cb4`
 | 5 | FRBA | A+ | 85.00 | $18.20 | $16.74 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 6 | GO | A+ | 85.00 | $19.51 | $17.95 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
 | 7 | KINS | A+ | 85.00 | $19.52 | $17.96 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 8 | TATT | A+ | 85.00 | $64.82 | $59.63 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Virgin territory; Strong sector |
-| 9 | NRIM | A | 77.00 | $92.46 | $85.06 | 8.0% | Stage1→Stage2 breakout; Strong volume; RS positive; Moderate resistance; Strong sector |
-| 10 | ABM | A | 75.00 | $50.37 | $46.34 | 8.0% | Stage1→Stage2 breakout; Adequate volume; RS positive; Virgin territory; Strong sector |
+
+_13 more candidates not shown; 1 tie the cutoff score (85.00). Among equal scores the order is alphabetical, not a quality ranking — treat the tied set as interchangeable._
 
 ## Short candidates (top 5)
 (none)

--- a/trading/trading/weinstein/snapshot/bin/render_weekly_report.ml
+++ b/trading/trading/weinstein/snapshot/bin/render_weekly_report.ml
@@ -1,10 +1,14 @@
 (** [render_weekly_report] CLI — render a weekly snapshot as Markdown.
 
-    Usage: [render_weekly_report <pick-file>]
+    Usage: [render_weekly_report <pick-file> [-long-limit N] [-short-limit N]]
 
     Reads a single weekly snapshot from disk, renders it via
-    {!Report_renderer.render}, and prints the Markdown to stdout. Exits non-zero
-    on read or schema-version errors. *)
+    {!Report_renderer.render}, and prints the Markdown to stdout. The optional
+    [-long-limit] / [-short-limit] flags cap the candidate tables (default
+    {!Report_renderer.default_long_display_limit} /
+    {!Report_renderer.default_short_display_limit}) — e.g. [-long-limit 5] to
+    surface a book-sized list. Exits non-zero on read or schema-version errors,
+    or [2] on a usage error. *)
 
 open Core
 open Weinstein_snapshot
@@ -16,13 +20,31 @@ let _read_snapshot path : Weekly_snapshot.t =
       eprintf "Failed to read snapshot %s: %s\n" path (Status.show err);
       exit 1
 
-let _run pick_path =
+let _run pick_path ~long_limit ~short_limit =
   let snap = _read_snapshot pick_path in
-  print_string (Report_renderer.render snap)
+  print_string (Report_renderer.render ?long_limit ?short_limit snap)
+
+let _usage () =
+  eprintf
+    "Usage: render_weekly_report <pick-file> [-long-limit N] [-short-limit N]\n";
+  exit 2
+
+(* Parse [-long-limit N] / [-short-limit N] from the args after the positional
+   pick-file. Any unrecognised flag or missing value is a usage error. *)
+let rec _parse_flags args ~long_limit ~short_limit =
+  match args with
+  | [] -> (long_limit, short_limit)
+  | "-long-limit" :: n :: rest ->
+      _parse_flags rest ~long_limit:(Some (Int.of_string n)) ~short_limit
+  | "-short-limit" :: n :: rest ->
+      _parse_flags rest ~long_limit ~short_limit:(Some (Int.of_string n))
+  | _ -> _usage ()
 
 let () =
   match Sys.get_argv () |> Array.to_list with
-  | _ :: pick_path :: _ -> _run pick_path
-  | _ ->
-      eprintf "Usage: render_weekly_report <pick-file>\n";
-      exit 2
+  | _ :: pick_path :: flags ->
+      let long_limit, short_limit =
+        _parse_flags flags ~long_limit:None ~short_limit:None
+      in
+      _run pick_path ~long_limit ~short_limit
+  | _ -> _usage ()

--- a/trading/trading/weinstein/snapshot/lib/report_renderer.ml
+++ b/trading/trading/weinstein/snapshot/lib/report_renderer.ml
@@ -1,9 +1,13 @@
 open Core
 
-(* Display caps for the candidate tables. Match the section headers
-   ("top 10" / "top 5") to keep header and content in sync. *)
-let _long_display_limit = 10
-let _short_display_limit = 5
+(* Default display caps for the candidate tables. These bound the *human*
+   report only — the underlying snapshot (.sexp) keeps the screener's full
+   capped list, and strategy / backtest selection is unaffected. Callers may
+   override both (see [render]'s optional params) to surface a book-sized list
+   (~5) or the full set. The section header echoes the effective limit so header
+   and content stay in sync. *)
+let default_long_display_limit = 7
+let default_short_display_limit = 5
 
 (* Marker rendered for empty lists / tables so the reader never sees a missing
    section. *)
@@ -25,6 +29,46 @@ let _candidate_row ~rank (c : Weekly_snapshot.candidate) =
   Printf.sprintf "| %d | %s | %s | %.2f | $%.2f | $%.2f | %.1f%% | %s |" rank
     c.symbol c.grade c.score c.entry c.stop risk c.rationale
 
+let _plural n = if n = 1 then "" else "s"
+
+(* Body of the truncation note. [n_tied = 0] means the hidden names all score
+   below the cutoff (a plain "N lower-scored"); [n_tied > 0] means some hidden
+   names tie the cutoff score, so the cut is arbitrary among equals — the note
+   says so to keep a reader from trusting the alphabetical tie-break as a
+   ranking (score is anti-predictive at the top grade; the RS/earliness
+   tie-break was WF-CV-rejected as a return lever). *)
+let _note_body ~n_hidden ~n_tied ~cutoff_score =
+  if n_tied = 0 then
+    Printf.sprintf "_%d lower-scored candidate%s not shown._" n_hidden
+      (_plural n_hidden)
+  else
+    Printf.sprintf
+      "_%d more candidate%s not shown; %d tie the cutoff score (%.2f). Among \
+       equal scores the order is alphabetical, not a quality ranking — treat \
+       the tied set as interchangeable._"
+      n_hidden (_plural n_hidden) n_tied cutoff_score
+
+(* Score of the last shown candidate — the cutoff below which names are hidden.
+   Shown is non-empty whenever a note is produced (the table had rows). *)
+let _cutoff_score shown = (List.last_exn shown).Weekly_snapshot.score
+
+(* How many hidden candidates tie the cutoff score. *)
+let _count_tied ~cutoff hidden =
+  List.count hidden ~f:(fun (c : Weekly_snapshot.candidate) ->
+      Float.equal c.score cutoff)
+
+(* Honesty note appended below a truncated table. Candidates arrive sorted
+   score-descending with an alphabetical tie-break (screener default). [None]
+   when nothing was hidden. *)
+let _truncation_note ~shown ~hidden =
+  if List.is_empty hidden then None
+  else
+    let cutoff = _cutoff_score shown in
+    Some
+      (_note_body ~n_hidden:(List.length hidden)
+         ~n_tied:(_count_tied ~cutoff hidden)
+         ~cutoff_score:cutoff)
+
 let _candidate_table candidates ~limit =
   let header =
     _table_header
@@ -41,12 +85,16 @@ let _candidate_table candidates ~limit =
   in
   match candidates with
   | [] -> _empty_marker
-  | _ ->
-      let truncated = List.take candidates limit in
+  | _ -> (
+      let shown = List.take candidates limit in
+      let hidden = List.drop candidates limit in
       let rows =
-        List.mapi truncated ~f:(fun i c -> _candidate_row ~rank:(i + 1) c)
+        List.mapi shown ~f:(fun i c -> _candidate_row ~rank:(i + 1) c)
       in
-      String.concat ~sep:"\n" (header :: rows)
+      let table = String.concat ~sep:"\n" (header :: rows) in
+      match _truncation_note ~shown ~hidden with
+      | None -> table
+      | Some note -> table ^ "\n\n" ^ note)
 
 let _held_row (h : Weekly_snapshot.held_position) =
   Printf.sprintf "| %s | %s | $%.2f | %s |" h.symbol (Date.to_string h.entered)
@@ -70,7 +118,9 @@ let _macro_section (m : Weekly_snapshot.macro_context) =
 
 let _section ~title body = Printf.sprintf "## %s\n%s" title body
 
-let render (t : Weekly_snapshot.t) : string =
+let render ?(long_limit = default_long_display_limit)
+    ?(short_limit = default_short_display_limit) (t : Weekly_snapshot.t) :
+    string =
   let buf = Buffer.create 1024 in
   Buffer.add_string buf
     (Printf.sprintf "# Weekly Pick Report — %s\n\n" (Date.to_string t.date));
@@ -82,12 +132,14 @@ let render (t : Weekly_snapshot.t) : string =
     (_section ~title:"Strong sectors" (_sector_list t.sectors_strong));
   Buffer.add_string buf "\n\n";
   Buffer.add_string buf
-    (_section ~title:"Long candidates (top 10)"
-       (_candidate_table t.long_candidates ~limit:_long_display_limit));
+    (_section
+       ~title:(Printf.sprintf "Long candidates (top %d)" long_limit)
+       (_candidate_table t.long_candidates ~limit:long_limit));
   Buffer.add_string buf "\n\n";
   Buffer.add_string buf
-    (_section ~title:"Short candidates (top 5)"
-       (_candidate_table t.short_candidates ~limit:_short_display_limit));
+    (_section
+       ~title:(Printf.sprintf "Short candidates (top %d)" short_limit)
+       (_candidate_table t.short_candidates ~limit:short_limit));
   Buffer.add_string buf "\n\n";
   Buffer.add_string buf
     (_section ~title:"Held positions" (_held_table t.held_positions));

--- a/trading/trading/weinstein/snapshot/lib/report_renderer.mli
+++ b/trading/trading/weinstein/snapshot/lib/report_renderer.mli
@@ -11,13 +11,27 @@
     - System version line: [System version: `<sha>`]
     - [## Macro] section: regime in bold + score
     - [## Strong sectors] section: bulleted list (or "(none)" if empty)
-    - [## Long candidates (top 10)]: ranked Markdown table
-    - [## Short candidates (top 5)]: ranked Markdown table
+    - [## Long candidates (top N)]: ranked Markdown table ([N = long_limit])
+    - [## Short candidates (top N)]: ranked Markdown table ([N = short_limit])
     - [## Held positions]: Markdown table
 
     All section headers are always rendered, even when the underlying data list
     is empty — empty tables / lists render as ["(none)"] so a reader never sees
-    a missing section.
+    a missing section. The [top N] in each candidate header echoes the effective
+    limit.
+
+    {1 Display caps and the tie-honesty note}
+
+    The candidate tables are display-only caps on the {e human} report; the
+    underlying {!Weekly_snapshot.t} retains the screener's full capped list and
+    strategy / backtest selection is unaffected. When a table is truncated, an
+    italic note is appended below it stating how many candidates were hidden and
+    — crucially — how many of them {e tie the cutoff score}. Candidates arrive
+    score-descending with an alphabetical tie-break, so names hidden at the
+    cutoff are not "worse" than the last shown when they tie its score: the cut
+    is arbitrary among equals. The note tells a reader funding a book-sized
+    subset to treat the tied set as interchangeable rather than trusting the
+    alphabetical order as a quality ranking.
 
     {1 Determinism}
 
@@ -33,7 +47,17 @@
     (caller is responsible for the sign convention of [entry] and [stop]
     relative to side). *)
 
-val render : Weekly_snapshot.t -> string
-(** [render snapshot] returns the snapshot rendered as a single Markdown string,
-    terminated by a final newline. Always succeeds — every section header is
-    emitted unconditionally. Pure function: no I/O, no exceptions. *)
+val default_long_display_limit : int
+(** Default number of long candidates shown in the report table (7). *)
+
+val default_short_display_limit : int
+(** Default number of short candidates shown in the report table (5). *)
+
+val render : ?long_limit:int -> ?short_limit:int -> Weekly_snapshot.t -> string
+(** [render ?long_limit ?short_limit snapshot] returns the snapshot rendered as
+    a single Markdown string, terminated by a final newline. [long_limit] /
+    [short_limit] cap the respective candidate tables and default to
+    {!default_long_display_limit} / {!default_short_display_limit}; a truncated
+    table gains the tie-honesty note described above. Always succeeds — every
+    section header is emitted unconditionally. Pure function: no I/O, no
+    exceptions. *)

--- a/trading/trading/weinstein/snapshot/test/test_report_renderer.ml
+++ b/trading/trading/weinstein/snapshot/test/test_report_renderer.ml
@@ -90,7 +90,7 @@ let test_full_snapshot_contains_all_sections _ =
          _has_substring "- XLK";
          _has_substring "- XLY";
          _has_substring "- XLC";
-         _has_substring "## Long candidates (top 10)";
+         _has_substring "## Long candidates (top 7)";
          (* Pinned candidate row — fully formatted. Risk = (502.13-466.20)/502.13*100 = 7.155... → "7.2%" *)
          _has_substring
            "| 1 | AAPL | A+ | 0.91 | $502.13 | $466.20 | 7.2% | Stage 2 \
@@ -105,7 +105,7 @@ let test_empty_long_candidates_renders_marker _ =
   assert_that md
     (all_of
        [
-         _has_substring "## Long candidates (top 10)\n(none)";
+         _has_substring "## Long candidates (top 7)\n(none)";
          _has_substring "## Short candidates (top 5)\n(none)";
        ])
 
@@ -155,13 +155,12 @@ let test_render_is_deterministic _ =
   let second = Report_renderer.render _full_snapshot in
   assert_that first (equal_to second)
 
-let test_long_candidates_truncated_to_top_10 _ =
-  (* 12 candidates → only first 10 rendered; rank 10 row present, rank 11
-     absent. *)
+(* [n] candidates with the given per-index score. *)
+let _long_snap ~n ~score_of =
   let make_c i =
     {
       Weekly_snapshot.symbol = Printf.sprintf "SYM%02d" i;
-      score = 1.0 -. (Float.of_int i *. 0.01);
+      score = score_of i;
       grade = "B";
       entry = 100.0;
       stop = 90.0;
@@ -171,18 +170,56 @@ let test_long_candidates_truncated_to_top_10 _ =
       resistance_grade = None;
     }
   in
+  { _empty_snapshot with long_candidates = List.init n ~f:(fun i -> make_c i) }
+
+let test_long_candidates_truncated_to_default_7 _ =
+  (* 12 distinctly-scored candidates → first 7 rendered; rank 7 present, rank 8
+     absent; note reports 5 lower-scored hidden (no ties at the cutoff). *)
   let snap =
-    {
-      _empty_snapshot with
-      long_candidates = List.init 12 ~f:(fun i -> make_c (i + 1));
-    }
+    _long_snap ~n:12 ~score_of:(fun i -> 1.0 -. (Float.of_int i *. 0.01))
   in
   let md = Report_renderer.render snap in
   assert_that md
     (all_of
        [
-         _has_substring "| 10 | SYM10 |";
-         not_ ~msg:"row 11 must be truncated" (_has_substring "| 11 | SYM11 |");
+         _has_substring "| 7 | SYM06 |";
+         not_ ~msg:"row 8 must be truncated" (_has_substring "| 8 | SYM07 |");
+         _has_substring "_5 lower-scored candidates not shown._";
+       ])
+
+let test_truncation_note_flags_tied_cutoff _ =
+  (* 12 candidates all tied at score 0.85 → the cut is arbitrary among equals;
+     the note must say 5 more are hidden and all 5 tie the cutoff. *)
+  let snap = _long_snap ~n:12 ~score_of:(fun _ -> 0.85) in
+  let md = Report_renderer.render snap in
+  assert_that md
+    (_has_substring
+       "_5 more candidates not shown; 5 tie the cutoff score (0.85). Among \
+        equal scores the order is alphabetical, not a quality ranking — treat \
+        the tied set as interchangeable._")
+
+let test_no_note_when_not_truncated _ =
+  (* Exactly [long_limit] candidates → no truncation, no note. *)
+  let snap =
+    _long_snap ~n:7 ~score_of:(fun i -> 1.0 -. (Float.of_int i *. 0.01))
+  in
+  let md = Report_renderer.render snap in
+  assert_that md
+    (not_ ~msg:"no note when nothing hidden" (_has_substring "not shown"))
+
+let test_long_limit_override _ =
+  (* Explicit [long_limit:3] tightens the cap and the header echoes it. *)
+  let snap =
+    _long_snap ~n:12 ~score_of:(fun i -> 1.0 -. (Float.of_int i *. 0.01))
+  in
+  let md = Report_renderer.render ~long_limit:3 snap in
+  assert_that md
+    (all_of
+       [
+         _has_substring "## Long candidates (top 3)";
+         _has_substring "| 3 | SYM02 |";
+         not_ ~msg:"row 4 truncated at limit 3" (_has_substring "| 4 | SYM03 |");
+         _has_substring "_9 lower-scored candidates not shown._";
        ])
 
 let suite =
@@ -199,8 +236,12 @@ let suite =
          "bearish_macro_rendered" >:: test_bearish_macro_rendered;
          "risk_pct_formatting" >:: test_risk_pct_formatting;
          "render_is_deterministic" >:: test_render_is_deterministic;
-         "long_candidates_truncated_to_top_10"
-         >:: test_long_candidates_truncated_to_top_10;
+         "long_candidates_truncated_to_default_7"
+         >:: test_long_candidates_truncated_to_default_7;
+         "truncation_note_flags_tied_cutoff"
+         >:: test_truncation_note_flags_tied_cutoff;
+         "no_note_when_not_truncated" >:: test_no_note_when_not_truncated;
+         "long_limit_override" >:: test_long_limit_override;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Tightens the human weekly-pick report to an actionable size and stops it silently hiding equally-graded names — the P0 from `next-session-priorities-2026-07-02.md` (the #1782 "display ordering" thread). **Display-only:** touches `Report_renderer` (the `.md` report) and the render CLI. The underlying snapshot `.sexp` still holds the screener's full capped list, and **strategy / backtest selection is unchanged** (screener cap + ranking untouched).

### Renderer (`report_renderer.ml/.mli`)
- Display limits are now parameters of `render` (`?long_limit` / `?short_limit`), defaulting to **7 / 5** (long was hard-coded 10). Section headers echo the effective limit (`Long candidates (top N)`).
- When a table is truncated, an italic **tie-honesty note** is appended: how many candidates are hidden and — crucially — how many *tie the cutoff score*. Candidates arrive score-desc with an alphabetical tie-break, so names hidden at the cutoff are not "worse" than the last shown when they tie its score; the cut is arbitrary among equals. The note tells a reader funding a book-sized subset to treat the tied set as interchangeable rather than trusting the alphabetical order as a ranking (score is anti-predictive at the top grade; the RS/earliness tie-break was WF-CV-rejected as a *return* lever).

### CLI (`render_weekly_report`)
- Optional `-long-limit N` / `-short-limit N` flags (positional pick-file unchanged) — e.g. `-long-limit 5` to surface a book-sized list.

### Committed 2026-H1 series
- All 26 `.md` in `dev/weekly-picks/5a2689cb4/` re-rendered from the existing `.sexp` (deterministic re-render, no re-screen). Example — 2026-01-16 now shows top-7 + `_13 more candidates not shown; 4 tie the cutoff score (85.00)…_`.

## Test plan / coverage
- `dune build && dune runtest trading/weinstein/snapshot/` — 11 tests pass. Added: default-7 truncation, tie-cutoff note wording, no-note-when-not-truncated, explicit `long_limit` override (header + count + note).
- `dune build @fmt` clean; full `dune runtest devtools/checks` green (nesting/file-length/mli-coverage/magic-numbers/fmt all OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)