### PR TITLE
fix(weinstein-stops): advance shared per-ticker stop state once per tick

### DIFF
--- a/trading/trading/weinstein/strategy/lib/stop_transitions.ml
+++ b/trading/trading/weinstein/strategy/lib/stop_transitions.ml
@@ -1,0 +1,67 @@
+(** Position transitions emitted by the stops pass. See .mli. *)
+
+open Trading_strategy
+
+let trigger_fill_price ?(on_close = false)
+    ~(side : Trading_base.Types.position_side) ~bar () =
+  if on_close then bar.Types.Daily_price.close_price
+  else
+    match side with
+    | Long -> bar.Types.Daily_price.low_price
+    | Short -> bar.Types.Daily_price.high_price
+
+let make_exit_transition ?(on_close = false) ~(pos : Position.t) ~current_date
+    ~state ~bar () =
+  let actual_price =
+    trigger_fill_price ~on_close ~side:pos.Position.side ~bar ()
+  in
+  let exit_reason =
+    Position.StopLoss
+      {
+        stop_price = Weinstein_stops.get_stop_level state;
+        actual_price;
+        loss_percent = 0.0;
+      }
+  in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind = Position.TriggerExit { exit_reason; exit_price = actual_price };
+  }
+
+let make_adjust_transition ~(pos : Position.t) ~current_date
+    ~(risk_params : Position.risk_params) ~new_level =
+  let new_risk_params =
+    {
+      Position.stop_loss_price = Some new_level;
+      take_profit_price = risk_params.take_profit_price;
+      max_hold_days = risk_params.max_hold_days;
+    }
+  in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind = Position.UpdateRiskParams { new_risk_params };
+  }
+
+let handle_trigger_only ~on_close ~(pos : Position.t) ~state ~bar ~current_date
+    =
+  if
+    Weinstein_stops.check_stop_hit ~on_close ~state ~side:pos.Position.side ~bar
+      ()
+  then
+    ( Some (make_exit_transition ~on_close ~pos ~current_date ~state ~bar ()),
+      None )
+  else (None, None)
+
+let of_stop_event ~on_close ~(pos : Position.t)
+    ~(risk_params : Position.risk_params) ~state ~bar ~current_date ~event =
+  match event with
+  | Weinstein_stops.Stop_hit _ ->
+      ( Some (make_exit_transition ~on_close ~pos ~current_date ~state ~bar ()),
+        None )
+  | Weinstein_stops.Stop_raised { new_level; _ } ->
+      ( None,
+        Some (make_adjust_transition ~pos ~current_date ~risk_params ~new_level)
+      )
+  | _ -> (None, None)

