### PR TITLE
feat(scale-in): config knobs + pullback-add detector (default-off)

### DIFF
--- a/trading/trading/weinstein/strategy/lib/scale_in_detector.ml
+++ b/trading/trading/weinstein/strategy/lib/scale_in_detector.ml
@@ -1,0 +1,82 @@
+(** Pure detection of the scale-in add trigger. See .mli. *)
+
+open Core
+
+type trigger = Pullback | Early_new_high | Either [@@deriving sexp, eq, show]
+
+(* Default pullback-touch band: a bar's low within 3% above the breakout level
+   counts as the retest of the breakout zone. *)
+let default_pullback_proximity_pct = 0.03
+
+(* Default extension gate: no add when the close sits more than 15% above the
+   30-week MA (price has outrun its own trend). *)
+let default_extension_max_pct = 0.15
+
+type config = {
+  initial_entry_fraction : float; [@sexp.default 1.0]
+  max_adds : int; [@sexp.default 1]
+  add_trigger : trigger; [@sexp.default Pullback]
+  pullback_proximity_pct : float; [@sexp.default default_pullback_proximity_pct]
+  extension_max_pct : float; [@sexp.default default_extension_max_pct]
+  require_not_late : bool; [@sexp.default true]
+}
+[@@deriving sexp, eq, show]
+
+let default_config =
+  {
+    initial_entry_fraction = 1.0;
+    max_adds = 1;
+    add_trigger = Pullback;
+    pullback_proximity_pct = default_pullback_proximity_pct;
+    extension_max_pct = default_extension_max_pct;
+    require_not_late = true;
+  }
+
+(* Current bar + strictly-prior bars, both in chronological order collapsed to
+   (current, rev_prior). [None] when fewer than two bars — a pullback or a
+   continuation needs at least one full bar after the entry week. *)
+let _split_current bars =
+  match List.rev bars with
+  | current :: (_ :: _ as rev_prior) -> Some (current, rev_prior)
+  | _ -> None
+
+(* Some prior bar's low touched the pullback zone. *)
+let _touched_pullback_zone ~touch_level rev_prior =
+  List.exists rev_prior ~f:(fun (b : Types.Daily_price.t) ->
+      Float.( <= ) b.low_price touch_level)
+
+(* The current bar holds the breakout level and turns back up. *)
+let _held_and_turned ~entry_price ~(current : Types.Daily_price.t) ~rev_prior =
+  let prev_close = (List.hd_exn rev_prior).Types.Daily_price.close_price in
+  Float.( >= ) current.close_price entry_price
+  && Float.( > ) current.close_price prev_close
+
+let pullback_hold ~proximity_pct ~entry_price ~bars_since_entry =
+  match _split_current bars_since_entry with
+  | None -> false
+  | Some (current, rev_prior) ->
+      let touch_level = entry_price *. (1.0 +. proximity_pct) in
+      _touched_pullback_zone ~touch_level rev_prior
+      && _held_and_turned ~entry_price ~current ~rev_prior
+
+let early_new_high ~entry_price ~bars_since_entry =
+  match _split_current bars_since_entry with
+  | None -> false
+  | Some (current, rev_prior) ->
+      let prior_max =
+        List.fold rev_prior ~init:Float.neg_infinity
+          ~f:(fun acc (b : Types.Daily_price.t) -> Float.max acc b.close_price)
+      in
+      Float.( > ) current.Types.Daily_price.close_price prior_max
+      && Float.( > ) current.Types.Daily_price.close_price entry_price
+
+let add_signal ~trigger ~proximity_pct ~entry_price ~bars_since_entry =
+  match trigger with
+  | Pullback -> pullback_hold ~proximity_pct ~entry_price ~bars_since_entry
+  | Early_new_high -> early_new_high ~entry_price ~bars_since_entry
+  | Either ->
+      pullback_hold ~proximity_pct ~entry_price ~bars_since_entry
+      || early_new_high ~entry_price ~bars_since_entry
+
+let extended_above_ma ~max_pct ~close ~ma =
+  Float.( > ) ma 0.0 && Float.( > ) ((close -. ma) /. ma) max_pct

--- a/trading/trading/weinstein/strategy/lib/scale_in_detector.mli
+++ b/trading/trading/weinstein/strategy/lib/scale_in_detector.mli
@@ -1,0 +1,85 @@
+(** Pure detection of the scale-in add trigger (explore/exploit scale-in v1).
+
+    Weinstein's scale-in dial buys half on the breakout and adds the other half
+    when the first pullback to the breakout zone {e holds}
+    (weinstein-book-reference.md §The Trader's Way; plan
+    [dev/plans/capital-management-scale-in-2026-07-02.md] §3.2). The add
+    {b follows revealed strength, never predicts}: it fires on a market-revealed
+    event over the position's own bars, not on a conviction score.
+
+    All functions are pure — same inputs, same answer. The runner (PR 4 of the
+    scale-in build) owns position/portfolio state, cash arbitration, and the
+    not-late / not-extended gate wiring; this module owns only the per-symbol
+    price-action predicates. *)
+
+(** Which revealed event arms the add. [Pullback] is v1's default (the faithful
+    ½ + ½). [Early_new_high] and [Either] exist as experiment axes because a
+    pure-pullback trigger systematically under-sizes gap-and-go winners that
+    never retest the breakout — the #1 instrumented check in the plan (§3.4). *)
+type trigger = Pullback | Early_new_high | Either [@@deriving sexp, eq, show]
+
+type config = {
+  initial_entry_fraction : float; [@sexp.default 1.0]
+      (** Fraction of the full risk unit committed at the initial breakout
+          entry. [1.0] (default) = today's full single entry — the no-op.
+          Enabled specs set [0.5] (Weinstein's half-on-breakout). *)
+  max_adds : int; [@sexp.default 1]
+      (** Maximum follow-up adds per symbol. Weinstein describes exactly one
+          (the pullback half); inert while [enable_scale_in = false]. *)
+  add_trigger : trigger; [@sexp.default Pullback]
+  pullback_proximity_pct : float; [@sexp.default 0.03]
+      (** How close (fraction above entry) a bar's low must come to the breakout
+          level to count as the pullback touch. *)
+  extension_max_pct : float; [@sexp.default 0.15]
+      (** Extension gate: no add when the current close sits more than this
+          fraction above the 30-week MA — price has outrun its own trend
+          (Weinstein: never buy extended). Consumed by the runner via
+          {!extended_above_ma}. *)
+  require_not_late : bool; [@sexp.default true]
+      (** When [true] the runner blocks adds on [Stage2 { late = true }]
+          holdings (MA-slope deceleration — the topping warning). *)
+}
+[@@deriving sexp, eq, show]
+
+val default_config : config
+(** All-fields default; [initial_entry_fraction = 1.0] keeps the disabled
+    behaviour bit-identical. *)
+
+val pullback_hold :
+  proximity_pct:float ->
+  entry_price:float ->
+  bars_since_entry:Types.Daily_price.t list ->
+  bool
+(** [pullback_hold ~proximity_pct ~entry_price ~bars_since_entry] is [true]
+    when, over the (chronological) weekly bars strictly after the entry week:
+
+    - some {e prior} bar's low touched the pullback zone
+      ([low <= entry_price * (1 + proximity_pct)]), and
+    - the current (last) bar closed at or above [entry_price] (the pullback
+      {e held} the breakout level), and
+    - the current close is above the previous close (the turn back up).
+
+    Needs at least two bars ([false] otherwise) — a touch and a turn cannot be
+    the same observation as the entry itself. *)
+
+val early_new_high :
+  entry_price:float -> bars_since_entry:Types.Daily_price.t list -> bool
+(** [true] when the current (last) bar's close is a new high above every prior
+    post-entry close and above [entry_price] — the continuation reveal for
+    gap-and-go names that never retest. Needs at least two bars. The extension
+    gate ({!extended_above_ma}) is the runner's job. *)
+
+val add_signal :
+  trigger:trigger ->
+  proximity_pct:float ->
+  entry_price:float ->
+  bars_since_entry:Types.Daily_price.t list ->
+  bool
+(** Dispatch on [trigger]: [Pullback] → {!pullback_hold}, [Early_new_high] →
+    {!early_new_high}, [Either] → their disjunction. *)
+
+val extended_above_ma : max_pct:float -> close:float -> ma:float -> bool
+(** [true] when [(close - ma) / ma > max_pct] — price has outrun its 30-week MA
+    by more than the gate allows. [false] for non-positive [ma] (warmup /
+    missing MA never blocks-by-crash; the runner separately requires a real MA
+    before adding). *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -19,6 +19,7 @@ module Macro_bearish_trim_wiring = Macro_bearish_trim_wiring
 module Laggard_rotation_runner = Laggard_rotation_runner
 module Special_exits = Special_exits
 module Liquidity_config = Liquidity_config
+module Scale_in_detector = Scale_in_detector
 module Liquidity_metric = Liquidity_metric
 module Liquidity_exit_runner = Liquidity_exit_runner
 module Stage3_force_exit = Stage3_force_exit

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -128,6 +128,12 @@ module Liquidity_config = Liquidity_config
     callers building a {!Weinstein_strategy.config} can reference
     {!Liquidity_config.default_config} without a separate library import. *)
 
+module Scale_in_detector = Scale_in_detector
+(** Scale-in add-trigger detection + knobs ({!Scale_in_detector.config}).
+    Re-exposed so callers building a {!Weinstein_strategy.config} can reference
+    {!Scale_in_detector.default_config} and the [trigger] variants without a
+    separate library import. *)
+
 module Liquidity_metric = Liquidity_metric
 (** Pure trailing dollar-ADV metric. See {!Liquidity_metric}. *)
 
@@ -535,6 +541,15 @@ type config = {
           entry liquidity gate). Default [Liquidity_config.default_config] is a
           no-op (both thresholds [0.0]) — bit-identical to baseline. See
           [Weinstein_strategy_config]. *)
+  enable_scale_in : bool; [@sexp.default false]
+      (** Master switch for the explore/exploit scale-in mechanism (½-unit
+          initial entries + one pullback add into revealed strength). Default
+          [false] is a no-op — bit-identical to baseline. See
+          [Weinstein_strategy_config]. *)
+  scale_in_config : Scale_in_detector.config;
+      [@sexp.default Scale_in_detector.default_config]
+      (** Scale-in knobs; only consulted when [enable_scale_in = true]. See
+          [Weinstein_strategy_config] and {!Scale_in_detector}. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -142,9 +142,22 @@ type config = {
   liquidity_config : Liquidity_config.t;
       [@sexp.default Liquidity_config.default_config]
       (** See [.mli]. *)
+  enable_scale_in : bool; [@sexp.default false]
+      (** Master switch for the explore/exploit scale-in mechanism (½-unit
+          initial entries + one pullback add into revealed strength). Default
+          [false] is a no-op — bit-identical to baseline. See [.mli]. *)
+  scale_in_config : Scale_in_detector.config;
+      [@sexp.default Scale_in_detector.default_config]
+      (** Scale-in knobs (initial fraction, add trigger, gates); only consulted
+          when [enable_scale_in = true]. See [.mli]. *)
 }
 [@@deriving sexp]
 
+(* Flat record literal over every config field — exactly one line per field
+   by construction (no logic), growing one line per new default-off
+   experiment knob. OCaml has no partial record literals, so splitting is
+   impossible and extracting field groups would only add indirection.
+   @large-function: flat default-config record literal, one line per field *)
 let default_config ~universe ~index_symbol =
   let indices = { primary = index_symbol; global = [] } in
   {
@@ -193,6 +206,8 @@ let default_config ~universe ~index_symbol =
     harvest_fraction = 0.5;
     short_sleeve_fraction = 0.0;
     liquidity_config = Liquidity_config.default_config;
+    enable_scale_in = false;
+    scale_in_config = Scale_in_detector.default_config;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -460,6 +460,31 @@ type config = {
           a [Variant_matrix] axis, e.g.
           [((key (liquidity_config min_hold_dollar_adv)) (values (0.0 1e6)))].
           Default-off until an experiment-ledger ACCEPT. *)
+  enable_scale_in : bool; [@sexp.default false]
+      (** Master switch for the explore/exploit scale-in mechanism
+          ([dev/plans/capital-management-scale-in-2026-07-02.md]): initial
+          entries at [scale_in_config.initial_entry_fraction] of the full risk
+          unit (broader survey of fresh Stage-2 breakouts) plus at most
+          [scale_in_config.max_adds] follow-up adds into {e revealed} strength
+          (the first pullback that holds the breakout — Weinstein's ½ + ½, "The
+          Trader's Way"). A
+          {b reallocation inside the existing exposure envelope}: per-symbol
+          notional stays capped at [portfolio_config.max_position_pct_long] and
+          no gross-exposure knob changes.
+
+          Default [false] is a {b no-op} — the entry walk, sizing, and
+          transitions are bit-identical to baseline (experiment-flag-discipline
+          R1); the mechanism is searchable as a flag axis the day it lands (R2).
+      *)
+  scale_in_config : Scale_in_detector.config;
+      [@sexp.default Scale_in_detector.default_config]
+      (** Scale-in knobs — initial-entry fraction, add trigger ([Pullback] v1
+          default / [Early_new_high] / [Either]), pullback proximity, the
+          extension gate (max distance above the 30-week MA), and the not-late
+          gate. Only consulted when [enable_scale_in = true]; each field is
+          addressable as a [Variant_matrix] dot-path axis, e.g.
+          [((key (scale_in_config add_trigger)) (values (Pullback Either)))].
+          See {!Scale_in_detector}. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -27,6 +27,7 @@
   test_macro_bearish_trim_runner
   test_laggard_rotation_runner
   test_stops_runner
+  test_scale_in_detector
   test_stops_split_runner
   test_weekly_ma_cache
   test_weinstein_strategy

--- a/trading/trading/weinstein/strategy/test/test_scale_in_detector.ml
+++ b/trading/trading/weinstein/strategy/test/test_scale_in_detector.ml
@@ -1,0 +1,201 @@
+(** Tests for {!Scale_in_detector} — pure pullback-hold / early-new-high
+    detection (explore/exploit scale-in v1) — and the default-off config
+    contract (experiment-flag-discipline R1/R2). *)
+
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+
+let _bar date ~close ?low ?high () =
+  let low = Option.value low ~default:(close *. 0.99) in
+  let high = Option.value high ~default:(close *. 1.01) in
+  {
+    Types.Daily_price.date = Date.of_string date;
+    open_price = close;
+    high_price = high;
+    low_price = low;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+    active_through = None;
+  }
+
+(* Entry at 100. Weekly bars strictly after the entry week. *)
+let _entry = 100.0
+
+let _pullback ~bars =
+  Scale_in_detector.pullback_hold ~proximity_pct:0.03 ~entry_price:_entry
+    ~bars_since_entry:bars
+
+(* ------- pullback_hold ------- *)
+
+let test_pullback_touch_then_turn_up_fires _ =
+  (* Advance (108), pull back to the breakout zone (low 101 <= 103), then turn
+     up while holding above entry (close 105 > 101 and >= 100). *)
+  let bars =
+    [
+      _bar "2024-01-12" ~close:108.0 ();
+      _bar "2024-01-19" ~close:101.0 ~low:101.0 ();
+      _bar "2024-01-26" ~close:105.0 ~low:102.0 ();
+    ]
+  in
+  assert_that (_pullback ~bars) (equal_to true)
+
+let test_pullback_without_touch_does_not_fire _ =
+  (* Steady advance, never near the breakout zone: no touch, no add. *)
+  let bars =
+    [
+      _bar "2024-01-12" ~close:108.0 ~low:106.0 ();
+      _bar "2024-01-19" ~close:112.0 ~low:110.0 ();
+      _bar "2024-01-26" ~close:115.0 ~low:113.0 ();
+    ]
+  in
+  assert_that (_pullback ~bars) (equal_to false)
+
+let test_pullback_that_breaks_entry_does_not_fire _ =
+  (* Touch happened but the current close sits below entry — the pullback did
+     NOT hold the breakout level. *)
+  let bars =
+    [
+      _bar "2024-01-12" ~close:104.0 ();
+      _bar "2024-01-19" ~close:97.0 ~low:96.0 ();
+      _bar "2024-01-26" ~close:99.0 ~low:97.0 ();
+    ]
+  in
+  assert_that (_pullback ~bars) (equal_to false)
+
+let test_pullback_without_turn_up_does_not_fire _ =
+  (* Touched the zone but the current close is still falling (no turn). *)
+  let bars =
+    [
+      _bar "2024-01-12" ~close:108.0 ();
+      _bar "2024-01-19" ~close:104.0 ~low:101.0 ();
+      _bar "2024-01-26" ~close:103.0 ~low:101.5 ();
+    ]
+  in
+  assert_that (_pullback ~bars) (equal_to false)
+
+let test_pullback_needs_two_bars _ =
+  (* A single post-entry bar cannot be both the touch and the turn. *)
+  let bars = [ _bar "2024-01-12" ~close:105.0 ~low:101.0 () ] in
+  assert_that (_pullback ~bars) (equal_to false)
+
+(* ------- early_new_high ------- *)
+
+let test_early_new_high_fires_on_new_post_entry_high _ =
+  let bars =
+    [
+      _bar "2024-01-12" ~close:104.0 ();
+      _bar "2024-01-19" ~close:103.0 ();
+      _bar "2024-01-26" ~close:106.0 ();
+    ]
+  in
+  assert_that
+    (Scale_in_detector.early_new_high ~entry_price:_entry ~bars_since_entry:bars)
+    (equal_to true)
+
+let test_early_new_high_not_fired_below_prior_high _ =
+  let bars =
+    [
+      _bar "2024-01-12" ~close:108.0 ();
+      _bar "2024-01-19" ~close:105.0 ();
+      _bar "2024-01-26" ~close:107.0 ();
+    ]
+  in
+  assert_that
+    (Scale_in_detector.early_new_high ~entry_price:_entry ~bars_since_entry:bars)
+    (equal_to false)
+
+(* ------- add_signal dispatch ------- *)
+
+let test_either_fires_on_new_high_when_pullback_does_not _ =
+  (* Gap-and-go shape: never touches the zone, keeps making highs — Pullback
+     misses it, Either catches it (the §3.4 monster-under-sizing fix). *)
+  let bars =
+    [
+      _bar "2024-01-12" ~close:110.0 ~low:108.0 ();
+      _bar "2024-01-19" ~close:115.0 ~low:112.0 ();
+    ]
+  in
+  let signal trigger =
+    Scale_in_detector.add_signal ~trigger ~proximity_pct:0.03
+      ~entry_price:_entry ~bars_since_entry:bars
+  in
+  assert_that
+    (signal Scale_in_detector.Pullback, signal Scale_in_detector.Either)
+    (equal_to (false, true))
+
+(* ------- extension gate ------- *)
+
+let test_extended_above_ma _ =
+  assert_that
+    ( Scale_in_detector.extended_above_ma ~max_pct:0.15 ~close:120.0 ~ma:100.0,
+      Scale_in_detector.extended_above_ma ~max_pct:0.15 ~close:110.0 ~ma:100.0,
+      Scale_in_detector.extended_above_ma ~max_pct:0.15 ~close:120.0 ~ma:0.0 )
+    (equal_to (true, false, false))
+
+(* ------- config: default-off contract ------- *)
+
+let test_config_defaults_are_no_op _ =
+  assert_that Scale_in_detector.default_config
+    (all_of
+       [
+         field
+           (fun (c : Scale_in_detector.config) -> c.initial_entry_fraction)
+           (float_equal 1.0);
+         field
+           (fun (c : Scale_in_detector.config) -> c.add_trigger)
+           (equal_to Scale_in_detector.Pullback);
+         field (fun (c : Scale_in_detector.config) -> c.max_adds) (equal_to 1);
+         field
+           (fun (c : Scale_in_detector.config) -> c.require_not_late)
+           (equal_to true);
+       ])
+
+let test_strategy_config_omitted_fields_default_off _ =
+  (* A config sexp that predates scale-in (no scale_in fields) must parse with
+     enable_scale_in = false and the default knobs — old scenario sexps replay
+     unchanged (experiment-flag-discipline R1). *)
+  let base =
+    Weinstein_strategy.default_config ~universe:[ "AAPL" ] ~index_symbol:"SPY"
+  in
+  let round_tripped =
+    Weinstein_strategy.config_of_sexp (Weinstein_strategy.sexp_of_config base)
+  in
+  assert_that round_tripped
+    (all_of
+       [
+         field
+           (fun (c : Weinstein_strategy.config) -> c.enable_scale_in)
+           (equal_to false);
+         field
+           (fun (c : Weinstein_strategy.config) -> c.scale_in_config)
+           (equal_to Scale_in_detector.default_config);
+       ])
+
+let suite =
+  "scale_in_detector"
+  >::: [
+         "pullback: touch then turn up fires"
+         >:: test_pullback_touch_then_turn_up_fires;
+         "pullback: no touch does not fire"
+         >:: test_pullback_without_touch_does_not_fire;
+         "pullback: broken entry does not fire"
+         >:: test_pullback_that_breaks_entry_does_not_fire;
+         "pullback: no turn up does not fire"
+         >:: test_pullback_without_turn_up_does_not_fire;
+         "pullback: needs two bars" >:: test_pullback_needs_two_bars;
+         "early_new_high: fires on new post-entry high"
+         >:: test_early_new_high_fires_on_new_post_entry_high;
+         "early_new_high: not fired below prior high"
+         >:: test_early_new_high_not_fired_below_prior_high;
+         "add_signal: Either catches gap-and-go that Pullback misses"
+         >:: test_either_fires_on_new_high_when_pullback_does_not;
+         "extension gate thresholds" >:: test_extended_above_ma;
+         "config defaults are no-op" >:: test_config_defaults_are_no_op;
+         "strategy config round-trips default-off"
+         >:: test_strategy_config_omitted_fields_default_off;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
PR 3 of 4 of the explore/exploit scale-in build (`dev/plans/capital-management-scale-in-2026-07-02.md`, #1829). Independent of #1830/#1831; PR 4 (runner + wiring) consumes all three.

## What it does

**`Scale_in_detector` (new, pure)** — the per-symbol price-action predicates for the add trigger:
- `pullback_hold`: some prior post-entry bar's low touched the breakout zone (`low ≤ entry×(1+proximity)`), the current close **holds** the breakout level (`≥ entry`), and turns up (`> prev close`). Weinstein's ½+½ ("The Trader's Way") — the add **follows revealed strength, never predicts**.
- `early_new_high`: current close is a new post-entry high — the continuation reveal for gap-and-go names that never retest.
- `add_signal` dispatches on the `trigger` knob (`Pullback` v1 default / `Early_new_high` / `Either`); `Either` exists because a pure-pullback trigger under-sizes the gap-and-go monsters (the plan's §3.4 #1 instrumented check — pinned by a test).
- `extended_above_ma`: the distance-above-30-week-MA extension gate (rate-vs-trend, Weinstein's own "never buy extended" measure).

**Config (default-off per `experiment-flag-discipline` R1/R2):**
- `enable_scale_in : bool [@sexp.default false]` — master switch; nothing consumes it yet, so this PR is a **no-behavior-change** land.
- `scale_in_config : Scale_in_detector.config [@sexp.default …]` — `initial_entry_fraction` (1.0 = no-op; enabled specs set 0.5), `max_adds` (1), `add_trigger`, `pullback_proximity_pct`, `extension_max_pct`, `require_not_late`. Every field is a `Variant_matrix` dot-path axis via the generic sexp overlay merge (R2 — verified `Overlay_validator.apply_overrides` resolves record fields generically).

## Test plan
- 11 tests: 5 pullback cases (fire / no-touch / broken-entry / no-turn / needs-two-bars), 2 early-new-high, the Pullback-misses-Either-catches gap-and-go case, extension-gate thresholds, default-config no-op values, and strategy-config sexp round-trip (old sexps parse with `enable_scale_in = false`).
- `dune build` clean, `dune build @fmt` exit 0, nesting linter OK (360 fns). Weinstein test suite green except the two known pre-existing env-data failures (`ad_bars_unicorn`/`ad_bars_compose`, breadth-cache fixtures — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)