### PR TITLE
docs(experiments): envelope knobs are dead code — P0 pair-sweep cancelled

### DIFF
--- a/dev/experiments/envelope-knob-liveness-2026-07-05/bull/comparison.md
+++ b/dev/experiments/envelope-knob-liveness-2026-07-05/bull/comparison.md
@@ -1,0 +1,92 @@
+# Backtest comparison
+
+- Date range: 2019-06-01 .. 2019-12-31
+- Universe size: 500 (baseline) / 500 (variant)
+- Initial cash: $1000000.00
+- Final portfolio value: $1131817.10 (baseline) / $1131817.10 (variant), delta = $0.00
+- Round-trips: 7 (baseline) / 7 (variant), delta = 0
+
+## Metric diffs
+
+| Metric | Baseline | Variant | Delta |
+|---|---|---|---|
+| total_pnl | -59830.1400 | -59830.1400 | 0.0000 |
+| avg_holding_days | 40.2857 | 40.2857 | 0.0000 |
+| win_count | 0.0000 | 0.0000 | 0.0000 |
+| loss_count | 7.0000 | 7.0000 | 0.0000 |
+| win_rate | 0.0000 | 0.0000 | 0.0000 |
+| sharpe_ratio | 1.7674 | 1.7674 | 0.0000 |
+| max_drawdown | 5.6084 | 5.6084 | 0.0000 |
+| profit_factor | 0.0000 | 0.0000 | 0.0000 |
+| cagr | 23.6559 | 23.6559 | 0.0000 |
+| calmar_ratio | 4.2179 | 4.2179 | 0.0000 |
+| open_position_count | 8.0000 | 8.0000 | 0.0000 |
+| open_positions_value | 1115426.3700 | 1115426.3700 | 0.0000 |
+| unrealized_pnl | 192094.3200 | 192094.3200 | 0.0000 |
+| trade_frequency | 1.5832 | 1.5832 | 0.0000 |
+| total_return_pct | 13.1817 | 13.1817 | 0.0000 |
+| volatility_pct_annualized | 8.9584 | 8.9584 | 0.0000 |
+| downside_deviation_pct_annualized | 5.8482 | 5.8482 | 0.0000 |
+| best_day_pct | 2.1535 | 2.1535 | 0.0000 |
+| worst_day_pct | -3.1630 | -3.1630 | 0.0000 |
+| best_week_pct | 3.0726 | 3.0726 | 0.0000 |
+| worst_week_pct | -3.8064 | -3.8064 | 0.0000 |
+| best_month_pct | 7.3109 | 7.3109 | 0.0000 |
+| worst_month_pct | -2.3921 | -2.3921 | 0.0000 |
+| best_quarter_pct | 10.5378 | 10.5378 | 0.0000 |
+| worst_quarter_pct | 0.0000 | 0.0000 | 0.0000 |
+| best_year_pct | 13.1817 | 13.1817 | 0.0000 |
+| worst_year_pct | 0.0000 | 0.0000 | 0.0000 |
+| num_trades | 7.0000 | 7.0000 | 0.0000 |
+| loss_rate | 100.0000 | 100.0000 | 0.0000 |
+| avg_win_dollar | 0.0000 | 0.0000 | 0.0000 |
+| avg_win_pct | 0.0000 | 0.0000 | 0.0000 |
+| avg_loss_dollar | -8547.1629 | -8547.1629 | 0.0000 |
+| avg_loss_pct | -7.4316 | -7.4316 | 0.0000 |
+| largest_win_dollar | 0.0000 | 0.0000 | 0.0000 |
+| largest_loss_dollar | -12842.8200 | -12842.8200 | 0.0000 |
+| avg_trade_size_dollar | 156360.3071 | 156360.3071 | 0.0000 |
+| avg_trade_size_pct | 15.6360 | 15.6360 | 0.0000 |
+| avg_holding_days_winners | 0.0000 | 0.0000 | 0.0000 |
+| avg_holding_days_losers | 40.2857 | 40.2857 | 0.0000 |
+| expectancy | -8547.1629 | -8547.1629 | 0.0000 |
+| win_loss_ratio | 0.0000 | 0.0000 | 0.0000 |
+| max_consecutive_wins | 0.0000 | 0.0000 | 0.0000 |
+| max_consecutive_losses | 7.0000 | 7.0000 | 0.0000 |
+| sortino_ratio_annualized | 1.9295 | 1.9295 | 0.0000 |
+| mar_ratio | 2.0120 | 2.0120 | 0.0000 |
+| omega_ratio | 1.3273 | 1.3273 | 0.0000 |
+| avg_drawdown_pct | 1.5820 | 1.5820 | 0.0000 |
+| median_drawdown_pct | 0.8843 | 0.8843 | 0.0000 |
+| max_drawdown_duration_days | 83.0000 | 83.0000 | 0.0000 |
+| avg_drawdown_duration_days | 14.1667 | 14.1667 | 0.0000 |
+| time_in_drawdown_pct | 38.0623 | 38.0623 | 0.0000 |
+| ulcer_index | 1.5881 | 1.5881 | 0.0000 |
+| pain_index | 0.8376 | 0.8376 | 0.0000 |
+| underwater_curve_area | 242.0538 | 242.0538 | 0.0000 |
+| skewness | -0.6249 | -0.6249 | 0.0000 |
+| kurtosis | 5.2328 | 5.2328 | 0.0000 |
+| cvar_95 | -1.4314 | -1.4314 | 0.0000 |
+| cvar_99 | -2.5742 | -2.5742 | 0.0000 |
+| tail_ratio | 0.9223 | 0.9223 | 0.0000 |
+| gain_to_pain | 1.3273 | 1.3273 | 0.0000 |
+| concavity_coef | 0.0000 | 0.0000 | 0.0000 |
+| bucket_asymmetry | 0.0000 | 0.0000 | 0.0000 |
+| benchmark_alpha_pct_annualized | 0.0000 | 0.0000 | 0.0000 |
+| benchmark_beta | 0.0000 | 0.0000 | 0.0000 |
+| tracking_error_pct_annualized | 0.0000 | 0.0000 | 0.0000 |
+| information_ratio | 0.0000 | 0.0000 | 0.0000 |
+| correlation_to_benchmark | 0.0000 | 0.0000 | 0.0000 |
+| rolling_sharpe_stability | 0.9490 | 0.9490 | 0.0000 |
+| trade_frequency_annualized | 6.0443 | 6.0443 | 0.0000 |
+| position_turnover | 0.0105 | 0.0105 | 0.0000 |
+| position_concentration_hhi | 0.1902 | 0.1902 | 0.0000 |
+
+## Scalar diffs
+
+| Field | Delta (variant - baseline) |
+|---|---|
+| final_portfolio_value | 0.0000 |
+| n_round_trips | 0.0000 |
+| n_steps | 0.0000 |
+