--- a/trading/trading/weinstein/strategy/lib/stop_transitions.mli
+++ b/trading/trading/weinstein/strategy/lib/stop_transitions.mli
@@ -1,0 +1,63 @@
+(** Position transitions emitted by the stops pass — the pure mapping from a
+    stop trigger / {!Weinstein_stops.stop_event} to the [TriggerExit] /
+    [UpdateRiskParams] transitions {!Stops_runner} hands the strategy. Extracted
+    from [Stops_runner] (file-length); no behaviour change. *)
+
+open Trading_strategy
+
+val trigger_fill_price :
+  ?on_close:bool ->
+  side:Trading_base.Types.position_side ->
+  bar:Types.Daily_price.t ->
+  unit ->
+  float
+(** Worst-case fill price when a stop trigger fires: the bar's low for a long
+    (stop crossed going down), the bar's high for a short (crossed going up) —
+    the G1 audit-record contract. With [on_close = true] (the weekly-close
+    trigger rule) the close price is used for both sides. *)
+
+val make_exit_transition :
+  ?on_close:bool ->
+  pos:Position.t ->
+  current_date:Core.Date.t ->
+  state:Weinstein_stops.stop_state ->
+  bar:Types.Daily_price.t ->
+  unit ->
+  Position.transition
+(** [TriggerExit] with a [StopLoss] reason at {!trigger_fill_price}; the
+    recorded [stop_price] is [state]'s current level. *)
+
+val make_adjust_transition :
+  pos:Position.t ->
+  current_date:Core.Date.t ->
+  risk_params:Position.risk_params ->
+  new_level:float ->
+  Position.transition
+(** [UpdateRiskParams] raising [stop_loss_price] to [new_level]; take-profit /
+    max-hold carry over from [risk_params]. *)
+
+val handle_trigger_only :
+  on_close:bool ->
+  pos:Position.t ->
+  state:Weinstein_stops.stop_state ->
+  bar:Types.Daily_price.t ->
+  current_date:Core.Date.t ->
+  Position.transition option * Position.transition option
+(** Trigger-check-only branch (weekly cadence, non-Friday bar): the state
+    machine is not advanced; an (exit, adjust) pair with the exit populated when
+    the bar crosses the existing stop level. Book §Stop-Loss Rules — the GTC
+    stop sits in the market every day; only its placement re-evaluation is
+    weekly. *)
+
+val of_stop_event :
+  on_close:bool ->
+  pos:Position.t ->
+  risk_params:Position.risk_params ->
+  state:Weinstein_stops.stop_state ->
+  bar:Types.Daily_price.t ->
+  current_date:Core.Date.t ->
+  event:Weinstein_stops.stop_event ->
+  Position.transition option * Position.transition option
+(** Translate a {!Weinstein_stops.stop_event} into the (exit, adjust) transition
+    pair for one position: [Stop_hit] → exit at the pre-advance [state]'s level,
+    [Stop_raised] → adjust to the new level, anything else → neither. *)

--- a/trading/trading/weinstein/strategy/lib/stops_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/stops_runner.ml
@@ -74,102 +74,24 @@ let _compute_ma_and_stage ?ma_cache ?prior_stage_ma_values
         Hashtbl.set tbl ~key:symbol ~data:result.ma_value);
     (result.ma_direction, result.ma_value, result.stage)
 
