### PR TITLE
fix(simulation): side-aware fill routing (Fill_router extraction)

### DIFF
--- a/trading/trading/simulation/lib/dune
+++ b/trading/trading/simulation/lib/dune
@@ -12,6 +12,7 @@
   core)
  (modules
   simulator
+  fill_router
   simulator_metrics
   fill_date_stamp
   split_handler

--- a/trading/trading/simulation/lib/fill_router.ml
+++ b/trading/trading/simulation/lib/fill_router.ml
@@ -1,0 +1,103 @@
+(** Side-aware routing of fill trades onto position lifecycles. See .mli. *)
+
+open Core
+
+(* Expected trade side for filling a position's entry / exit order. A long
+   enters with a Buy and exits with a Sell; a short enters with a Sell
+   (sell-to-open) and exits with a Buy (buy-to-cover). *)
+let _entry_trade_side :
+    Trading_base.Types.position_side -> Trading_base.Types.side = function
+  | Long -> Buy
+  | Short -> Sell
+
+let _exit_trade_side :
+    Trading_base.Types.position_side -> Trading_base.Types.side = function
+  | Long -> Sell
+  | Short -> Buy
+
+let _is_entering_state = function
+  | Trading_strategy.Position.Entering _ -> true
+  | _ -> false
+
+let _is_exiting_state = function
+  | Trading_strategy.Position.Exiting _ -> true
+  | _ -> false
+
+(* Whether [pos] can receive a fill on [symbol] with [trade_side]: symbol
+   matches, the position is in the expected state, and the trade side is the
+   one that state's open order produces for the position's side. The side check
+   keeps routing correct when an entry and an exit order coexist on one symbol
+   (two sibling positions, e.g. a scale-in add entering while the original
+   exits) — state alone would route a Sell fill to the Entering position. *)
+let _fill_target_matches ~symbol ~trade_side ~state_match ~expected_side
+    (pos : Trading_strategy.Position.t) =
+  String.equal pos.symbol symbol
+  && state_match (Trading_strategy.Position.get_state pos)
+  && Trading_base.Types.equal_side (expected_side pos.side) trade_side
+
+(* Find a position that can receive this fill, by symbol + state + side. *)
+let _find_fill_position positions ~symbol ~trade_side ~state_match
+    ~expected_side ~is_entry =
+  Map.to_alist positions
+  |> List.find_map ~f:(fun (id, pos) ->
+      if
+        _fill_target_matches ~symbol ~trade_side ~state_match ~expected_side pos
+      then Some (id, pos, is_entry)
+      else None)
+
+let _find_fill_target positions ~symbol ~trade_side =
+  match
+    _find_fill_position positions ~symbol ~trade_side
+      ~state_match:_is_entering_state ~expected_side:_entry_trade_side
+      ~is_entry:true
+  with
+  | Some _ as r -> r
+  | None ->
+      _find_fill_position positions ~symbol ~trade_side
+        ~state_match:_is_exiting_state ~expected_side:_exit_trade_side
+        ~is_entry:false
+
+let _no_risk_params =
+  Trading_strategy.Position.
+    { stop_loss_price = None; take_profit_price = None; max_hold_days = None }
+
+(* Apply a fill to a position (works for both entry and exit fills). *)
+let _apply_fill ~date ~position ~trade ~is_entry =
+  let open Result.Let_syntax in
+  let open Trading_strategy.Position in
+  let qty = trade.Trading_base.Types.quantity in
+  let price = trade.Trading_base.Types.price in
+  let fill_kind =
+    if is_entry then EntryFill { filled_quantity = qty; fill_price = price }
+    else ExitFill { filled_quantity = qty; fill_price = price }
+  in
+  let fill_trans = { position_id = position.id; date; kind = fill_kind } in
+  let%bind pos = apply_transition position fill_trans in
+  let complete_kind =
+    if is_entry then EntryComplete { risk_params = _no_risk_params }
+    else ExitComplete
+  in
+  let complete_trans = { position_id = pos.id; date; kind = complete_kind } in
+  apply_transition pos complete_trans
+
+let set_or_drop_if_closed positions ~key ~data =
+  if Trading_strategy.Position.is_closed data then Map.remove positions key
+  else Map.set positions ~key ~data
+
+(* Route one fill trade onto the position map: find the (symbol, state, side)
+   target, apply the fill, install the updated position (or drop it when
+   Closed). A trade whose side matches no open order on its symbol is a no-op. *)
+let _apply_one_trade ~date positions trade =
+  let open Result.Let_syntax in
+  let symbol = trade.Trading_base.Types.symbol in
+  match
+    _find_fill_target positions ~symbol
+      ~trade_side:trade.Trading_base.Types.side
+  with
+  | Some (id, pos, is_entry) ->
+      let%bind updated = _apply_fill ~date ~position:pos ~trade ~is_entry in
+      Ok (set_or_drop_if_closed positions ~key:id ~data:updated)
+  | None -> Ok positions
+
+let update_positions_from_trades ~date ~positions ~trades =
+  List.fold_result trades ~init:positions ~f:(_apply_one_trade ~date)

--- a/trading/trading/simulation/lib/fill_router.mli
+++ b/trading/trading/simulation/lib/fill_router.mli
@@ -1,0 +1,39 @@
+(** Side-aware routing of fill trades onto position lifecycles.
+
+    Extracted from [Simulator] so the routing contract is independently
+    testable. Each fill trade routes to a position whose state {e and} side
+    expect that trade side:
+
+    - Long [Entering] ← Buy, Long [Exiting] ← Sell
+    - Short [Entering] ← Sell (sell-to-open), Short [Exiting] ← Buy
+      (buy-to-cover)
+
+    The side check keeps routing correct when an entry and an exit order coexist
+    on one symbol — two sibling positions, e.g. a scale-in add entering while
+    the original position exits. State-only routing (the historical behaviour,
+    safe under the one-position-per-symbol invariant) would route a Sell fill to
+    the Entering position and book it as an entry fill. A trade whose side
+    matches no open order on its symbol is ignored. *)
+
+val update_positions_from_trades :
+  date:Core.Date.t ->
+  positions:Trading_strategy.Position.t Core.String.Map.t ->
+  trades:Trading_base.Types.trade list ->
+  Trading_strategy.Position.t Core.String.Map.t Status.status_or
+(** [update_positions_from_trades ~date ~positions ~trades] folds [trades] over
+    [positions]: each trade routes to its (symbol, state, side) target, the fill
+    \+ completion transitions are applied, and the updated position is installed
+    — or removed when the fill closes it (Closed positions are
+    strategy-invisible; audit trails live elsewhere). Entry fills complete with
+    empty risk params (the strategy installs stops via [UpdateRiskParams]).
+    Returns an error if a routed transition is invalid for the target's state.
+*)
+
+val set_or_drop_if_closed :
+  Trading_strategy.Position.t Core.String.Map.t ->
+  key:string ->
+  data:Trading_strategy.Position.t ->
+  Trading_strategy.Position.t Core.String.Map.t
+(** Install [data] under [key], or remove [key] when [data] is Closed. Shared
+    with [Simulator]'s strategy-transition application path so both sites treat
+    Closed positions identically. *)

--- a/trading/trading/simulation/lib/simulator.ml
+++ b/trading/trading/simulation/lib/simulator.ml
@@ -221,47 +221,6 @@ let _call_strategy t =
     let%bind output = S.on_market_close ~get_price ~get_indicator ~portfolio in
     Ok output.transitions
 
-(** Find position by symbol and state *)
-let _find_position_by_symbol_state positions ~symbol ~state_match =
-  Map.to_alist positions
-  |> List.find_map ~f:(fun (id, pos) ->
-      if
-        String.equal pos.Trading_strategy.Position.symbol symbol
-        && state_match (Trading_strategy.Position.get_state pos)
-      then Some (id, pos)
-      else None)
-
-let _no_risk_params =
-  Trading_strategy.Position.
-    { stop_loss_price = None; take_profit_price = None; max_hold_days = None }
-
-(** Apply a fill to a position (works for both entry and exit fills). *)
-let _apply_fill ~date ~position ~trade ~is_entry =
-  let open Result.Let_syntax in
-  let open Trading_strategy.Position in
-  let qty = trade.Trading_base.Types.quantity in
-  let price = trade.Trading_base.Types.price in
-  let fill_kind =
-    if is_entry then EntryFill { filled_quantity = qty; fill_price = price }
-    else ExitFill { filled_quantity = qty; fill_price = price }
-  in
-  let fill_trans = { position_id = position.id; date; kind = fill_kind } in
-  let%bind pos = apply_transition position fill_trans in
-  let complete_kind =
-    if is_entry then EntryComplete { risk_params = _no_risk_params }
-    else ExitComplete
-  in
-  let complete_trans = { position_id = pos.id; date; kind = complete_kind } in
-  apply_transition pos complete_trans
-
-let _is_entering_state = function
-  | Trading_strategy.Position.Entering _ -> true
-  | _ -> false
-
-let _is_exiting_state = function
-  | Trading_strategy.Position.Exiting _ -> true
-  | _ -> false
-
 let _is_holding_state = function
   | Trading_strategy.Position.Holding _ -> true
   | _ -> false
@@ -272,32 +231,10 @@ let _count_stop_eligible positions =
   Map.count positions ~f:(fun pos ->
       _is_holding_state (Trading_strategy.Position.get_state pos))
 
-let _find_fill_target acc symbol =
-  let try_find state_match is_entry =
-    _find_position_by_symbol_state acc ~symbol ~state_match
-    |> Option.map ~f:(fun (id, pos) -> (id, pos, is_entry))
-  in
-  match try_find _is_entering_state true with
-  | Some _ as r -> r
-  | None -> try_find _is_exiting_state false
-
-(* Install [data] in [acc] or remove [key] when Closed. Closed positions are
-   strategy-invisible and contribute 0 to valuation; audit trails live in
-   [Trade_audit] / [Stop_log] / [final_portfolio.positions]. *)
-let _set_or_drop_if_closed acc ~key ~data =
-  if Trading_strategy.Position.is_closed data then Map.remove acc key
-  else Map.set acc ~key ~data
-
-(** Update positions from trades. *)
-let _update_positions_from_trades ~date ~positions ~trades =
-  let open Result.Let_syntax in
-  List.fold_result trades ~init:positions ~f:(fun acc trade ->
-      let symbol = trade.Trading_base.Types.symbol in
-      match _find_fill_target acc symbol with
-      | Some (id, pos, is_entry) ->
-          let%bind updated = _apply_fill ~date ~position:pos ~trade ~is_entry in
-          Ok (_set_or_drop_if_closed acc ~key:id ~data:updated)
-      | None -> Ok acc)
+(* Fill routing (which position receives a fill trade, by symbol + state +
+   side) lives in {!Fill_router}. Closed positions are strategy-invisible and
+   contribute 0 to valuation; audit trails live in [Trade_audit] / [Stop_log] /
+   [final_portfolio.positions]. *)
 
 let _apply_trigger_exit acc trans =
   let open Result.Let_syntax in
@@ -305,7 +242,9 @@ let _apply_trigger_exit acc trans =
   | None -> Ok acc
   | Some pos ->
       let%bind updated = Trading_strategy.Position.apply_transition pos trans in
-      Ok (_set_or_drop_if_closed acc ~key:trans.position_id ~data:updated)
+      Ok
+        (Fill_router.set_or_drop_if_closed acc ~key:trans.position_id
+           ~data:updated)
 
 (** Apply transitions to positions. [CancelEntry] is delegated to
     {!Cancel_handler.apply_to_positions}; the rest are inline. *)
@@ -408,7 +347,8 @@ let _process_fills_and_cancels t ~portfolio ~positions =
       portfolio all_trades
   in
   let%bind positions =
-    _update_positions_from_trades ~date:t.current_date ~positions ~trades
+    Fill_router.update_positions_from_trades ~date:t.current_date ~positions
+      ~trades
   in
   let cancel_transitions =
     Cancel_handler.transitions_for_rejected_trades ~date:t.current_date

--- a/trading/trading/simulation/test/dune
+++ b/trading/trading/simulation/test/dune
@@ -420,3 +420,16 @@
   trading.portfolio
   types
   matchers))