--- a/dev/experiments/envelope-knob-liveness-2026-07-05/crash/comparison.md
+++ b/dev/experiments/envelope-knob-liveness-2026-07-05/crash/comparison.md
@@ -1,0 +1,92 @@
+# Backtest comparison
+
+- Date range: 2020-01-02 .. 2020-06-30
+- Universe size: 500 (baseline) / 500 (variant)
+- Initial cash: $1000000.00
+- Final portfolio value: $958946.21 (baseline) / $958946.21 (variant), delta = $0.00
+- Round-trips: 20 (baseline) / 20 (variant), delta = 0
+
+## Metric diffs
+
+| Metric | Baseline | Variant | Delta |
+|---|---|---|---|
+| total_pnl | -137573.6400 | -137573.6400 | 0.0000 |
+| avg_holding_days | 20.5000 | 20.5000 | 0.0000 |
+| win_count | 2.0000 | 2.0000 | 0.0000 |
+| loss_count | 18.0000 | 18.0000 | 0.0000 |
+| win_rate | 10.0000 | 10.0000 | 0.0000 |
+| sharpe_ratio | -0.2788 | -0.2788 | 0.0000 |
+| max_drawdown | 20.6171 | 20.6171 | 0.0000 |
+| profit_factor | 0.1585 | 0.1585 | 0.0000 |
+| cagr | -8.1546 | -8.1546 | 0.0000 |
+| calmar_ratio | -0.3955 | -0.3955 | 0.0000 |
+| open_position_count | 7.0000 | 7.0000 | 0.0000 |
+| open_positions_value | 897616.9800 | 897616.9800 | 0.0000 |
+| unrealized_pnl | 97682.3500 | 97682.3500 | 0.0000 |
+| trade_frequency | 3.6684 | 3.6684 | 0.0000 |
+| total_return_pct | -4.1054 | -4.1054 | 0.0000 |
+| volatility_pct_annualized | 14.9341 | 14.9341 | 0.0000 |
+| downside_deviation_pct_annualized | 10.8226 | 10.8226 | 0.0000 |
+| best_day_pct | 3.6039 | 3.6039 | 0.0000 |
+| worst_day_pct | -3.8989 | -3.8989 | 0.0000 |
+| best_week_pct | 5.8555 | 5.8555 | 0.0000 |
+| worst_week_pct | -10.4208 | -10.4208 | 0.0000 |
+| best_month_pct | 2.9138 | 2.9138 | 0.0000 |
+| worst_month_pct | -6.8507 | -6.8507 | 0.0000 |
+| best_quarter_pct | 6.9032 | 6.9032 | 0.0000 |
+| worst_quarter_pct | -10.2977 | -10.2977 | 0.0000 |
+| best_year_pct | 0.0000 | 0.0000 | 0.0000 |
+| worst_year_pct | -4.1054 | -4.1054 | 0.0000 |
+| num_trades | 20.0000 | 20.0000 | 0.0000 |
+| loss_rate | 90.0000 | 90.0000 | 0.0000 |
+| avg_win_dollar | 12958.8400 | 12958.8400 | 0.0000 |
+| avg_win_pct | 5.1557 | 5.1557 | 0.0000 |
+| avg_loss_dollar | -9082.8511 | -9082.8511 | 0.0000 |
+| avg_loss_pct | -6.9824 | -6.9824 | 0.0000 |
+| largest_win_dollar | 23157.6800 | 23157.6800 | 0.0000 |
+| largest_loss_dollar | -22157.4500 | -22157.4500 | 0.0000 |
+| avg_trade_size_dollar | 174802.9800 | 174802.9800 | 0.0000 |
+| avg_trade_size_pct | 17.4803 | 17.4803 | 0.0000 |
+| avg_holding_days_winners | 5.0000 | 5.0000 | 0.0000 |
+| avg_holding_days_losers | 22.2222 | 22.2222 | 0.0000 |
+| expectancy | -6878.6820 | -6878.6820 | 0.0000 |
+| win_loss_ratio | 1.4267 | 1.4267 | 0.0000 |
+| max_consecutive_wins | 1.0000 | 1.0000 | 0.0000 |
+| max_consecutive_losses | 15.0000 | 15.0000 | 0.0000 |
+| sortino_ratio_annualized | -0.3557 | -0.3557 | 0.0000 |
+| mar_ratio | -0.1867 | -0.1867 | 0.0000 |
+| omega_ratio | 0.9540 | 0.9540 | 0.0000 |
+| avg_drawdown_pct | 3.6143 | 3.6143 | 0.0000 |
+| median_drawdown_pct | 0.6548 | 0.6548 | 0.0000 |
+| max_drawdown_duration_days | 131.0000 | 131.0000 | 0.0000 |
+| avg_drawdown_duration_days | 23.2857 | 23.2857 | 0.0000 |
+| time_in_drawdown_pct | 38.6617 | 38.6617 | 0.0000 |
+| ulcer_index | 9.0841 | 9.0841 | 0.0000 |
+| pain_index | 5.1429 | 5.1429 | 0.0000 |
+| underwater_curve_area | 1383.4372 | 1383.4372 | 0.0000 |
+| skewness | -0.7606 | -0.7606 | 0.0000 |
+| kurtosis | 5.3865 | 5.3865 | 0.0000 |
+| cvar_95 | -2.8284 | -2.8284 | 0.0000 |
+| cvar_99 | -3.8812 | -3.8812 | 0.0000 |
+| tail_ratio | 0.7697 | 0.7697 | 0.0000 |
+| gain_to_pain | 0.9540 | 0.9540 | 0.0000 |
+| concavity_coef | 0.0000 | 0.0000 | 0.0000 |
+| bucket_asymmetry | 0.0000 | 0.0000 | 0.0000 |
+| benchmark_alpha_pct_annualized | 0.0000 | 0.0000 | 0.0000 |
+| benchmark_beta | 0.0000 | 0.0000 | 0.0000 |
+| tracking_error_pct_annualized | 0.0000 | 0.0000 | 0.0000 |
+| information_ratio | 0.0000 | 0.0000 | 0.0000 |
+| correlation_to_benchmark | 0.0000 | 0.0000 | 0.0000 |
+| rolling_sharpe_stability | 1.1638 | 1.1638 | 0.0000 |
+| trade_frequency_annualized | 18.7308 | 18.7308 | 0.0000 |
+| position_turnover | 0.0296 | 0.0296 | 0.0000 |
+| position_concentration_hhi | 0.3793 | 0.3793 | 0.0000 |
+
+## Scalar diffs
+
+| Field | Delta (variant - baseline) |
+|---|---|
+| final_portfolio_value | 0.0000 |
+| n_round_trips | 0.0000 |
+| n_steps | 0.0000 |
+