-(** Worst-case fill price when a stop trigger fires.
+(* Transition emission (worst-case fill price, exit/adjust builders, the
+   trigger-only branch, and the stop_event → transitions mapping) lives in
+   {!Stop_transitions} — including the G1 short-fill audit contract. *)
 
-    For a long, the stop fires when the bar's low crosses DOWN through the stop
-    level — the worst-case fill is at the bar's low (maximum slippage in the
-    loss direction). For a short, the stop fires when the bar's high crosses UP
-    through the stop level — the worst-case fill is at the bar's high (maximum
-    slippage on the cover).
-
-    Pre-G1-fix this function unconditionally returned [bar.low_price], which for
-    shorts produced audit-log entries like ALB 2019-01-29 (stop $103.58,
-    actual_price $77.49 when bar low was $76) that read as if the stop fired
-    against profitable territory — the recorded actual price was the bar low,
-    not the trigger price near the high. See G1 in
-    [dev/notes/short-side-gaps-2026-04-29.md]. *)
-let _trigger_fill_price ?(on_close = false)
-    ~(side : Trading_base.Types.position_side) ~bar () =
-  if on_close then bar.Types.Daily_price.close_price
-  else
-    match side with
-    | Long -> bar.Types.Daily_price.low_price
-    | Short -> bar.Types.Daily_price.high_price
-
-let _make_exit_transition ?(on_close = false) ~(pos : Position.t) ~current_date
-    ~state ~bar () =
-  let actual_price =
-    _trigger_fill_price ~on_close ~side:pos.Position.side ~bar ()
-  in
-  let exit_reason =
-    Position.StopLoss
-      {
-        stop_price = Weinstein_stops.get_stop_level state;
-        actual_price;
-        loss_percent = 0.0;
-      }
-  in
-  {
-    Position.position_id = pos.id;
-    date = current_date;
-    kind = Position.TriggerExit { exit_reason; exit_price = actual_price };
-  }
-
-let _make_adjust_transition ~(pos : Position.t) ~current_date
-    ~(risk_params : Position.risk_params) ~new_level =
-  let new_risk_params =
-    {
-      Position.stop_loss_price = Some new_level;
-      take_profit_price = risk_params.take_profit_price;
-      max_hold_days = risk_params.max_hold_days;
-    }
-  in
-  {
-    Position.position_id = pos.id;
-    date = current_date;
-    kind = Position.UpdateRiskParams { new_risk_params };
-  }
-
-(** Trigger-only branch for [Weekly] cadence on a non-Friday bar. The state
-    machine is not advanced (no trail tightening, no correction-cycle
-    bookkeeping progresses). The trigger check still fires continuously — book
-    §Stop-Loss Rules: the GTC stop sits in the market every day; only its
-    placement re-evaluation is weekly. If the bar's high/low crosses the
-    existing stop level, an exit transition is emitted at the same actual_price
-    the daily path would have used (bar low for longs, bar high for shorts). *)
-let _handle_stop_trigger_only ~on_close ~(pos : Position.t) ~state ~bar
-    ~current_date =
-  if
-    Weinstein_stops.check_stop_hit ~on_close ~state ~side:pos.Position.side ~bar
-      ()
-  then
-    ( Some (_make_exit_transition ~on_close ~pos ~current_date ~state ~bar ()),
-      None )
-  else (None, None)
-
-(** Translate a {!Weinstein_stops.stop_event} into the (exit, adjust) transition
-    pair the runner emits to the strategy. Pure mapping — extracted from
-    [_handle_stop] to keep that function within the nesting linter's limits. *)
-let _transitions_of_stop_event ~on_close ~(pos : Position.t)
-    ~(risk_params : Position.risk_params) ~state ~bar ~current_date ~event =
-  match event with
-  | Weinstein_stops.Stop_hit _ ->
-      ( Some (_make_exit_transition ~on_close ~pos ~current_date ~state ~bar ()),
-        None )
-  | Weinstein_stops.Stop_raised { new_level; _ } ->
-      ( None,
-        Some
-          (_make_adjust_transition ~pos ~current_date ~risk_params ~new_level)
-      )
-  | _ -> (None, None)
-
-(** Daily-cadence branch (and Weekly-on-Friday): advance the state machine via
-    {!Weinstein_stops.update}, persist the new state, and emit the resulting
-    (exit, adjust) transition pair. Mutates [stop_states]. *)
-let _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
-    ~stage_config ~lookback_bars ~(pos : Position.t)
-    ~(risk_params : Position.risk_params) ~state ~bar ~stop_states ~ticker
-    ~bar_reader ~as_of ~prior_stages ~current_date () =
+(** Advance the shared per-ticker stop state machine
+    {b at most once per [update] call}. [advanced] memoizes
+    [(pre_advance_state, event)] per ticker: the first position on a ticker
+    advances the machine (persisting the new state into [stop_states] and the
+    new stage into [prior_stages]); subsequent same-ticker positions (sibling
+    positions, e.g. a scale-in add) replay the memoized event so each position
+    still emits its own exit / adjust transition while the machine advances
+    exactly once — {!Weinstein_stops.update}'s contract is one call per period,
+    and a second call per tick would also double-age [weeks_advancing] in
+    [prior_stages]. Sibling positions on one ticker share the position side (the
+    memoized advance uses the first position's side). *)
+let _advance_machine ?ma_cache ?prior_stage_ma_values ~stops_config
+    ~stage_config ~lookback_bars ~(pos : Position.t) ~state ~bar ~stop_states
+    ~ticker ~bar_reader ~as_of ~prior_stages () =
   let ma_direction, ma_value, stage =
     _compute_ma_and_stage ?ma_cache ?prior_stage_ma_values ~stage_config
       ~lookback_bars ~bar_reader ~as_of ~prior_stages ~symbol:ticker
@@ -181,9 +103,37 @@ let _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
       ~current_bar:bar ~ma_value ~ma_direction ~stage
   in
   stop_states := Map.set !stop_states ~key:ticker ~data:new_state;
-  _transitions_of_stop_event
+  (state, event)
+
+let _advance_ticker_once ?ma_cache ?prior_stage_ma_values ~advanced
+    ~stops_config ~stage_config ~lookback_bars ~(pos : Position.t) ~state ~bar
+    ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages () =
+  match Hashtbl.find advanced ticker with
+  | Some memo -> memo
+  | None ->
+      let memo =
+        _advance_machine ?ma_cache ?prior_stage_ma_values ~stops_config
+          ~stage_config ~lookback_bars ~pos ~state ~bar ~stop_states ~ticker
+          ~bar_reader ~as_of ~prior_stages ()
+      in
+      Hashtbl.set advanced ~key:ticker ~data:memo;
+      memo
+
+(** Daily-cadence branch (and Weekly-on-Friday): advance the state machine once
+    per ticker (see {!_advance_ticker_once}) and emit this position's (exit,
+    adjust) transition pair off the pre-advance state + event. *)
+let _handle_stop_full ?ma_cache ?prior_stage_ma_values ~advanced ~stops_config
+    ~stage_config ~lookback_bars ~(pos : Position.t)
+    ~(risk_params : Position.risk_params) ~state ~bar ~stop_states ~ticker
+    ~bar_reader ~as_of ~prior_stages ~current_date () =
+  let pre_state, event =
+    _advance_ticker_once ?ma_cache ?prior_stage_ma_values ~advanced
+      ~stops_config ~stage_config ~lookback_bars ~pos ~state ~bar ~stop_states
+      ~ticker ~bar_reader ~as_of ~prior_stages ()
+  in
+  Stop_transitions.of_stop_event
     ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos
-    ~risk_params ~state ~bar ~current_date ~event
+    ~risk_params ~state:pre_state ~bar ~current_date ~event
 
 (** Fast-crash absolute-stop exit, OR'd alongside the structural trigger.
 
@@ -196,7 +146,8 @@ let _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
     carries one, so the catastrophic stop is dormant until a trend leg exists.
     No exit when [catastrophic_armed = false] or [pct = 0.0] (the default), so
     existing callers / goldens are bit-identical. The exit fill price reuses the
-    structural [_make_exit_transition] (bar low for longs / high for shorts). *)
+    structural [Stop_transitions.make_exit_transition] (bar low for longs / high
+    for shorts). *)
 let _catastrophic_hit ~catastrophic_armed ~stops_config ~(pos : Position.t)
     ~state ~bar =
   match Weinstein_stops.Catastrophic_stop.trailing_high_of_state state with
@@ -210,7 +161,7 @@ let _catastrophic_exit ~catastrophic_armed ~stops_config ~(pos : Position.t)
     ~state ~bar ~current_date =
   if _catastrophic_hit ~catastrophic_armed ~stops_config ~pos ~state ~bar then
     Some
-      (_make_exit_transition
+      (Stop_transitions.make_exit_transition
          ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos
          ~current_date ~state ~bar ())
   else None
@@ -219,18 +170,18 @@ let _catastrophic_exit ~catastrophic_armed ~stops_config ~(pos : Position.t)
     adjust_transition option).
 
     Under [Weekly] cadence with [as_of] not on a Friday, only the trigger check
-    runs (see [_handle_stop_trigger_only]); the state machine is not advanced
-    and [stop_states] is unchanged. Under [Daily] (or [Weekly] on Friday), the
-    state machine runs as before via [_handle_stop_full].
+    runs (see [Stop_transitions.handle_trigger_only]); the state machine is not
+    advanced and [stop_states] is unchanged. Under [Daily] (or [Weekly] on
+    Friday), the state machine runs as before via [_handle_stop_full].
 
     The fast-crash absolute stop ([_catastrophic_exit]) is OR'd alongside both
     branches: if the structural path produced no exit but the catastrophic stop
     fires, its exit is emitted instead. The structural exit takes precedence
     when both fire (same [TriggerExit] kind). *)
 let _handle_stop ?ma_cache ?prior_stage_ma_values ?(stop_update_cadence = Daily)
