### PR TITLE
[main-fix] fix(status): simulation.md Last-updated must be bare YYYY-MM-DD

### DIFF
--- a/dev/status/simulation.md
+++ b/dev/status/simulation.md
@@ -1,6 +1,6 @@
 # Status: simulation
 
-## Last updated: 2026-07-04 (run 2 — #1847 MERGED)
+## Last updated: 2026-07-04
 
 ### 2026-07-04 — sibling round-trip pairing fix (#1847, MERGED as `761c30cf`)
 


### PR DESCRIPTION
Main is red: build-and-test `dune runtest` exits 1 on HEAD `66141546` (#1850 summary merge) because the status_file_integrity linter rejects `dev/status/simulation.md`:

```
FAIL: status file integrity linter — malformed or missing fields in dev/status/:
simulation.md: '## Last updated' is not YYYY-MM-DD: '2026-07-04 (run 2 — #1847 MERGED)'
```

The prior orchestrator run's Step 5.5 reconcile wrote an annotated date; it merged via the run-2 summary bundle (#1850). This restores the bare `YYYY-MM-DD`; the '(run 2 — #1847 MERGED)' context already lives in the file body.

Verified locally: `status_file_integrity.sh` exits 0 after the fix.

Docs-only (status file) → CI-gated, QC skipped per `.claude/rules/pr-merge-gates.md`.

🤖 Dispatched by GHA orchestrator run [28726311764](https://github.com/dayfine/trading/actions/runs/28726311764)