--- a/dev/experiments/envelope-knob-liveness-2026-07-05/recovery/comparison.md
+++ b/dev/experiments/envelope-knob-liveness-2026-07-05/recovery/comparison.md
@@ -1,0 +1,92 @@
+# Backtest comparison
+
+- Date range: 2023-01-02 .. 2023-12-31
+- Universe size: 500 (baseline) / 500 (variant)
+- Initial cash: $1000000.00
+- Final portfolio value: $1092696.09 (baseline) / $1092696.09 (variant), delta = $0.00
+- Round-trips: 31 (baseline) / 31 (variant), delta = 0
+
+## Metric diffs
+
+| Metric | Baseline | Variant | Delta |
+|---|---|---|---|
+| total_pnl | -130023.8450 | -130023.8450 | 0.0000 |
+| avg_holding_days | 45.2581 | 45.2581 | 0.0000 |
+| win_count | 5.0000 | 5.0000 | 0.0000 |
+| loss_count | 26.0000 | 26.0000 | 0.0000 |
+| win_rate | 16.1290 | 16.1290 | 0.0000 |
+| sharpe_ratio | 0.5854 | 0.5854 | 0.0000 |
+| max_drawdown | 14.5900 | 14.5900 | 0.0000 |
+| profit_factor | 0.1471 | 0.1471 | 0.0000 |
+| cagr | 9.3297 | 9.3297 | 0.0000 |
+| calmar_ratio | 0.6395 | 0.6395 | 0.0000 |
+| open_position_count | 7.0000 | 7.0000 | 0.0000 |
+| open_positions_value | 967976.3400 | 967976.3400 | 0.0000 |
+| unrealized_pnl | 223645.3150 | 223645.3150 | 0.0000 |
+| trade_frequency | 3.6655 | 3.6655 | 0.0000 |
+| total_return_pct | 9.2696 | 9.2696 | 0.0000 |
+| volatility_pct_annualized | 14.4244 | 14.4244 | 0.0000 |
+| downside_deviation_pct_annualized | 8.9659 | 8.9659 | 0.0000 |
+| best_day_pct | 3.2143 | 3.2143 | 0.0000 |
+| worst_day_pct | -3.1952 | -3.1952 | 0.0000 |
+| best_week_pct | 7.9364 | 7.9364 | 0.0000 |
+| worst_week_pct | -5.8937 | -5.8937 | 0.0000 |
+| best_month_pct | 12.4175 | 12.4175 | 0.0000 |
+| worst_month_pct | -6.7687 | -6.7687 | 0.0000 |
+| best_quarter_pct | 6.4988 | 6.4988 | 0.0000 |
+| worst_quarter_pct | -0.2684 | -0.2684 | 0.0000 |
+| best_year_pct | 9.2696 | 9.2696 | 0.0000 |
+| worst_year_pct | 0.0000 | 0.0000 | 0.0000 |
+| num_trades | 31.0000 | 31.0000 | 0.0000 |
+| loss_rate | 83.8710 | 83.8710 | 0.0000 |
+| avg_win_dollar | 4485.1670 | 4485.1670 | 0.0000 |
+| avg_win_pct | 6.0413 | 6.0413 | 0.0000 |
+| avg_loss_dollar | -5863.4492 | -5863.4492 | 0.0000 |
+| avg_loss_pct | -6.2699 | -6.2699 | 0.0000 |
+| largest_win_dollar | 17622.2550 | 17622.2550 | 0.0000 |
+| largest_loss_dollar | -15212.8400 | -15212.8400 | 0.0000 |
+| avg_trade_size_dollar | 101970.6027 | 101970.6027 | 0.0000 |
+| avg_trade_size_pct | 10.1971 | 10.1971 | 0.0000 |
+| avg_holding_days_winners | 116.8000 | 116.8000 | 0.0000 |
+| avg_holding_days_losers | 31.5000 | 31.5000 | 0.0000 |
+| expectancy | -4194.3176 | -4194.3176 | 0.0000 |
+| win_loss_ratio | 0.7649 | 0.7649 | 0.0000 |
+| max_consecutive_wins | 2.0000 | 2.0000 | 0.0000 |
+| max_consecutive_losses | 9.0000 | 9.0000 | 0.0000 |
+| sortino_ratio_annualized | 0.6484 | 0.6484 | 0.0000 |
+| mar_ratio | 0.3985 | 0.3985 | 0.0000 |
+| omega_ratio | 1.0995 | 1.0995 | 0.0000 |
+| avg_drawdown_pct | 4.1559 | 4.1559 | 0.0000 |
+| median_drawdown_pct | 2.2485 | 2.2485 | 0.0000 |
+| max_drawdown_duration_days | 161.0000 | 161.0000 | 0.0000 |
+| avg_drawdown_duration_days | 43.6250 | 43.6250 | 0.0000 |
+| time_in_drawdown_pct | 59.4937 | 59.4937 | 0.0000 |
+| ulcer_index | 5.5272 | 5.5272 | 0.0000 |
+| pain_index | 3.8279 | 3.8279 | 0.0000 |
+| underwater_curve_area | 1512.0218 | 1512.0218 | 0.0000 |
+| skewness | -0.0004 | -0.0004 | 0.0000 |
+| kurtosis | 2.2596 | 2.2596 | 0.0000 |
+| cvar_95 | -2.2344 | -2.2344 | 0.0000 |
+| cvar_99 | -3.0997 | -3.0997 | 0.0000 |
+| tail_ratio | 1.0016 | 1.0016 | 0.0000 |
+| gain_to_pain | 1.0995 | 1.0995 | 0.0000 |
+| concavity_coef | 0.0000 | 0.0000 | 0.0000 |
+| bucket_asymmetry | 0.0000 | 0.0000 | 0.0000 |
+| benchmark_alpha_pct_annualized | 0.0000 | 0.0000 | 0.0000 |
+| benchmark_beta | 0.0000 | 0.0000 | 0.0000 |
+| tracking_error_pct_annualized | 0.0000 | 0.0000 | 0.0000 |
+| information_ratio | 0.0000 | 0.0000 | 0.0000 |
+| correlation_to_benchmark | 0.0000 | 0.0000 | 0.0000 |
+| rolling_sharpe_stability | 0.7797 | 0.7797 | 0.0000 |
+| trade_frequency_annualized | 19.7605 | 19.7605 | 0.0000 |
+| position_turnover | 0.0176 | 0.0176 | 0.0000 |
+| position_concentration_hhi | 0.1546 | 0.1546 | 0.0000 |
+
+## Scalar diffs
+
+| Field | Delta (variant - baseline) |
+|---|---|
+| final_portfolio_value | 0.0000 |
+| n_round_trips | 0.0000 |
+| n_steps | 0.0000 |
+