-    ?(catastrophic_armed = false) ~stops_config ~stage_config ~lookback_bars
-    ~(pos : Position.t) ~(risk_params : Position.risk_params) ~state ~bar
-    ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages () =
+    ?(catastrophic_armed = false) ~advanced ~stops_config ~stage_config
+    ~lookback_bars ~(pos : Position.t) ~(risk_params : Position.risk_params)
+    ~state ~bar ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages () =
   let current_date = bar.Types.Daily_price.date in
   let advance_state_machine =
     match stop_update_cadence with
@@ -239,11 +190,11 @@ let _handle_stop ?ma_cache ?prior_stage_ma_values ?(stop_update_cadence = Daily)
   in
   let exit_tr, adjust_tr =
     if not advance_state_machine then
-      _handle_stop_trigger_only
+      Stop_transitions.handle_trigger_only
         ~on_close:stops_config.Weinstein_stops.trigger_on_weekly_close ~pos
         ~state ~bar ~current_date
     else
-      _handle_stop_full ?ma_cache ?prior_stage_ma_values ~stops_config
+      _handle_stop_full ?ma_cache ?prior_stage_ma_values ~advanced ~stops_config
         ~stage_config ~lookback_bars ~pos ~risk_params ~state ~bar ~stop_states
         ~ticker ~bar_reader ~as_of ~prior_stages ~current_date ()
   in
