### PR TITLE
experiment(scale-in): continuation-add v2 surface spec (broad-only)

### DIFF
--- a/dev/experiments/continuation-add-v2-2026-07-05/STATUS.md
+++ b/dev/experiments/continuation-add-v2-2026-07-05/STATUS.md
@@ -1,0 +1,17 @@
+# Continuation-add v2 surface — STATUS
+
+- **Mechanism:** merged default-off (#1855; plan #1852). REJECT of scale-in v1
+  and its WHYs unaffected — this is the untested full-size+continuation-add
+  shape with the book's actual trigger.
+- **State: READY TO RUN, launch BLOCKED on Docker.raw recompact** (55 GB >
+  30 GB sweep-hygiene preflight; user GUI action). Est. runtime ~8–12 h
+  (13 folds × 4 variants, top-3000 snapshot mode, fork-per-fold).
+- **Launch:** `walk_forward` runner with `spec_top3000.sexp`, snapshot dir
+  `wfcv-top3000-1998`, `--parallel 1`, out-dir under `/tmp/sweeps/` per
+  sweep-hygiene. Nothing else on the container.
+- **First-fold sanity before the full run:** instrument or audit-diff one
+  fold to confirm continuation adds actually emit AND fill (the #1846
+  measurement lesson); verify trades.csv sibling rows look sane (post-#1847
+  pairing).
+- **Verdict:** to the ledger either way, with WHYs (mechanism-validation
+  rigor). No promotion without ACCEPT + confirmation grid.

--- a/dev/experiments/continuation-add-v2-2026-07-05/base_top3000.sexp
+++ b/dev/experiments/continuation-add-v2-2026-07-05/base_top3000.sexp
@@ -1,0 +1,27 @@
+;; BROAD deep long-only base for the continuation-add v2 surface — top-3000-2000 PIT,
+;; 2000-2026, catstop ON, PRODUCTION caps (0.30/0.70/0.30). Mirror of
+;; goldens-sp500-historical/top3000-2000-2026-catstop.sexp with concentration at
+;; the production default (0.30, #1753) since scale-in adds cap at
+;; max_position_pct_long. Broad is the DECISIVE cell for this mechanism (the
+;; capacity bottleneck + gap-and-go monsters live on breadth; sp500 risks a
+;; false null per the 2026-06-25 correction + declining-MA breadth lesson).
+((name "continuation-add-v2-base-top3000")
+ (description "BROAD deep long-only + catstop base for the continuation-add v2 WF-CV (top-3000-2000 PIT, production caps).")
+ (period ((start_date 2000-01-01) (end_date 2026-04-30)))
+ (universe_path "../goldens-custom-universe/composition/top-3000-2000.sexp")
+ (universe_size 3000)
+ (config_overrides
+  (((enable_short_side false))
+   ((stops_config ((catastrophic_stop_pct 0.10))))
+   ((portfolio_config ((max_position_pct_long 0.30))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected ((total_return_pct ((min -90.0) (max 90000.0))) (total_trades ((min 1) (max 90000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))

--- a/dev/experiments/continuation-add-v2-2026-07-05/spec_top3000.sexp
+++ b/dev/experiments/continuation-add-v2-2026-07-05/spec_top3000.sexp
@@ -1,0 +1,32 @@
+;; Continuation-add v2 WF-CV surface — BROAD-ONLY (top-3000 is the decisive
+;; cell; NO sp500 cell per user directive 2026-07-04). Plan:
+;; dev/plans/continuation-add-v2-2026-07-04.md (#1852); mechanism #1855.
+;;
+;; The shape under test: FULL-size initial entries + FULL-size continuation
+;; adds (the book's Ch. 3 continuation buy) — the un-taxed press-the-winner
+;; half of scale-in. extension_max_pct 0.25 is REQUIRED (consolidation
+;; breakout closes sit up to ~22% above the 30w MA; 0.15 kills the trigger —
+;; the "Either dead at 0.15" hazard, see scale_in_detector.mli).
+;;
+;; Run with --snapshot-dir /workspaces/trading-1/dev/data/snapshots/wfcv-top3000-1998
+;; + --parallel 1 (fork-per-fold; N=3000 memory). PRE-FLIGHT: sweep-hygiene
+;; checklist (Docker.raw < 30 GB — recompact first; 55 GB as of 2026-07-04).
+;; Instrument add flow (emit/funded/filled) on the first fold before trusting
+;; conclusions — the #1846 lesson. trades.csv is trustworthy post-#1847.
+((base_scenario "/workspaces/trading-1/dev/experiments/continuation-add-v2-2026-07-05/base_top3000.sexp")
+ (window_spec
+  (Rolling
+   ((start_date 2000-01-01)(end_date 2026-04-30)(train_days 0)(test_days 730)(step_days 730))))
+ (variants
+  (((label "baseline") (overrides ()))
+   ((label "cont_add")
+    (overrides (((enable_scale_in true))
+                ((scale_in_config ((initial_entry_fraction 1.0)(add_fraction (1.0))(add_trigger Consolidation_breakout)(extension_max_pct 0.25)))))))
+   ((label "cont_add_tight")
+    (overrides (((enable_scale_in true))
+                ((scale_in_config ((initial_entry_fraction 1.0)(add_fraction (1.0))(add_trigger Consolidation_breakout)(extension_max_pct 0.25)(consolidation ((band_pct 0.06)))))))))
+   ((label "cont_add_vol")
+    (overrides (((enable_scale_in true))
+                ((scale_in_config ((initial_entry_fraction 1.0)(add_fraction (1.0))(add_trigger Consolidation_breakout)(extension_max_pct 0.25)(consolidation ((volume_ratio_min 1.5)))))))))))
+ (baseline_label "baseline")
+ (gate ((metric Sharpe)(m 7)(n 13)(worst_delta 0.30))))


### PR DESCRIPTION
Surface inputs for the continuation-add v2 WF-CV (plan #1852, mechanism #1855): top-3000 base (mirror of the v1 broad base) + 4-variant spec (baseline / cont_add / cont_add_tight / cont_add_vol), all full-size entries + full-size continuation adds at `extension_max_pct 0.25` (the documented gate requirement). Broad-only — no sp500 cell per user directive.

Launch deliberately deferred: sweep-hygiene preflight requires Docker.raw < 30 GB (currently 55 GB; user GUI recompact), est. runtime 8–12 h. STATUS.md carries the launch checklist incl. first-fold add-flow sanity check (the #1846 measurement lesson).

Docs/experiment-inputs-only PR: CI gate only, QC skipped (per #1840 precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)