--- a/dev/notes/envelope-knobs-dead-2026-07-05.md
+++ b/dev/notes/envelope-knobs-dead-2026-07-05.md
@@ -1,0 +1,97 @@
+# Envelope knobs are dead code — P0 pair-sweep cancelled (2026-07-05)
+
+**TL;DR:** The planned P0 experiment (min_cash_pct × max_long_exposure_pct
+coupled pair-sweep, `next-session-priorities-2026-07-06.md`) is **invalid**.
+Both knobs are dead in the simulation path. The backtest already runs at
+**89–99% deployment** — there is no 70% envelope ceiling to loosen. The sweep
+would have produced 9 bit-identical cells and burned ~9h (the #1051
+inert-sweep class). Cancelled before launch.
+
+## The code trace (decisive)
+
+- `Portfolio_risk.min_cash_pct` — sole consumer is
+  `Portfolio_risk.check_limits` (`_check_cash`, portfolio_risk.ml:337).
+  `check_limits` has **zero callers** outside tests (verified: grep over
+  `trading/` + `analysis/`, all `.ml`, non-test → empty). The `.mli` already
+  says so: *"Deprecated as of 2026-05-01: never wired into the entry walk."*
+- `Portfolio_risk.max_long_exposure_pct` — two consumers:
+  1. `compute_position_size` (portfolio_risk.ml:204): **per-position**
+     `min(side_exposure_cap, position_cap)`. With production values
+     (0.70 exposure vs 0.30 `max_position_pct_long`) the per-position cap
+     always binds → inert for any value ≥ 0.30. This is the mechanical root
+     of the 2026-06-25 ledger finding "exposure {0.70,0.90} bit-identical"
+     (`2026-06-25-capacity-concentration-surface.sexp`) — recorded then as
+     "never binds", actually "not an aggregate cap at all".
+  2. `check_limits._check_exposure` — the only *aggregate* exposure check;
+     dead (no callers).
+- **Bonus finding:** the entire `check_limits` battery is unwired —
+  `max_positions`, `min_cash_pct`, aggregate long/short exposure, sector
+  *count* caps. Live entry-path gates are only: remaining-cash walk
+  (`weinstein_strategy_screening.ml` seeds `remaining_cash = portfolio.cash`
+  — the full balance, no reserve), per-position sizing caps
+  (`compute_position_size`), short-notional cap, and the opt-in
+  `max_sector_exposure_pct` dollar gate. Portfolio-level cash floor is
+  absolute-dollar *solvency* (`Portfolio_cash_floor`), not a percentage
+  reserve.
+
+## The empirical confirm (11 minutes, the #1846 lesson applied)
+
+`backtest_runner --smoke --csv-mode --baseline` with variant override
+`portfolio_config.min_cash_pct=0.90` (absurd: if live, blocks nearly all
+entries; baseline default 0.10). Artifacts:
+`dev/experiments/envelope-knob-liveness-2026-07-05/`.
+
+| Window | Baseline vs variant | Deployment at end (baseline) |
+|---|---|---|
+| bull 2019H2 | bit-identical (Δ=0 on every metric) | $1,115,426 / $1,131,817 = **98.6%** |
+| crash 2020H1 | bit-identical | 93.6% |
+| recovery 2023 | bit-identical | 88.6% |
+
+Variant `params.sexp` confirms the override was applied (`min_cash_pct 0.90`)
+— not an override-plumbing no-op.
+
+## What this corrects
+
+- **`next-session-priorities-2026-07-06.md` P0** — premise "the binding cash
+  constraint (min_cash_pct 0.30 / max_long_exposure_pct 0.70 — the same 70%
+  ceiling from both sides)" is false. The binding constraint is **cash itself
+  at ~full deployment**. The `Insufficient_cash` skips (~10/Friday) happen at
+  ~0% reserve, not at a 30% floor.
+- **`project_capital_mgmt_scale_in_design` memory** — same claim ("≤70%
+  invested, forces the cash-skips") corrected.
+- **Base scenario fixtures** — the "production caps" overrides
+  `((portfolio_config ((max_long_exposure_pct 0.70))))` and
+  `((portfolio_config ((min_cash_pct 0.30))))` carried by
+  `goldens-sp500-historical/*` and experiment bases are **inert decoration**.
+  Left in place (removing them changes nothing and churns fixtures), but do
+  not read them as behavior.
+
+## Implications (the transferable why)
+
+1. **The envelope cannot be loosened** — it is already ~100%. The only true
+   expansion is margin/leverage, a structural + faithfulness question, not a
+   knob. Therefore the stated precondition for ever revisiting
+   continuation-adds ("pair with an envelope change") is **unsatisfiable in
+   the current architecture** — the v2 REJECT's WHY #4 (adds financed by
+   displaced entries) is structural and final. Scale-in program stays closed.
+2. **The only buildable envelope experiment is tightening** — a *working*
+   cash-reserve mechanism (default-off, new flag per
+   `experiment-flag-discipline.md`) testing whether holding 10–30% reserve
+   buys enough DD/dispersion relief to justify the return cost. The fat-tail
+   law predicts it's a breadth tax; measuring it would price "how valuable is
+   the marginal entry" directly. Not obviously worth 9h of broad WF-CV —
+   decision item, not a default next step.
+3. **Decision item (needs human/review approval per CLAUDE.md core-module
+   rule):** wire or delete `check_limits`. A limits API that looks load-bearing
+   but is test-only invited this wrong premise twice (the 06-25 misread +
+   this P0). Deleting the dead fields (or wiring them for real) removes the
+   trap. Cross-module change — propose, don't bundle.
+
+## Process note
+
+Cost of the wrong premise: one merged priorities doc + one memory claim.
+Caught by tracing consumers before authoring the spec (~30 min) + an 11-min
+smoke A/B — vs ~9h of bit-identical sweep. The check that caught it
+generalizes: **before sweeping any knob, grep its consumers to the actual
+call site in the sim path** — `.mli` deprecation notes and ledger
+"inert/bit-identical" rows are the smoke; a dead knob is the fire.