@@ -259,8 +210,8 @@ let _handle_stop ?ma_cache ?prior_stage_ma_values ?(stop_update_cadence = Daily)
 (** Process stop for one position; returns updated (exits, adjusts) accumulator.
 *)
 let _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
-    ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars ~stop_states
-    ~get_price ~bar_reader ~as_of ~prior_stages (pos : Position.t)
+    ?catastrophic_armed ~advanced ~stops_config ~stage_config ~lookback_bars
+    ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages (pos : Position.t)
     (exits, adjusts) =
   let ticker = pos.symbol in
   match
@@ -269,9 +220,9 @@ let _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
   | Position.Holding h, Some state, Some bar -> (
       match
         _handle_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
-          ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars ~pos
-          ~risk_params:h.risk_params ~state ~bar ~stop_states ~ticker
-          ~bar_reader ~as_of ~prior_stages ()
+          ?catastrophic_armed ~advanced ~stops_config ~stage_config
+          ~lookback_bars ~pos ~risk_params:h.risk_params ~state ~bar
+          ~stop_states ~ticker ~bar_reader ~as_of ~prior_stages ()
       with
       | Some exit_tr, _ -> (exit_tr :: exits, adjusts)
       | _, Some adj_tr -> (exits, adj_tr :: adjusts)
@@ -281,7 +232,11 @@ let _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
 let update ?ma_cache ?stop_update_cadence ?prior_stage_ma_values
     ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars ~positions
     ~get_price ~stop_states ~bar_reader ~as_of ~prior_stages () =
+  (* Per-call memo: ticker -> (pre_advance_state, event). Ensures the shared
+     per-ticker state machine advances once per tick even when several sibling
+     positions hold the same ticker (see [_advance_ticker_once]). *)
+  let advanced = Hashtbl.create (module String) in
   Map.fold positions ~init:([], []) ~f:(fun ~key:_ ~data:pos acc ->
       _process_stop ?ma_cache ?prior_stage_ma_values ?stop_update_cadence
-        ?catastrophic_armed ~stops_config ~stage_config ~lookback_bars
+        ?catastrophic_armed ~advanced ~stops_config ~stage_config ~lookback_bars
         ~stop_states ~get_price ~bar_reader ~as_of ~prior_stages pos acc)

--- a/trading/trading/weinstein/strategy/test/test_stops_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_stops_runner.ml
@@ -25,9 +25,11 @@ let get_price_of bars symbol = List.Assoc.find bars symbol ~equal:String.equal
 
 (** Build a Position.t in the [Holding] state for [ticker] at [price]. Defaults
     to [Long]; pass [~side:Short] for short positions (used by the G1
-    short-stop-direction reproducer tests below). *)
-let make_holding_pos ?(side = Trading_base.Types.Long) ticker price date =
-  let pos_id = ticker in
+    short-stop-direction reproducer tests below). [?id] overrides the position
+    id (defaults to [ticker]) — used by the sibling-position tests, which hold
+    two positions on one ticker. *)
+let make_holding_pos ?(side = Trading_base.Types.Long) ?id ticker price date =
+  let pos_id = Option.value id ~default:ticker in
   let make_trans kind =
     { Trading_strategy.Position.position_id = pos_id; date; kind }
   in
@@ -630,6 +632,130 @@ let test_catastrophic_pct_zero_no_exit _ =
   assert_that exits is_empty
 
 (* ------------------------------------------------------------------ *)