+
+(test
+ (name test_fill_routing)
+ (modules test_fill_routing)
+ (libraries
+  ounit2
+  core
+  core_unix.time_ns_unix
+  status
+  trading.simulation
+  trading.base
+  trading.strategy
+  matchers))

--- a/trading/trading/simulation/test/test_fill_routing.ml
+++ b/trading/trading/simulation/test/test_fill_routing.ml
@@ -1,0 +1,271 @@
+(** Tests for the simulator's side-aware fill routing
+    ({!Fill_router.update_positions_from_trades}).
+
+    Routing is by symbol + state + side: Long Entering ← Buy, Long Exiting ←
+    Sell, Short Entering ← Sell, Short Exiting ← Buy. The two-sibling scenarios
+    (an Entering add and an Exiting original on the same symbol, as scale-in
+    produces) pin that a Sell fill reaches the Exiting position and a Buy fill
+    reaches the Entering one — state-only routing would send both to Entering.
+*)
+
+open Core
+open OUnit2
+open Matchers
+open Trading_strategy.Position
+module Fill_router = Trading_simulation.Fill_router
+
+let _date = Date.of_string "2024-03-08"
+
+let _ok_exn ~msg = function
+  | Ok v -> v
+  | Error err -> assert_failure (msg ^ ": " ^ Status.show err)
+
+let _entering ~id ~symbol ~side ~target_quantity ~entry_price : t =
+  let transition =
+    {
+      position_id = id;
+      date = _date;
+      kind =
+        CreateEntering
+          {
+            symbol;
+            side;
+            target_quantity;
+            entry_price;
+            reasoning = ManualDecision { description = "test" };
+          };
+    }
+  in
+  create_entering transition |> _ok_exn ~msg:"create_entering"
+
+let _apply pos kind ~msg =
+  apply_transition pos { position_id = pos.id; date = _date; kind }
+  |> _ok_exn ~msg
+
+let _holding ~id ~symbol ~side ~quantity ~entry_price : t =
+  let pos =
+    _entering ~id ~symbol ~side ~target_quantity:quantity ~entry_price
+  in
+  let pos =
+    _apply pos
+      (EntryFill { filled_quantity = quantity; fill_price = entry_price })
+      ~msg:"entry fill"
+  in
+  _apply pos
+    (EntryComplete
+       {
+         risk_params =
+           {
+             stop_loss_price = None;
+             take_profit_price = None;
+             max_hold_days = None;
+           };
+       })
+    ~msg:"entry complete"
+
+let _exiting ~id ~symbol ~side ~quantity ~entry_price ~exit_price : t =
+  let pos = _holding ~id ~symbol ~side ~quantity ~entry_price in
+  _apply pos
+    (TriggerExit
+       {
+         exit_reason = SignalReversal { description = "test exit" };
+         exit_price;
+       })
+    ~msg:"trigger exit"
+
+let _positions_of (list : t list) =
+  String.Map.of_alist_exn (List.map list ~f:(fun p -> (p.id, p)))
+
+let _trade ~symbol ~(side : Trading_base.Types.side) ~quantity ~price :
+    Trading_base.Types.trade =
+  {
+    id = "trade-1";
+    order_id = "order-1";
+    symbol;
+    side;
+    quantity;
+    price;
+    commission = 0.0;
+    timestamp = Time_ns_unix.now ();
+  }
+
+let _update ~positions ~trades =
+  Fill_router.update_positions_from_trades ~date:_date ~positions ~trades
+  |> _ok_exn ~msg:"update_positions_from_trades"
+
+(* Sibling pair on one symbol: the original Exiting (sell order open) and an
+   add Entering (buy order open) — the state scale-in produces when a stop
+   fires while an unfilled add is in flight. *)
+let _sibling_positions () =
+  _positions_of
+    [
+      _exiting ~id:"AAPL-orig" ~symbol:"AAPL" ~side:Long ~quantity:10.0
+        ~entry_price:100.0 ~exit_price:95.0;
+      _entering ~id:"AAPL-add" ~symbol:"AAPL" ~side:Long ~target_quantity:5.0
+        ~entry_price:101.0;
+    ]
+
+(* ------- Tests ------- *)
+
+let test_sell_fill_routes_to_exiting_sibling _ =
+  (* Sell 10 must fill the Exiting original (which closes and is dropped from
+     the map), NOT the Entering add — state-only routing would pick Entering
+     first and book the sell as an entry fill. *)
+  let updated =
+    _update ~positions:(_sibling_positions ())
+      ~trades:[ _trade ~symbol:"AAPL" ~side:Sell ~quantity:10.0 ~price:95.0 ]
+  in
+  assert_that updated
+    (all_of
+       [
+         field (fun m -> Map.mem m "AAPL-orig") (equal_to false);
+         field
+           (fun m -> Map.find m "AAPL-add")
+           (is_some_and
+              (matching ~msg:"add must still be Entering with no fills"
+                 (fun (p : t) ->
+                   match get_state p with
+                   | Entering e -> Some e.filled_quantity
+                   | _ -> None)
+                 (float_equal 0.0)));
+       ])
+
+let test_buy_fill_routes_to_entering_sibling _ =
+  (* Buy 5 must fill the Entering add (→ Holding), leaving the Exiting original
+     untouched. *)
+  let updated =
+    _update ~positions:(_sibling_positions ())
+      ~trades:[ _trade ~symbol:"AAPL" ~side:Buy ~quantity:5.0 ~price:101.0 ]
+  in
+  assert_that updated
+    (all_of
+       [
+         field
+           (fun m -> Map.find m "AAPL-add")
+           (is_some_and
+              (matching ~msg:"add must be Holding its fill"
+                 (fun (p : t) ->
+                   match get_state p with
+                   | Holding h -> Some h.quantity
+                   | _ -> None)
+                 (float_equal 5.0)));
+         field
+           (fun m -> Map.find m "AAPL-orig")
+           (is_some_and
+              (matching ~msg:"original must still be Exiting unfilled"
+                 (fun (p : t) ->
+                   match get_state p with
+                   | Exiting e -> Some e.filled_quantity
+                   | _ -> None)
+                 (float_equal 0.0)));
+       ])
+
+let test_both_fills_same_tick_route_independently _ =
+  (* Buy 5 + Sell 10 in one batch: add completes to Holding, original closes
+     (dropped). *)
+  let updated =
+    _update ~positions:(_sibling_positions ())
+      ~trades:
+        [
+          _trade ~symbol:"AAPL" ~side:Buy ~quantity:5.0 ~price:101.0;
+          _trade ~symbol:"AAPL" ~side:Sell ~quantity:10.0 ~price:95.0;
+        ]
+  in
+  assert_that updated
+    (all_of
+       [
+         field (fun m -> Map.mem m "AAPL-orig") (equal_to false);
+         field
+           (fun m -> Map.find m "AAPL-add")
+           (is_some_and
+              (matching ~msg:"add must be Holding"
+                 (fun (p : t) ->
+                   match get_state p with
+                   | Holding h -> Some h.quantity
+                   | _ -> None)
+                 (float_equal 5.0)));
+       ])
+
+let test_single_long_entry_fill_regression _ =
+  (* Baseline behavior unchanged: one Long Entering + Buy → Holding. *)
+  let positions =
+    _positions_of
+      [
+        _entering ~id:"MSFT-1" ~symbol:"MSFT" ~side:Long ~target_quantity:8.0
+          ~entry_price:200.0;
+      ]
+  in
+  let updated =
+    _update ~positions
+      ~trades:[ _trade ~symbol:"MSFT" ~side:Buy ~quantity:8.0 ~price:200.5 ]
+  in
+  assert_that
+    (Map.find updated "MSFT-1")
+    (is_some_and
+       (matching ~msg:"entry filled to Holding"
+          (fun (p : t) ->
+            match get_state p with Holding h -> Some h.quantity | _ -> None)
+          (float_equal 8.0)))
+
+let test_short_entry_fills_on_sell _ =
+  (* A short enters with a Sell (sell-to-open). *)
+  let positions =
+    _positions_of
+      [
+        _entering ~id:"TSLA-1" ~symbol:"TSLA" ~side:Short ~target_quantity:4.0
+          ~entry_price:250.0;
+      ]
+  in
+  let updated =
+    _update ~positions
+      ~trades:[ _trade ~symbol:"TSLA" ~side:Sell ~quantity:4.0 ~price:249.0 ]
+  in
+  assert_that
+    (Map.find updated "TSLA-1")
+    (is_some_and
+       (matching ~msg:"short entry filled to Holding"
+          (fun (p : t) ->
+            match get_state p with Holding h -> Some h.quantity | _ -> None)
+          (float_equal 4.0)))
+
+let test_side_mismatched_fill_is_ignored _ =
+  (* Only a Long Entering (buy order) exists; a Sell trade matches no open
+     order and must leave positions unchanged. *)
+  let positions =
+    _positions_of
+      [
+        _entering ~id:"NVDA-1" ~symbol:"NVDA" ~side:Long ~target_quantity:3.0
+          ~entry_price:500.0;
+      ]
+  in
+  let updated =
+    _update ~positions
+      ~trades:[ _trade ~symbol:"NVDA" ~side:Sell ~quantity:3.0 ~price:499.0 ]
+  in
+  assert_that
+    (Map.find updated "NVDA-1")
+    (is_some_and
+       (matching ~msg:"entering position untouched"
+          (fun (p : t) ->
+            match get_state p with
+            | Entering e -> Some e.filled_quantity
+            | _ -> None)
+          (float_equal 0.0)))
+
+let suite =
+  "fill_routing"
+  >::: [
+         "sell_fill_routes_to_exiting_sibling"
+         >:: test_sell_fill_routes_to_exiting_sibling;
+         "buy_fill_routes_to_entering_sibling"
+         >:: test_buy_fill_routes_to_entering_sibling;
+         "both_fills_same_tick_route_independently"
+         >:: test_both_fills_same_tick_route_independently;
+         "single_long_entry_fill_regression"
+         >:: test_single_long_entry_fill_regression;
+         "short_entry_fills_on_sell" >:: test_short_entry_fills_on_sell;
+         "side_mismatched_fill_is_ignored"
+         >:: test_side_mismatched_fill_is_ignored;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
PR 1 of 4 of the capital-management scale-in build (`dev/plans/capital-management-scale-in-2026-07-02.md`, #1829). Core-hardening prerequisite; independently correct.

## What it does

`Simulator`'s `_find_fill_target` routed fill trades by **symbol + state only**. That is safe under the current one-position-per-symbol invariant, but scale-in introduces sibling positions (an add `Entering` while the original is `Exiting` on the same symbol) — with both a buy and a sell order open, a **Sell fill would route to the Entering position and book as an entry fill**.

- Routing is now **side-aware**: Long Entering ← Buy, Long Exiting ← Sell, Short Entering ← Sell (sell-to-open), Short Exiting ← Buy (buy-to-cover). A trade whose side matches no open order on its symbol is ignored.
- The routing cluster is **extracted to a new `Fill_router` module** (`simulation/lib/fill_router.{ml,mli}`): `simulator.ml` was at 523 lines (over the 500 declared-large cap) and the fold tripped the nesting linter (avg 3.10); extraction fixes both per `code-health-discipline.md` (no marker, no bump) and makes the routing contract independently testable. `simulator.ml` is now 431 lines.
- **Bit-identical today**: under the one-position-per-symbol invariant, every fill's side always matches the sole candidate's expected side, so routing decisions are unchanged.

## A1 note (core module)

Touches `trading/trading/simulation/` — strategy-agnostic correctness hardening (routing by side generalizes to any strategy; no Weinstein logic).

## Test plan
- New `test_fill_routing.ml` (6 tests): sibling Sell→Exiting / Buy→Entering routing, both-fills-same-tick, single-entry regression, short entry on Sell, side-mismatched fill ignored.
- `dune build` clean; `dune runtest trading/simulation/test` all suites green; `dune build @fmt` exit 0; nesting linter OK (298 fns); file-length OK.
- Local full `dune runtest` also surfaced pre-existing env-data failures (missing repo-root `data/` fixtures, e.g. `tiered-loader-parity.sexp` — absent on host too) unrelated to this diff; CI with proper fixtures is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)