--- a/dev/notes/next-session-priorities-2026-07-06.md
+++ b/dev/notes/next-session-priorities-2026-07-06.md
@@ -31,18 +31,24 @@ capital-reallocation variants** (v1, v2, harvest-rotate, laggard-cap,
 macro-trim all dead — the class is exhausted). Mechanisms stay merged,
 default-off, searchable.
 
-## P0 candidate — the envelope pair-sweep (the one reallocation lever never tested)
+## ~~P0 candidate — the envelope pair-sweep~~ — CANCELLED 2026-07-05 (premise false)
 
-Every reallocation rejection shares one root cause: the binding cash
-constraint (`min_cash_pct 0.30` / `max_long_exposure_pct 0.70` — the same 70%
-ceiling from both sides). This pair has NEVER been swept together (single-knob
-sweeps read "inert" because the other side binds —
-`project_capital_mgmt_scale_in_design` §two-orthogonal-levers). A 2-axis
-surface (e.g. min_cash {0.30, 0.20, 0.10} × max_exposure {0.70, 0.80, 0.90},
-coupled cells only) answers whether the strategy is capacity-starved — and is
-the stated precondition for ever revisiting continuation adds. Bear-fold risk
-is the obvious cost; the 13-fold WF-CV prices exactly that. ~9h broad run,
-preflight now clear.
+**Both knobs are dead code in the sim path** — see
+`dev/notes/envelope-knobs-dead-2026-07-05.md`. `min_cash_pct` is consumed only
+by the never-called `check_limits`; `max_long_exposure_pct` is per-position
+min()'d (0.70 vs 0.30 per-position cap → never binds) and its aggregate check
+is also only in `check_limits`. Smoke A/B with `min_cash_pct=0.90` =
+bit-identical on all 3 windows; actual deployment is 89–99% invested. There is
+no 70% ceiling — the sweep would have been 9 bit-identical cells (~9h wasted).
+
+Consequences: the envelope cannot be *loosened* (already ~100%; only margin
+would expand it) → the precondition for revisiting continuation adds is
+unsatisfiable in the current architecture → scale-in stays closed. The only
+buildable envelope experiment is a *tightening* mechanism (working cash-reserve
+flag, default-off) — likely a breadth tax; decision item, not a default next
+step. Also decision item: wire or delete the dead `check_limits` battery
+(`max_positions`, `min_cash_pct`, aggregate exposure, sector counts all
+unwired).
 
 ## Other open threads (carried)
 