+(* Sibling positions on one ticker (scale-in shape)                     *)
+(*                                                                      *)
+(* Two Holding positions share one ticker and therefore one entry in    *)
+(* stop_states — the shared stop discipline governs both units. The     *)
+(* runner must (a) emit a per-position transition for BOTH siblings     *)
+(* (both exit on a hit; both get UpdateRiskParams on a raise), while    *)
+(* (b) advancing the shared state machine exactly ONCE per tick —       *)
+(* Weinstein_stops.update's contract is one call per period.            *)
+(* ------------------------------------------------------------------ *)
+
+(** Two Long Holdings on [ticker] with distinct position ids. *)
+let _sibling_positions ticker price date =
+  String.Map.of_alist_exn
+    [
+      ( ticker ^ "-orig",
+        make_holding_pos ~id:(ticker ^ "-orig") ticker price date );
+      (ticker ^ "-add", make_holding_pos ~id:(ticker ^ "-add") ticker price date);
+    ]
+
+let _transition_ids (transitions : Trading_strategy.Position.transition list) =
+  List.map transitions ~f:(fun tr -> tr.Trading_strategy.Position.position_id)
+  |> List.sort ~compare:String.compare
+
+let test_sibling_positions_stop_hit_exits_both _ =
+  (* Shared stop breached → one TriggerExit per sibling position. *)
+  let ticker = "AAPL" in
+  let date = Date.of_string "2024-01-05" in
+  let positions = _sibling_positions ticker 100.0 date in
+  let stop_states =
+    ref
+      (String.Map.singleton ticker
+         (Weinstein_stops.Initial { stop_level = 90.0; reference_level = 95.0 }))
+  in
+  let bar = make_bar "2024-01-12" ~close:95.0 ~low:85.0 () in
+  let exits, adjusts =
+    Stops_runner.update ~stops_config:default_cfg
+      ~stage_config:default_stage_cfg ~lookback_bars:52 ~positions
+      ~get_price:(get_price_of [ (ticker, bar) ])
+      ~stop_states ~bar_reader:(Bar_reader.empty ())
+      ~as_of:(Date.of_string "2024-01-12")
+      ~prior_stages:(Hashtbl.create (module String))
+      ()
+  in
+  assert_that adjusts is_empty;
+  assert_that (_transition_ids exits) (equal_to [ "AAPL-add"; "AAPL-orig" ])
+
+(** A Trailing state one recovery-bar away from a raise: a completed ≥8%
+    correction ([last_correction_extreme] 88 vs [last_trend_extreme] 100,
+    [min_correction_pct] = 0.08) with a fresh anchor
+    ([correction_observed_since_reset]), so a close above 100 completes the
+    cycle and raises the stop off the correction low. *)
+let _raise_ready_trailing =
+  Weinstein_stops.Trailing
+    {
+      stop_level = 80.0;
+      last_correction_extreme = 88.0;
+      last_trend_extreme = 100.0;
+      ma_at_last_adjustment = 90.0;
+      correction_count = 1;
+      correction_observed_since_reset = true;
+    }
+
+let test_sibling_positions_raise_adjusts_both _ =
+  (* Shared trailing stop raises → BOTH siblings get an UpdateRiskParams at
+     the same new level. Under a per-position machine advance (the pre-fix
+     behaviour) only the first sibling would see the raise event — the second
+     call re-runs the machine on the already-raised state, so the second
+     position's risk params silently go stale. *)
+  let ticker = "AAPL" in
+  let date = Date.of_string "2024-01-05" in
+  let positions = _sibling_positions ticker 100.0 date in
+  let stop_states = ref (String.Map.singleton ticker _raise_ready_trailing) in
+  let bar = make_bar "2024-01-12" ~close:105.0 ~low:103.0 ~high:106.0 () in
+  let exits, adjusts =
+    Stops_runner.update ~stops_config:default_cfg
+      ~stage_config:default_stage_cfg ~lookback_bars:52 ~positions
+      ~get_price:(get_price_of [ (ticker, bar) ])
+      ~stop_states ~bar_reader:(Bar_reader.empty ())
+      ~as_of:(Date.of_string "2024-01-12")
+      ~prior_stages:(Hashtbl.create (module String))
+      ()
+  in
+  assert_that exits is_empty;
+  let new_levels =
+    List.filter_map adjusts ~f:(fun tr ->
+        match tr.Trading_strategy.Position.kind with
+        | Trading_strategy.Position.UpdateRiskParams { new_risk_params } ->
+            new_risk_params.stop_loss_price
+        | _ -> None)
+  in
+  assert_that (_transition_ids adjusts) (equal_to [ "AAPL-add"; "AAPL-orig" ]);
+  (* Both adjusts carry the same (single-advance) new stop level. *)
+  assert_that new_levels
+    (matching ~msg:"two identical raised levels"
+       (function [ a; b ] when Float.equal a b -> Some a | _ -> None)
+       (gt (module Float_ord) 80.0))
+
+let test_sibling_positions_advance_state_once _ =
+  (* The shared per-ticker state after an update over two siblings must equal
+     the state after the same update over ONE position — the machine advanced
+     once, not once per sibling. *)
+  let ticker = "AAPL" in
+  let date = Date.of_string "2024-01-05" in
+  let bar = make_bar "2024-01-12" ~close:105.0 ~low:103.0 ~high:106.0 () in
+  let run positions =
+    let stop_states = ref (String.Map.singleton ticker _raise_ready_trailing) in
+    let _ =
+      Stops_runner.update ~stops_config:default_cfg
+        ~stage_config:default_stage_cfg ~lookback_bars:52 ~positions
+        ~get_price:(get_price_of [ (ticker, bar) ])
+        ~stop_states ~bar_reader:(Bar_reader.empty ())
+        ~as_of:(Date.of_string "2024-01-12")
+        ~prior_stages:(Hashtbl.create (module String))
+        ()
+    in
+    Map.find_exn !stop_states ticker
+  in
+  let single =
+    run (String.Map.singleton ticker (make_holding_pos ticker 100.0 date))
+  in
+  let sibling = run (_sibling_positions ticker 100.0 date) in
+  assert_that sibling (equal_to single)
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -665,4 +791,10 @@ let () =
            >:: test_weekly_cadence_no_state_advance_when_only_midweek;
            "G11: Weekly cadence still fires trigger on mid-week bar"
            >:: test_weekly_cadence_trigger_fires_on_midweek_bar;
+           "siblings: stop hit exits both positions"
+           >:: test_sibling_positions_stop_hit_exits_both;
+           "siblings: raise adjusts both positions"
+           >:: test_sibling_positions_raise_adjusts_both;
+           "siblings: shared state machine advances once"
+           >:: test_sibling_positions_advance_state_once;
          ])


