### PR TITLE
feat(scale-in): Consolidation_breakout trigger + explicit add_fraction (default-off)

### DIFF
--- a/trading/trading/weinstein/strategy/lib/scale_in_detector.ml
+++ b/trading/trading/weinstein/strategy/lib/scale_in_detector.ml
@@ -2,7 +2,8 @@
 
 open Core
 
-type trigger = Pullback | Early_new_high | Either [@@deriving sexp, eq, show]
+type trigger = Pullback | Early_new_high | Either | Consolidation_breakout
+[@@deriving sexp, eq, show]
 
 (* Default pullback-touch band: a bar's low within 3% above the breakout level
    counts as the retest of the breakout zone. *)
@@ -12,13 +13,43 @@ let default_pullback_proximity_pct = 0.03
    30-week MA (price has outrun its own trend). *)
 let default_extension_max_pct = 0.15
 
+(* Consolidation-breakout defaults (book gives no numbers; all axes): a real
+   zone spans at least 4 completed weeks, ranges no more than 10% top to
+   bottom, sits within 10% above the 30-week MA, and the breakout bar carries
+   at least 1.25x the window's average volume. *)
+let default_consolidation_min_weeks = 4
+let default_consolidation_band_pct = 0.10
+let default_consolidation_ma_proximity_pct = 0.10
+let default_consolidation_volume_ratio_min = 1.25
+
+type consolidation_config = {
+  min_weeks : int; [@sexp.default default_consolidation_min_weeks]
+  band_pct : float; [@sexp.default default_consolidation_band_pct]
+  ma_proximity_pct : float;
+      [@sexp.default default_consolidation_ma_proximity_pct]
+  volume_ratio_min : float;
+      [@sexp.default default_consolidation_volume_ratio_min]
+}
+[@@deriving sexp, eq, show]
+
+let default_consolidation_config =
+  {
+    min_weeks = default_consolidation_min_weeks;
+    band_pct = default_consolidation_band_pct;
+    ma_proximity_pct = default_consolidation_ma_proximity_pct;
+    volume_ratio_min = default_consolidation_volume_ratio_min;
+  }
+
 type config = {
   initial_entry_fraction : float; [@sexp.default 1.0]
   max_adds : int; [@sexp.default 1]
   add_trigger : trigger; [@sexp.default Pullback]
+  add_fraction : float option; [@sexp.default None]
   pullback_proximity_pct : float; [@sexp.default default_pullback_proximity_pct]
   extension_max_pct : float; [@sexp.default default_extension_max_pct]
   require_not_late : bool; [@sexp.default true]
+  consolidation : consolidation_config;
+      [@sexp.default default_consolidation_config]
 }
 [@@deriving sexp, eq, show]
 
@@ -27,9 +58,11 @@ let default_config =
     initial_entry_fraction = 1.0;
     max_adds = 1;
     add_trigger = Pullback;
+    add_fraction = None;
     pullback_proximity_pct = default_pullback_proximity_pct;
     extension_max_pct = default_extension_max_pct;
     require_not_late = true;
+    consolidation = default_consolidation_config;
   }
 
 (* Current bar + strictly-prior bars, both in chronological order collapsed to
@@ -70,13 +103,62 @@ let early_new_high ~entry_price ~bars_since_entry =
       Float.( > ) current.Types.Daily_price.close_price prior_max
       && Float.( > ) current.Types.Daily_price.close_price entry_price
 
-let add_signal ~trigger ~proximity_pct ~entry_price ~bars_since_entry =
+(* The last [n] elements of [xs] (all of [xs] when shorter). *)
+let _last_n xs n =
+  let len = List.length xs in
+  if len <= n then xs else List.drop xs (len - n)
+
+(* Window predicates for the continuation buy. The window is the [min_weeks]
+   completed bars immediately before the current (breakout-candidate) bar. *)
+let _window_is_tight ~band_pct closes =
+  let max_c = List.fold closes ~init:Float.neg_infinity ~f:Float.max in
+  let min_c = List.fold closes ~init:Float.infinity ~f:Float.min in
+  Float.( > ) max_c 0.0 && Float.( <= ) ((max_c -. min_c) /. max_c) band_pct
+
+let _window_near_ma ~ma_proximity_pct ~ma closes =
+  let min_c = List.fold closes ~init:Float.infinity ~f:Float.min in
+  Float.( > ) ma 0.0 && Float.( <= ) min_c (ma *. (1.0 +. ma_proximity_pct))
+
+let _breaks_out_on_volume ~volume_ratio_min ~(current : Types.Daily_price.t)
+    window =
+  let closes =
+    List.map window ~f:(fun (b : Types.Daily_price.t) -> b.close_price)
+  in
+  let max_c = List.fold closes ~init:Float.neg_infinity ~f:Float.max in
+  let avg_vol =
+    List.fold window ~init:0.0 ~f:(fun acc (b : Types.Daily_price.t) ->
+        acc +. Float.of_int b.volume)
+    /. Float.of_int (List.length window)
+  in
+  Float.( > ) current.close_price max_c
+  && Float.( >= ) (Float.of_int current.volume) (volume_ratio_min *. avg_vol)
+
+let consolidation_breakout ~(consolidation : consolidation_config) ~ma
+    ~bars_since_entry =
+  match _split_current bars_since_entry with
+  | None -> false
+  | Some (current, rev_prior) ->
+      let window = _last_n (List.rev rev_prior) consolidation.min_weeks in
+      let closes =
+        List.map window ~f:(fun (b : Types.Daily_price.t) -> b.close_price)
+      in
+      List.length window >= consolidation.min_weeks
+      && _window_is_tight ~band_pct:consolidation.band_pct closes
+      && _window_near_ma ~ma_proximity_pct:consolidation.ma_proximity_pct ~ma
+           closes
+      && _breaks_out_on_volume ~volume_ratio_min:consolidation.volume_ratio_min
+           ~current window
+
+let add_signal ~trigger ~proximity_pct ~consolidation ~ma ~entry_price
+    ~bars_since_entry =
   match trigger with
   | Pullback -> pullback_hold ~proximity_pct ~entry_price ~bars_since_entry
   | Early_new_high -> early_new_high ~entry_price ~bars_since_entry
   | Either ->
       pullback_hold ~proximity_pct ~entry_price ~bars_since_entry
       || early_new_high ~entry_price ~bars_since_entry
+  | Consolidation_breakout ->
+      consolidation_breakout ~consolidation ~ma ~bars_since_entry
 
 let extended_above_ma ~max_pct ~close ~ma =
   Float.( > ) ma 0.0 && Float.( > ) ((close -. ma) /. ma) max_pct

--- a/trading/trading/weinstein/strategy/lib/scale_in_detector.mli
+++ b/trading/trading/weinstein/strategy/lib/scale_in_detector.mli
@@ -13,20 +13,58 @@
     price-action predicates. *)
 
 (** Which revealed event arms the add. [Pullback] is v1's default (the faithful
-    ½ + ½). [Early_new_high] and [Either] exist as experiment axes because a
-    pure-pullback trigger systematically under-sizes gap-and-go winners that
-    never retest the breakout — the #1 instrumented check in the plan (§3.4). *)
-type trigger = Pullback | Early_new_high | Either [@@deriving sexp, eq, show]
+    ½ + ½ — an INITIAL-position completion tactic tied to the base breakout).
+    [Early_new_high] and [Either] exist as v1 experiment axes.
+    [Consolidation_breakout] is the book's actual continuation buy (Ch. 3 §The
+    Trader's Way; plan [dev/plans/continuation-add-v2-2026-07-04.md]): price
+    consolidates near the rising 30-week MA, then breaks out anew above the
+    consolidation's top on volume — the press-the-winner add that catches
+    gap-and-go names, which never retest the entry but DO reconsolidate mid-run.
+*)
+type trigger = Pullback | Early_new_high | Either | Consolidation_breakout
+[@@deriving sexp, eq, show]
+
+type consolidation_config = {
+  min_weeks : int; [@sexp.default 4]
+      (** Completed weekly bars the consolidation window must span (before the
+          current, breakout-candidate bar). The book demands a real
+          reconsolidation zone, not a wiggle. *)
+  band_pct : float; [@sexp.default 0.10]
+      (** Window tightness: [(max_close - min_close) / max_close] must not
+          exceed this — a consolidation is a range, not a trend. *)
+  ma_proximity_pct : float; [@sexp.default 0.10]
+      (** "Drops back close to its MA": the window's min close must sit within
+          this fraction ABOVE the 30-week MA ([min_close <= ma * (1 + p)]). *)
+  volume_ratio_min : float; [@sexp.default 1.25]
+      (** "Impressive volume": the breakout bar's volume must be at least this
+          multiple of the window's average volume. *)
+}
+[@@deriving sexp, eq, show]
+(** Knobs for {!consolidation_breakout}. The book gives no numeric thresholds —
+    every field is a searchable [Variant_matrix] axis; defaults are starting
+    points only. *)
+
+val default_consolidation_config : consolidation_config
+(** All-fields default (4 weeks / 0.10 band / 0.10 MA proximity / 1.25 volume
+    ratio). *)
 
 type config = {
   initial_entry_fraction : float; [@sexp.default 1.0]
       (** Fraction of the full risk unit committed at the initial breakout
-          entry. [1.0] (default) = today's full single entry — the no-op.
-          Enabled specs set [0.5] (Weinstein's half-on-breakout). *)
+          entry. [1.0] (default) = today's full single entry — the no-op. v1
+          specs set [0.5] (Weinstein's half-on-breakout); the v2 continuation
+          surface keeps [1.0] (no explore-side tax). *)
   max_adds : int; [@sexp.default 1]
       (** Maximum follow-up adds per symbol. Weinstein describes exactly one
           (the pullback half); inert while [enable_scale_in = false]. *)
   add_trigger : trigger; [@sexp.default Pullback]
+  add_fraction : float option; [@sexp.default None]
+      (** Size of each add as a fraction of a full risk unit. [None] (default) =
+          the v1-derived [1.0 -. initial_entry_fraction] — bit-identical
+          backcompat, and full-size entries get zero-size adds. [Some f] sizes
+          the add explicitly (the v2 surface sets [Some 1.0]: the book buys the
+          {e entire} position at a continuation breakout — the per-symbol
+          notional cap remains the real ceiling). *)
   pullback_proximity_pct : float; [@sexp.default 0.03]
       (** How close (fraction above entry) a bar's low must come to the breakout
           level to count as the pullback touch. *)
@@ -34,10 +72,21 @@ type config = {
       (** Extension gate: no add when the current close sits more than this
           fraction above the 30-week MA — price has outrun its own trend
           (Weinstein: never buy extended). Consumed by the runner via
-          {!extended_above_ma}. *)
+          {!extended_above_ma} and applied to ALL triggers uniformly.
+          {b Interplay warning} (the "Either dead at 0.15" lesson): a
+          [Consolidation_breakout] close sits structurally up to
+          [(1 + ma_proximity_pct) * (1 + band_pct) - 1] above the MA (~21% at
+          defaults) — surfaces arming that trigger must raise this gate (plan:
+          0.25) or the trigger is dead on arrival. *)
   require_not_late : bool; [@sexp.default true]
       (** When [true] the runner blocks adds on [Stage2 { late = true }]
-          holdings (MA-slope deceleration — the topping warning). *)
+          holdings (MA-slope deceleration). For [Consolidation_breakout] this
+          doubles as the book's "MA must be clearly trending higher" health
+          gate. *)
+  consolidation : consolidation_config;
+      [@sexp.default default_consolidation_config]
+      (** {!consolidation_breakout} knobs; consulted only when [add_trigger] is
+          [Consolidation_breakout]. *)
 }
 [@@deriving sexp, eq, show]
 
@@ -69,14 +118,35 @@ val early_new_high :
     gap-and-go names that never retest. Needs at least two bars. The extension
     gate ({!extended_above_ma}) is the runner's job. *)
 
+val consolidation_breakout :
+  consolidation:consolidation_config ->
+  ma:float ->
+  bars_since_entry:Types.Daily_price.t list ->
+  bool
+(** The book's continuation buy (Ch. 3 §The Trader's Way), detected over the
+    (chronological) weekly bars strictly after the entry week. [true] when all
+    of, for the window of the last [min_weeks] bars before the current bar:
+
+    - the window is tight: [(max_close - min_close) / max_close <= band_pct];
+    - the window sits near the MA: [min_close <= ma * (1 + ma_proximity_pct)]
+      (requires [ma > 0]);
+    - the current bar breaks out: [close > window max close];
+    - on volume: [current volume >= volume_ratio_min * window avg volume].
+
+    Needs at least [min_weeks + 1] bars ([false] otherwise). The MA-health
+    ("clearly trending higher") gate is the runner's [require_not_late]. *)
+
 val add_signal :
   trigger:trigger ->
   proximity_pct:float ->
+  consolidation:consolidation_config ->
+  ma:float ->
   entry_price:float ->
   bars_since_entry:Types.Daily_price.t list ->
   bool
 (** Dispatch on [trigger]: [Pullback] → {!pullback_hold}, [Early_new_high] →
-    {!early_new_high}, [Either] → their disjunction. *)
+    {!early_new_high}, [Either] → their disjunction, [Consolidation_breakout] →
+    {!consolidation_breakout}. *)
 
 val extended_above_ma : max_pct:float -> close:float -> ma:float -> bool
 (** [true] when [(close - ma) / ma > max_pct] — price has outrun its 30-week MA

--- a/trading/trading/weinstein/strategy/lib/scale_in_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/scale_in_runner.ml
@@ -66,16 +66,25 @@ let _bars_since_entry ~bar_reader ~lookback_bars ~as_of ~entry_date symbol =
   |> List.filter ~f:(fun (b : Types.Daily_price.t) ->
       Date.diff b.date entry_date >= 5)
 
-(* Extension gate: requires a real MA reading (populated by the Friday stops
-   pass earlier in the tick); no MA → no add. *)
-let _not_extended ~(sc : Scale_in_detector.config) ~prior_stage_ma_values
-    ~symbol ~close =
+(* Extension gate + trigger dispatch against one MA reading. The gate applies
+   to ALL triggers uniformly; see the extension_max_pct interplay warning in
+   scale_in_detector.mli. *)
+let _gate_and_signal ~(sc : Scale_in_detector.config) ~ma ~close ~entry_price
+    ~bars =
+  (not
+     (Scale_in_detector.extended_above_ma ~max_pct:sc.extension_max_pct ~close
+        ~ma))
+  && Scale_in_detector.add_signal ~trigger:sc.add_trigger
+       ~proximity_pct:sc.pullback_proximity_pct ~consolidation:sc.consolidation
+       ~ma ~entry_price ~bars_since_entry:bars
+
+(* A real MA reading (populated by the Friday stops pass earlier in the tick)
+   is required — no MA → no add. *)
+let _not_extended_and_signalled ~(sc : Scale_in_detector.config)
+    ~prior_stage_ma_values ~symbol ~close ~entry_price ~bars =
   match Hashtbl.find prior_stage_ma_values symbol with
   | None -> false
-  | Some ma ->
-      not
-        (Scale_in_detector.extended_above_ma ~max_pct:sc.extension_max_pct
-           ~close ~ma)
+  | Some ma -> _gate_and_signal ~sc ~ma ~close ~entry_price ~bars
 
 (* Size the add: the remaining risk fraction (1 - initial_entry_fraction) of a
    full unit, capped so aggregate symbol notional (existing sibling + add)
@@ -85,7 +94,11 @@ let _add_sizing ~(config : config) ~portfolio_value ~existing_notional
     ~entry_price ~stop_price =
   let pc = config.portfolio_config in
   let sc = config.scale_in_config in
-  let add_fraction = Float.max 0.0 (1.0 -. sc.initial_entry_fraction) in
+  let add_fraction =
+    match sc.Scale_in_detector.add_fraction with
+    | Some f -> Float.max 0.0 f
+    | None -> Float.max 0.0 (1.0 -. sc.initial_entry_fraction)
+  in
   let cap_left =
     Float.max 0.0
       (pc.Portfolio_risk.max_position_pct_long
@@ -132,10 +145,8 @@ let _signal_and_gates ~(config : config) ~bar_reader ~prior_stages
       ~as_of:current_date ~entry_date symbol
   in
   _stage_admits ~require_not_late:sc.require_not_late ~prior_stages symbol
-  && _not_extended ~sc ~prior_stage_ma_values ~symbol ~close
-  && Scale_in_detector.add_signal ~trigger:sc.add_trigger
-       ~proximity_pct:sc.pullback_proximity_pct ~entry_price
-       ~bars_since_entry:bars
+  && _not_extended_and_signalled ~sc ~prior_stage_ma_values ~symbol ~close
+       ~entry_price ~bars
 
 (* Size a signalled add and build its transition; [None] when sizing collapses
    to zero shares (risk fraction, remaining per-name cap, or price). *)

--- a/trading/trading/weinstein/strategy/test/test_scale_in_detector.ml
+++ b/trading/trading/weinstein/strategy/test/test_scale_in_detector.ml
@@ -7,7 +7,7 @@ open Core
 open Matchers
 open Weinstein_strategy
 
-let _bar date ~close ?low ?high () =
+let _bar date ~close ?low ?high ?(volume = 1_000_000) () =
   let low = Option.value low ~default:(close *. 0.99) in
   let high = Option.value high ~default:(close *. 1.01) in
   {
@@ -17,7 +17,7 @@ let _bar date ~close ?low ?high () =
     low_price = low;
     close_price = close;
     adjusted_close = close;
-    volume = 1_000_000;
+    volume;
     active_through = None;
   }
 
@@ -120,11 +120,99 @@ let test_either_fires_on_new_high_when_pullback_does_not _ =
   in
   let signal trigger =
     Scale_in_detector.add_signal ~trigger ~proximity_pct:0.03
+      ~consolidation:Scale_in_detector.default_consolidation_config ~ma:100.0
       ~entry_price:_entry ~bars_since_entry:bars
   in
   assert_that
     (signal Scale_in_detector.Pullback, signal Scale_in_detector.Either)
     (equal_to (false, true))
+
+(* ------- consolidation_breakout (the book's continuation buy) ------- *)
+
+(* A textbook continuation: 4 tight weeks near the MA (closes 100..103 with
+   ma = 100), then a breakout bar above the window top on 2x volume. *)
+let _consolidation_then_breakout ~breakout_close ~breakout_volume =
+  [
+    _bar "2024-03-01" ~close:102.0 ();
+    _bar "2024-03-08" ~close:100.0 ();
+    _bar "2024-03-15" ~close:103.0 ();
+    _bar "2024-03-22" ~close:101.0 ();
+    _bar "2024-03-29" ~close:breakout_close ~volume:breakout_volume ();
+  ]
+
+let _cont ?(cfg = Scale_in_detector.default_consolidation_config) ?(ma = 100.0)
+    bars =
+  Scale_in_detector.consolidation_breakout ~consolidation:cfg ~ma
+    ~bars_since_entry:bars
+
+let test_consolidation_breakout_fires _ =
+  let bars =
+    _consolidation_then_breakout ~breakout_close:106.0
+      ~breakout_volume:2_000_000
+  in
+  assert_that (_cont bars) (equal_to true)
+
+let test_consolidation_too_wide_band_does_not_fire _ =
+  (* Window ranges 100 -> 115 (15% > 10% band): a trend, not a consolidation. *)
+  let bars =
+    [
+      _bar "2024-03-01" ~close:100.0 ();
+      _bar "2024-03-08" ~close:108.0 ();
+      _bar "2024-03-15" ~close:115.0 ();
+      _bar "2024-03-22" ~close:112.0 ();
+      _bar "2024-03-29" ~close:118.0 ~volume:2_000_000 ();
+    ]
+  in
+  assert_that (_cont bars) (equal_to false)
+
+let test_consolidation_far_above_ma_does_not_fire _ =
+  (* Same tight window, but the MA sits far below (min close 100 > 80 * 1.1):
+     the stock never "dropped back close to its MA". *)
+  let bars =
+    _consolidation_then_breakout ~breakout_close:106.0
+      ~breakout_volume:2_000_000
+  in
+  assert_that (_cont ~ma:80.0 bars) (equal_to false)
+
+let test_consolidation_no_breakout_does_not_fire _ =
+  (* Current close 102.5 stays inside the window (top 103): no breakout. *)
+  let bars =
+    _consolidation_then_breakout ~breakout_close:102.5
+      ~breakout_volume:2_000_000
+  in
+  assert_that (_cont bars) (equal_to false)
+
+let test_consolidation_weak_volume_does_not_fire _ =
+  (* Breakout in price but volume at the window average (< 1.25x). *)
+  let bars =
+    _consolidation_then_breakout ~breakout_close:106.0
+      ~breakout_volume:1_000_000
+  in
+  assert_that (_cont bars) (equal_to false)
+
+let test_consolidation_needs_min_weeks _ =
+  (* Only 3 completed bars before the breakout (< min_weeks 4). *)
+  let bars =
+    [
+      _bar "2024-03-08" ~close:100.0 ();
+      _bar "2024-03-15" ~close:103.0 ();
+      _bar "2024-03-22" ~close:101.0 ();
+      _bar "2024-03-29" ~close:106.0 ~volume:2_000_000 ();
+    ]
+  in
+  assert_that (_cont bars) (equal_to false)
+
+let test_add_signal_dispatches_consolidation_breakout _ =
+  let bars =
+    _consolidation_then_breakout ~breakout_close:106.0
+      ~breakout_volume:2_000_000
+  in
+  assert_that
+    (Scale_in_detector.add_signal
+       ~trigger:Scale_in_detector.Consolidation_breakout ~proximity_pct:0.03
+       ~consolidation:Scale_in_detector.default_consolidation_config ~ma:100.0
+       ~entry_price:_entry ~bars_since_entry:bars)
+    (equal_to true)
 
 (* ------- extension gate ------- *)
 
@@ -151,6 +239,39 @@ let test_config_defaults_are_no_op _ =
          field
            (fun (c : Scale_in_detector.config) -> c.require_not_late)
            (equal_to true);
+         field
+           (fun (c : Scale_in_detector.config) -> c.add_fraction)
+           (equal_to (None : float option));
+         field
+           (fun (c : Scale_in_detector.config) -> c.consolidation)
+           (equal_to Scale_in_detector.default_consolidation_config);
+       ])
+
+let test_v1_config_sexp_parses_with_new_fields_defaulted _ =
+  (* A v1-era scale_in_config sexp (no add_fraction / consolidation fields)
+     must parse with the new knobs at their no-op defaults — recorded specs
+     and the v1 ledger surface replay unchanged (R1). *)
+  let v1_sexp =
+    Sexplib.Sexp.of_string
+      "((initial_entry_fraction 0.5)(add_trigger Either)(extension_max_pct \
+       0.25))"
+  in
+  assert_that
+    (Scale_in_detector.config_of_sexp v1_sexp)
+    (all_of
+       [
+         field
+           (fun (c : Scale_in_detector.config) -> c.add_fraction)
+           (equal_to (None : float option));
+         field
+           (fun (c : Scale_in_detector.config) -> c.consolidation)
+           (equal_to Scale_in_detector.default_consolidation_config);
+         field
+           (fun (c : Scale_in_detector.config) -> c.initial_entry_fraction)
+           (float_equal 0.5);
+         field
+           (fun (c : Scale_in_detector.config) -> c.add_trigger)
+           (equal_to Scale_in_detector.Either);
        ])
 
 let test_strategy_config_omitted_fields_default_off _ =
@@ -192,8 +313,24 @@ let suite =
          >:: test_early_new_high_not_fired_below_prior_high;
          "add_signal: Either catches gap-and-go that Pullback misses"
          >:: test_either_fires_on_new_high_when_pullback_does_not;
+         "consolidation_breakout: fires on tight window + volume breakout"
+         >:: test_consolidation_breakout_fires;
+         "consolidation_breakout: wide band does not fire"
+         >:: test_consolidation_too_wide_band_does_not_fire;
+         "consolidation_breakout: far above MA does not fire"
+         >:: test_consolidation_far_above_ma_does_not_fire;
+         "consolidation_breakout: no breakout does not fire"
+         >:: test_consolidation_no_breakout_does_not_fire;
+         "consolidation_breakout: weak volume does not fire"
+         >:: test_consolidation_weak_volume_does_not_fire;
+         "consolidation_breakout: needs min_weeks window"
+         >:: test_consolidation_needs_min_weeks;
+         "add_signal: dispatches Consolidation_breakout"
+         >:: test_add_signal_dispatches_consolidation_breakout;
          "extension gate thresholds" >:: test_extended_above_ma;
          "config defaults are no-op" >:: test_config_defaults_are_no_op;
+         "v1 config sexp parses with new fields defaulted"
+         >:: test_v1_config_sexp_parses_with_new_fields_defaulted;
          "strategy config round-trips default-off"
          >:: test_strategy_config_omitted_fields_default_off;
        ]

--- a/trading/trading/weinstein/strategy/test/test_scale_in_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_scale_in_runner.ml
@@ -288,6 +288,51 @@ let test_per_name_cap_exhausted_sizes_zero _ =
   let transitions, _ = _run { f with positions; portfolio } in
   assert_that transitions is_empty
 
+(* Rewire the fixture's scale-in knobs (keeps every other gate open). *)
+let _with_scale_in f scale_in_config =
+  { f with config = { f.config with scale_in_config } }
+
+let test_explicit_add_fraction_sizes_full_unit _ =
+  (* v2 shape: full-size initial entries + add_fraction (Some 1.0). PV =
+     100k cash + 10sh x 105 = 101,050. Add risk = 1% x 1.0 x PV = 1010.5;
+     stop distance 10 -> 101 shares @ 105 = $10,605. *)
+  let f = _fixture () in
+  let f =
+    _with_scale_in f
+      {
+        Scale_in_detector.default_config with
+        initial_entry_fraction = 1.0;
+        add_fraction = Some 1.0;
+      }
+  in
+  let transitions, cash = _run f in
+  assert_that cash (float_equal 10605.0);
+  assert_that transitions
+    (elements_are
+       [
+         field
+           (fun (tr : Trading_strategy.Position.transition) -> tr.kind)
+           (matching ~msg:"Expected a full-unit sibling add"
+              (function
+                | Trading_strategy.Position.CreateEntering e ->
+                    Some (e.target_quantity, e.entry_price)
+                | _ -> None)
+              (equal_to (101.0, 105.0)));
+       ])
+
+let test_none_add_fraction_with_full_entries_emits_nothing _ =
+  (* Legacy sizing: add_fraction None derives 1 - initial_entry_fraction = 0
+     -> zero-size add -> no transition (the v1 zero-size-adds coupling the
+     explicit knob exists to fix). *)
+  let f = _fixture () in
+  let f =
+    _with_scale_in f
+      { Scale_in_detector.default_config with initial_entry_fraction = 1.0 }
+  in
+  let transitions, cash = _run f in
+  assert_that cash (float_equal 0.0);
+  assert_that transitions is_empty
+
 let suite =
   "scale_in_runner"
   >::: [
@@ -310,6 +355,10 @@ let suite =
          >:: test_stop_at_or_above_price_blocks_add;
          "per-name cap exhausted sizes to zero"
          >:: test_per_name_cap_exhausted_sizes_zero;
+         "explicit add_fraction sizes a full unit"
+         >:: test_explicit_add_fraction_sizes_full_unit;
+         "None add_fraction with full entries emits nothing"
+         >:: test_none_add_fraction_with_full_entries_emits_nothing;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What it does

Implements the book's actual continuation buy (Ch. 3 §The Trader's Way) as a new default-off add trigger, per `dev/plans/continuation-add-v2-2026-07-04.md` (#1852): price consolidates near the rising 30-week MA, then breaks out anew above the consolidation's top on volume. v1's `Early_new_high` was a proxy invention — this is the trigger that catches gap-and-go names, which never retest the entry but DO reconsolidate mid-run (and per the book, are the grand-slam home runs: <50% of continuation breakouts ever pull back).

- **`Scale_in_detector.Consolidation_breakout`** + nested `consolidation_config` (`min_weeks`/`band_pct`/`ma_proximity_pct`/`volume_ratio_min`). Pure weekly-bar detection: tight window (range ≤ band) sitting near the MA (min close ≤ ma×(1+prox)), current bar closes above the window top on ≥ ratio× the window's average volume. The book gives no numeric thresholds — every field is a `Variant_matrix` axis (R2).
- **`add_fraction : float option`**: `None` (default) = the v1-derived `1 − initial_entry_fraction` (bit-identical backcompat; also why full-size entries currently get zero-size adds); `Some f` sizes adds explicitly. Unblocks the v2 shape: full-size entries + full-size continuation adds (book: buy the *entire* position at a continuation breakout; `max_position_pct_long` aggregate cap remains the ceiling).
- **Runner**: `_add_sizing` honors `add_fraction`; `add_signal` dispatched with the MA reading (single lookup for gate + trigger). `require_not_late` doubles as the book's "MA must be clearly trending higher" gate.
- **Extension-gate interplay documented** (the "Either dead at 0.15" lesson): a consolidation breakout close sits structurally up to ~21% above the MA at defaults — v2 surfaces must set `extension_max_pct ≥ 0.25` (called out in the .mli and the plan; the surface spec will carry it).

## Flag discipline (R1/R2)

Default-off everywhere: `enable_scale_in` unchanged, new fields `[@sexp.default]` no-ops, `add_trigger` default stays `Pullback`. v1-era `scale_in_config` sexps (no new fields) parse with new knobs defaulted — pinned by test. No golden churn.

## Test plan (TDD)

Detector (19 tests, 7 new): fires on tight-window + volume breakout; wide band / far-above-MA / no-breakout / weak-volume / short-window each blocked; `add_signal` dispatch. Config: defaults no-op (incl. `add_fraction None` + default consolidation), v1-sexp backcompat parse.
Runner (15 tests, 2 new): explicit `add_fraction (Some 1.0)` sizes a full unit (101 sh @ 105 on the fixture); `None` + full-size entries emits nothing (the v1 coupling).

Verified in-container: `dune build @fmt` / `dune build` / both scale-in suites (OK) / `devtools/checks` linters clean (incl. nesting, after extracting `_gate_and_signal`). Pre-existing local-env ad_bars "real data" failures (missing breadth fixtures; CI provisions) are unrelated.

## Next (separate)

Surface spec + broad-only WF-CV (top-3000, 13×2y folds) + ledger verdict per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)