### PR DESCRIPTION
## What

Cancels the `next-session-priorities-2026-07-06.md` P0 (min_cash × max_exposure envelope pair-sweep) **before launch**: both knobs are dead code in the sim path. Adds the writeup + smoke evidence, amends the priorities doc.

## The finding

- `Portfolio_risk.check_limits` has **zero production callers** (test-only) → `min_cash_pct`, `max_positions`, aggregate exposure, sector-count caps all unwired. The `.mli` even marks `min_cash_pct` deprecated/never-wired.
- `max_long_exposure_pct`'s only live use is **per-position** `min()` vs `max_position_pct_long` (0.70 vs 0.30 → never binds). The 2026-06-25 ledger's "exposure {0.70,0.90} bit-identical" was this, misread as "never binds" rather than "not an aggregate cap".
- Empirical confirm (11-min smoke A/B, `--override portfolio_config.min_cash_pct=0.90` vs default 0.10): **bit-identical on all 3 windows**; actual deployment 89–99% invested (bull 2019H2: 98.6%). Artifacts in `dev/experiments/envelope-knob-liveness-2026-07-05/`.

## Consequences

- No 70% ceiling exists → sweep would have been 9 bit-identical cells (~9h wasted, #1051 class).
- Envelope cannot be loosened (already ~100%); only margin expands it → continuation-add revisit precondition unsatisfiable → **scale-in stays closed**.
- Decision items (not executed here): wire-or-delete `check_limits`; optional default-off cash-reserve *tightening* experiment.

Docs-only PR (dev/notes + dev/experiments .md artifacts) — QC gates skipped per `pr-merge-gates.md`, CI required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)