### PR DESCRIPTION
PR 2 of 4 of the capital-management scale-in build (`dev/plans/capital-management-scale-in-2026-07-02.md`, #1829). Independent of PR #1830; both are prerequisites for the scale-in runner.

## What it does

`Stops_runner.update` folds **positions**, and each position advanced the shared per-ticker Weinstein stop state machine (`stop_states[symbol]`). Under the one-position-per-symbol invariant that's one advance per tick — but sibling positions on one ticker (the scale-in shape: original + add, both Holding) would **double-advance** the machine each tick, violating `Weinstein_stops.update`'s documented one-call-per-period contract, double-stepping correction-cycle bookkeeping, and double-aging `weeks_advancing` in `prior_stages`. It would also silently leave the second sibling's risk params stale on a raise (the second machine call re-runs on the already-raised state, so only the first position saw the `Stop_raised` event).

Fix: a per-`update`-call memo (`ticker → (pre_advance_state, event)`). The first position on a ticker advances the machine (persisting new state + stage); subsequent same-ticker positions **replay the memoized event**, so every sibling still emits its own per-position transition:
- shared stop hit → `TriggerExit` for **all** siblings
- raise → `UpdateRiskParams` for **all** siblings at the same new level

**Bit-identical today** (one position per ticker → memo never hit twice). Trigger-only (non-Friday weekly-cadence) path unchanged — it is stateless per position.

## Test plan
- 3 new tests: sibling stop-hit exits both; sibling raise adjusts both at one level; shared state after a two-sibling update equals the single-position run (machine advanced once).
- All 17 stops_runner tests green; `dune build @fmt` exit 0; nesting linter OK (355 fns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)