### PR TITLE
feat(screener): lift early-Stage2 ≤4-week window into config knob

### DIFF
--- a/trading/analysis/weinstein/screener/lib/screener.ml
+++ b/trading/analysis/weinstein/screener/lib/screener.ml
@@ -50,6 +50,7 @@ type config = {
   neutral_blocks_shorts : bool; [@sexp.default false]
   enable_slow_grind_short_gate : bool; [@sexp.default false]
   min_price : float; [@sexp.default 0.0]
+  early_stage2_max_weeks : int; [@sexp.default 4]
 }
 [@@deriving sexp]
 
@@ -70,6 +71,7 @@ let default_config =
     neutral_blocks_shorts = false;
     enable_slow_grind_short_gate = false;
     min_price = 0.0;
+    early_stage2_max_weeks = 4;
   }
 
 type scored_candidate = {
@@ -171,15 +173,19 @@ let _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
     excluded by the price floor, sector gate, breakout test, volume band, or
     score floor. *)
 let _long_candidate ~weights ~thresholds ~params ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~min_price (a, sector) =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price
+    ~early_stage2_max_weeks (a, sector) =
   if not (passes_price_floor ~min_price ~price:a.Stock_analysis.breakout_price)
   then None
   else if equal_sector_rating sector.rating Weak then None
-  else if not (Stock_analysis.is_breakout_candidate a) then None
+  else if not (Stock_analysis.is_breakout_candidate ~early_stage2_max_weeks a)
+  then None
   else if not (passes_volume_band ~excl:volume_ratio_exclude_range a) then None
   else
     _score_and_build ~weights ~thresholds ~params ~min_grade ~min_score_override
-      ~max_score_override ~is_short:false ~scorer:score_long ~sector a
+      ~max_score_override ~is_short:false
+      ~scorer:(score_long ~early_stage2_max_weeks)
+      ~sector a
 
 (** Evaluate one (analysis, sector) pair as a short candidate. Bearish/Neutral
     only: score must pass {!Screener_admission.passes_score_floor}. *)
@@ -213,10 +219,12 @@ let _check_watchlist_grade ~thresholds ~buy_candidates ~score
 (** Evaluate one (analysis, sector) pair as a watchlist entry. Included when it
     is a grade-C or grade-D breakout candidate not already in [buy_candidates].
 *)
-let _watchlist_entry ~weights ~thresholds ~buy_candidates (sa, sector) =
-  if not (Stock_analysis.is_breakout_candidate sa) then None
+let _watchlist_entry ~weights ~thresholds ~early_stage2_max_weeks
+    ~buy_candidates (sa, sector) =
+  if not (Stock_analysis.is_breakout_candidate ~early_stage2_max_weeks sa) then
+    None
   else
-    let score, _ = score_long ~weights ~sector sa in
+    let score, _ = score_long ~early_stage2_max_weeks ~weights ~sector sa in
     _check_watchlist_grade ~thresholds ~buy_candidates ~score sa
 
 (* ------------------------------------------------------------------ *)
@@ -289,14 +297,14 @@ let _shorts_admitted_by_macro ~neutral_blocks_shorts macro_trend =
 (** Filter, score, grade, sort, and cap long candidates. *)
 let _evaluate_longs ~weights ~thresholds ~params ~min_grade ~min_score_override
     ~max_score_override ~volume_ratio_exclude_range ~min_price
-    ~max_buy_candidates ~neutral_blocks_longs ~ranking ~candidates ~macro_trend
-    : scored_candidate list =
+    ~early_stage2_max_weeks ~max_buy_candidates ~neutral_blocks_longs ~ranking
+    ~candidates ~macro_trend : scored_candidate list =
   if not (_longs_admitted_by_macro ~neutral_blocks_longs macro_trend) then []
   else
     let candidate_fn =
       _long_candidate ~weights ~thresholds ~params ~min_grade
         ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-        ~min_price
+        ~min_price ~early_stage2_max_weeks
     in
     _filter_and_cap ~ranking ~candidate_fn ~max_n:max_buy_candidates candidates
 
@@ -335,12 +343,14 @@ let _evaluate_shorts ~weights ~thresholds ~params ~min_grade ~min_score_override
 
 (** Build watchlist: breakout candidates with grade C/D not in the buy list.
     Empty when buys are inactive (Bearish market). *)
-let _build_watchlist ~weights ~thresholds ~candidates ~buy_candidates
-    ~buys_active : (string * string) list =
+let _build_watchlist ~weights ~thresholds ~early_stage2_max_weeks ~candidates
+    ~buy_candidates ~buys_active : (string * string) list =
   if not buys_active then []
   else
     List.filter_map candidates
-      ~f:(_watchlist_entry ~weights ~thresholds ~buy_candidates)
+      ~f:
+        (_watchlist_entry ~weights ~thresholds ~early_stage2_max_weeks
+           ~buy_candidates)
 
 (* ------------------------------------------------------------------ *)
 (* Main screener                                                        *)
@@ -361,12 +371,12 @@ let _resolve_sector ~sector_map ticker =
     [screen] so the latter stays within the 50-line linter cap. *)
 let _diagnostics_for_screen ~weights ~grade_thresholds ~min_grade
     ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-    ~min_price ~total_stocks ~candidates_after_held ~macro_trend ~candidates
-    ~buy_candidates ~short_candidates =
+    ~min_price ~early_stage2_max_weeks ~total_stocks ~candidates_after_held
+    ~macro_trend ~candidates ~buy_candidates ~short_candidates =
   let long_phases =
     count_long_phases ~weights ~thresholds:grade_thresholds ~min_grade
       ~min_score_override ~max_score_override ~volume_ratio_exclude_range
-      ~min_price ~candidates
+      ~min_price ~early_stage2_max_weeks ~candidates
   in
   let short_phases =
     count_short_phases ~weights ~thresholds:grade_thresholds ~min_grade
@@ -413,7 +423,9 @@ let _evaluate_candidates ~config ~decline_is_slow_grind ~candidates ~macro_trend
       ~min_score_override:config.min_score_override
       ~max_score_override:config.max_score_override
       ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
-      ~min_price:config.min_price ~max_buy_candidates:config.max_buy_candidates
+      ~min_price:config.min_price
+      ~early_stage2_max_weeks:config.early_stage2_max_weeks
+      ~max_buy_candidates:config.max_buy_candidates
       ~neutral_blocks_longs:config.neutral_blocks_longs
       ~ranking:config.candidate_ranking ~candidates ~macro_trend
   in
@@ -452,8 +464,9 @@ let _screen ~config ~decline_is_slow_grind ~macro_trend ~sector_map ~stocks
     short_candidates;
     watchlist =
       _build_watchlist ~weights:config.weights
-        ~thresholds:config.grade_thresholds ~candidates ~buy_candidates
-        ~buys_active;
+        ~thresholds:config.grade_thresholds
+        ~early_stage2_max_weeks:config.early_stage2_max_weeks ~candidates
+        ~buy_candidates ~buys_active;
     macro_trend;
     cascade_diagnostics =
       _diagnostics_for_screen ~weights:config.weights
@@ -461,8 +474,10 @@ let _screen ~config ~decline_is_slow_grind ~macro_trend ~sector_map ~stocks
         ~min_score_override:config.min_score_override
         ~max_score_override:config.max_score_override
         ~volume_ratio_exclude_range:config.volume_ratio_exclude_range
-        ~min_price:config.min_price ~total_stocks ~candidates_after_held
-        ~macro_trend ~candidates ~buy_candidates ~short_candidates;
+        ~min_price:config.min_price
+        ~early_stage2_max_weeks:config.early_stage2_max_weeks ~total_stocks
+        ~candidates_after_held ~macro_trend ~candidates ~buy_candidates
+        ~short_candidates;
   }
 
 let screen ~config ~macro_trend ~sector_map ~stocks ~held_tickers : result =

--- a/trading/analysis/weinstein/screener/lib/screener.mli
+++ b/trading/analysis/weinstein/screener/lib/screener.mli
@@ -245,6 +245,39 @@ type config = {
           override path via [((screening_config ((min_price 5.0))))] — see
           [Weinstein_strategy.config.screening_config]. Not wired into any
           default config or the automated tuner sweep surface. *)
+  early_stage2_max_weeks : int; [@sexp.default 4]
+      (** Early-Stage2 admission / scoring window, in weeks. A fresh Stage2
+          candidate (no observed Stage1→Stage2 breakout) is admitted as a
+          breakout candidate — and earns the "Early Stage2" scoring bonus — only
+          while [weeks_advancing <= early_stage2_max_weeks]. Default [4] is
+          bit-identical to the historical hardcoded window, so the default
+          config (and every golden) is unchanged.
+
+          One knob feeds both use sites: the admission gate
+          ({!Stock_analysis.is_breakout_candidate}, which drives
+          [is_breakout_candidate] in the cascade) and the scoring bonus
+          ({!Screener_scoring.score_long}'s early-Stage2 signal). They encode
+          the same "early-Stage2 window" concept — a single field keeps them
+          from drifting.
+
+          Default-off tuning axis (P2, deferred from PR #1818): the
+          breakout-*event* lookback is 8 weeks while this admission window is 4,
+          and now that the live gate bites (post-#1818 prior_stage fix) whether
+          [<= 4] is right is a tuning question. Reachable from the
+          scenario/strategy override path via
+          [((screening_config ((early_stage2_max_weeks N))))] — see
+          [Weinstein_strategy.config.screening_config] — so it routes through
+          [Overlay_validator.apply_overrides] and is a [Variant_matrix] [Key]
+          axis.
+
+          {b Why [@sexp.default 4] (not [@sexp.option]):} [Overlay_validator]
+          derives valid override key-paths from the {e serialized} base config,
+          so a field must stay PRESENT in [sexp_of_config] for the axis to
+          resolve (same rationale as [weights.w_early_stage2]).
+          [@sexp.default 4] keeps the field present in the serialized form while
+          parsing a missing field back to [4] (older config sexps round-trip).
+          Not wired into any non-default config until it earns an ACCEPT in the
+          experiment ledger ([.claude/rules/experiment-flag-discipline.md]). *)
 }
 [@@deriving sexp]
 (** Main screener configuration. *)

--- a/trading/analysis/weinstein/screener/lib/screener_admission.ml
+++ b/trading/analysis/weinstein/screener/lib/screener_admission.ml
@@ -34,14 +34,17 @@ let rs_blocks_short = function
   | _ -> false
 
 let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~min_price (a, sector) =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price
+    ~early_stage2_max_weeks (a, sector) =
   (* Volume-band exclusion and the min-price liquidity floor are folded into the
      breakout phase: keeps the cascade-diagnostics record stable (no new
      counter) while gating downstream counts. The long-side setup price is
-     [breakout_price]. *)
+     [breakout_price]. [early_stage2_max_weeks] is threaded into both the
+     breakout gate and the score so this diagnostic count tracks the same
+     early-Stage2 window the live cascade admits on. *)
   let passes_breakout =
     passes_price_floor ~min_price ~price:a.Stock_analysis.breakout_price
-    && Stock_analysis.is_breakout_candidate a
+    && Stock_analysis.is_breakout_candidate ~early_stage2_max_weeks a
     && passes_volume_band ~excl:volume_ratio_exclude_range a
   in
   let passes_sector =
@@ -50,7 +53,7 @@ let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
   let passes_grade =
     if not passes_sector then false
     else
-      let score, _ = score_long ~weights ~sector a in
+      let score, _ = score_long ~early_stage2_max_weeks ~weights ~sector a in
       passes_score_floor ~thresholds ~min_grade ~min_score_override
         ~max_score_override score
   in
@@ -59,12 +62,14 @@ let _long_admission ~weights ~thresholds ~min_grade ~min_score_override
 let _bump n b = if b then n + 1 else n
 
 let count_long_phases ~weights ~thresholds ~min_grade ~min_score_override
-    ~max_score_override ~volume_ratio_exclude_range ~min_price ~candidates =
+    ~max_score_override ~volume_ratio_exclude_range ~min_price
+    ~early_stage2_max_weeks ~candidates =
   List.fold candidates ~init:(0, 0, 0)
     ~f:(fun (breakout, sector_ok, grade_ok) pair ->
       let pb, ps, pg =
         _long_admission ~weights ~thresholds ~min_grade ~min_score_override
-          ~max_score_override ~volume_ratio_exclude_range ~min_price pair
+          ~max_score_override ~volume_ratio_exclude_range ~min_price
+          ~early_stage2_max_weeks pair
       in
       (_bump breakout pb, _bump sector_ok ps, _bump grade_ok pg))
 

--- a/trading/analysis/weinstein/screener/lib/screener_admission.mli
+++ b/trading/analysis/weinstein/screener/lib/screener_admission.mli
@@ -59,12 +59,16 @@ val count_long_phases :
   max_score_override:int option ->
   volume_ratio_exclude_range:volume_ratio_band option ->
   min_price:float ->
+  early_stage2_max_weeks:int ->
   candidates:(Stock_analysis.t * sector_context) list ->
   int * int * int
 (** Long-side cascade-phase counts [(breakout, sector, grade)] for the
     diagnostics record. Each phase short-circuits (a [false] earlier phase keeps
     later phases [false]) so the triple is monotone non-increasing. The
-    [min_price] liquidity floor folds into the breakout phase. *)
+    [min_price] liquidity floor folds into the breakout phase.
+    [early_stage2_max_weeks] is the early-Stage2 admission window (see
+    [Screener.config.early_stage2_max_weeks]) threaded into both the breakout
+    gate and the score so the diagnostic count tracks the live cascade. *)
 
 val count_short_phases :
   weights:scoring_weights ->

--- a/trading/analysis/weinstein/screener/lib/screener_scoring.ml
+++ b/trading/analysis/weinstein/screener/lib/screener_scoring.ml
@@ -76,12 +76,17 @@ let _early_stage2_weight ~w =
 let _virgin_support_weight ~w =
   match w.w_virgin_support with Some v -> v | None -> w.w_clean_resistance
 
-(** Stage signal for long setups: Stage1→2 transition or early Stage2. *)
-let _stage_long_signal ~w ~(a : Stock_analysis.t) =
+(** Stage signal for long setups: Stage1→2 transition or early Stage2. The
+    early-Stage2 arm fires while [weeks_advancing <= early_stage2_max_weeks]
+    (default 4 at the public boundary — same window
+    {!Stock_analysis.is_breakout_candidate} admits on, threaded from
+    [Screener.config.early_stage2_max_weeks] so the two never drift). *)
+let _stage_long_signal ~early_stage2_max_weeks ~w ~(a : Stock_analysis.t) =
   match (a.stage.stage, a.prior_stage) with
   | Stage2 _, Some (Stage1 _) ->
       [ (w.w_stage2_breakout, "Stage1→Stage2 breakout") ]
-  | Stage2 { weeks_advancing; _ }, _ when weeks_advancing <= 4 ->
+  | Stage2 { weeks_advancing; _ }, _
+    when weeks_advancing <= early_stage2_max_weeks ->
       [ (_early_stage2_weight ~w, "Early Stage2") ]
   | _ -> []
 
@@ -205,12 +210,18 @@ let _tally signals =
 (* Scoring                                                              *)
 (* ------------------------------------------------------------------ *)
 
-(** Compute a long-side score for a stock analysis. *)
-let score_long ~weights ~sector (a : Stock_analysis.t) : int * string list =
+(** Compute a long-side score for a stock analysis. [early_stage2_max_weeks]
+    (default 4) is the early-Stage2 scoring window; supplying it from
+    [Screener.config.early_stage2_max_weeks] keeps the scoring bonus window in
+    lockstep with the {!Stock_analysis.is_breakout_candidate} admission window.
+*)
+let score_long ?(early_stage2_max_weeks = 4) ~weights ~sector
+    (a : Stock_analysis.t) : int * string list =
   let w = weights in
   _tally
-    (_stage_long_signal ~w ~a @ _late_stage2_signal ~w ~a @ _volume_signal ~w ~a
-   @ _rs_long_signal ~w ~a @ _resistance_signal ~w ~a
+    (_stage_long_signal ~early_stage2_max_weeks ~w ~a
+    @ _late_stage2_signal ~w ~a @ _volume_signal ~w ~a @ _rs_long_signal ~w ~a
+    @ _resistance_signal ~w ~a
     @ _sector_long_signal ~w ~sector)
 
 (** Compute a short-side score for a stock analysis. *)

--- a/trading/analysis/weinstein/screener/lib/screener_scoring.mli
+++ b/trading/analysis/weinstein/screener/lib/screener_scoring.mli
@@ -119,12 +119,19 @@ val default_grade_thresholds : grade_thresholds
 (** [default_grade_thresholds] provides the reference thresholds. *)
 
 val score_long :
+  ?early_stage2_max_weeks:int ->
   weights:scoring_weights ->
   sector:sector_context ->
   Stock_analysis.t ->
   int * string list
-(** [score_long ~weights ~sector a] computes the long-side weighted score and
-    rationale list for [a]. *)
+(** [score_long ?early_stage2_max_weeks ~weights ~sector a] computes the
+    long-side weighted score and rationale list for [a].
+
+    [early_stage2_max_weeks] is the early-Stage2 scoring-bonus window (default
+    [4] — bit-identical to the historical hardcoded window). It is the same
+    window {!Stock_analysis.is_breakout_candidate} admits on; the screener
+    threads [Screener.config.early_stage2_max_weeks] into both so the scoring
+    bonus and the admission gate can never drift. *)
 
 val score_short :
   weights:scoring_weights ->

--- a/trading/analysis/weinstein/screener/test/test_screener.ml
+++ b/trading/analysis/weinstein/screener/test/test_screener.ml
@@ -1879,6 +1879,70 @@ let test_ranking_omitted_field_defaults_alphabetical _ =
   in
   assert_that no_ranking.candidate_ranking (equal_to Alphabetical)
 
+(* ------------------------------------------------------------------ *)
+(* early_stage2_max_weeks: early-Stage2 window knob                     *)
+(* ------------------------------------------------------------------ *)
+
+(** A fresh Stage2 analysis with no observed Stage1→Stage2 predecessor, so the
+    early-Stage2 scoring arm (not the Stage1→Stage2 breakout arm) is the one
+    that fires, gated by [early_stage2_max_weeks]. *)
+let early_stage2_analysis ~weeks_advancing : Stock_analysis.t =
+  {
+    (ranking_analysis ~ticker:"X" ~rs_norm:1.0 ~weeks_advancing
+       ~volume_ratio:3.0)
+    with
+    prior_stage = None;
+  }
+
+(** Count of "Early Stage2" labels in a scoring rationale (0 or 1). *)
+let early_stage2_labels rationale =
+  List.count rationale ~f:(String.equal "Early Stage2")
+
+(* Widened window earns the Early-Stage2 signal for a weeks_advancing = 5
+   candidate that the default window (4) does not — one knob drives the scoring
+   bonus, matching the admission gate window. *)
+let test_score_long_window_controls_early_stage2_signal _ =
+  let sector = make_sector "Tech" in
+  let a = early_stage2_analysis ~weeks_advancing:5 in
+  let default_rationale = snd (score_long ~weights:cfg.weights ~sector a) in
+  let widened_rationale =
+    snd (score_long ~early_stage2_max_weeks:8 ~weights:cfg.weights ~sector a)
+  in
+  assert_that
+    ( early_stage2_labels default_rationale,
+      early_stage2_labels widened_rationale )
+    (equal_to (0, 1))
+
+(* Axis-ability (experiment-flag-discipline R2): the field is present in the
+   serialized config (so [Overlay_validator] resolves the
+   [screening_config.early_stage2_max_weeks] override path) and an overlay value
+   round-trips. *)
+let test_early_stage2_max_weeks_serializes_and_round_trips _ =
+  let default_str = Sexp.to_string (sexp_of_config default_config) in
+  let widened_cfg =
+    config_of_sexp
+      (Sexp.of_string
+         (String.substr_replace_first default_str
+            ~pattern:"(early_stage2_max_weeks 4)"
+            ~with_:"(early_stage2_max_weeks 8)"))
+  in
+  assert_that
+    ( String.is_substring default_str ~substring:"early_stage2_max_weeks",
+      widened_cfg.early_stage2_max_weeks )
+    (equal_to (true, 8))
+
+(* An omitted field deserialises to the default 4 — older config sexps that
+   predate this knob round-trip to the historical hardcoded window. *)
+let test_early_stage2_max_weeks_omitted_defaults_4 _ =
+  let no_field =
+    config_of_sexp
+      (Sexp.of_string
+         (String.substr_replace_first
+            (Sexp.to_string (sexp_of_config default_config))
+            ~pattern:"(early_stage2_max_weeks 4)" ~with_:""))
+  in
+  assert_that no_field.early_stage2_max_weeks (equal_to 4)
+
 let suite =
   "screener_tests"
   >::: [
@@ -2028,6 +2092,12 @@ let suite =
          >:: test_ranking_field_serializes_and_round_trips;
          "test_ranking_omitted_field_defaults_alphabetical"
          >:: test_ranking_omitted_field_defaults_alphabetical;
+         "test_score_long_window_controls_early_stage2_signal"
+         >:: test_score_long_window_controls_early_stage2_signal;
+         "test_early_stage2_max_weeks_serializes_and_round_trips"
+         >:: test_early_stage2_max_weeks_serializes_and_round_trips;
+         "test_early_stage2_max_weeks_omitted_defaults_4"
+         >:: test_early_stage2_max_weeks_omitted_defaults_4;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.ml
@@ -410,13 +410,16 @@ let analyze ~(config : config) ~ticker ~bars ~benchmark_bars ~prior_stage
 (* ------------------------------------------------------------------ *)
 
 (** Initial-breakout arm (pre-existing): Stage1→Stage2 transition, or fresh
-    Stage2 with [weeks_advancing ≤ 4]. Mature Stage2 symbols (the cascade's
-    blind spot per dev/notes/capital-recycling-framing-2026-05-06.md) are
-    rejected by this arm but admitted by the continuation arm when enabled. *)
-let _initial_breakout_arm (a : t) : bool =
+    Stage2 with [weeks_advancing ≤ early_stage2_max_weeks]. Mature Stage2
+    symbols (the cascade's blind spot per
+    dev/notes/capital-recycling-framing-2026-05-06.md) are rejected by this arm
+    but admitted by the continuation arm when enabled. [early_stage2_max_weeks]
+    is the early-Stage2 admission window (default 4 at the public boundary). *)
+let _initial_breakout_arm ~early_stage2_max_weeks (a : t) : bool =
   match (a.stage.stage, a.prior_stage) with
   | Stage2 _, Some (Stage1 _) -> true
-  | Stage2 { weeks_advancing; late = false }, _ -> weeks_advancing <= 4
+  | Stage2 { weeks_advancing; late = false }, _ ->
+      weeks_advancing <= early_stage2_max_weeks
   | _ -> false
 
 (** Continuation-buy arm (Interpretation B of issue #889). Active only when
@@ -428,8 +431,10 @@ let _continuation_arm (a : t) : bool =
   | Some { is_continuation = true; _ }, Stage2 _ -> true
   | _ -> false
 
-let is_breakout_candidate (a : t) : bool =
-  let stage_ok = _initial_breakout_arm a || _continuation_arm a in
+let is_breakout_candidate ?(early_stage2_max_weeks = 4) (a : t) : bool =
+  let stage_ok =
+    _initial_breakout_arm ~early_stage2_max_weeks a || _continuation_arm a
+  in
   (* Volume confirmation: at least Adequate *)
   let volume_ok =
     match a.volume with

--- a/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
+++ b/trading/analysis/weinstein/stock_analysis/lib/stock_analysis.mli
@@ -176,16 +176,24 @@ val analyze_with_callbacks :
     [(bars, benchmark_bars)] input by constructing callbacks that index the same
     pre-computed series the bar-list path computes internally. *)
 
-val is_breakout_candidate : t -> bool
-(** [is_breakout_candidate analysis] returns true if the stock shows a potential
-    Stage 2 breakout: transitioning from Stage 1, with rising MA and strong
-    volume.
+val is_breakout_candidate : ?early_stage2_max_weeks:int -> t -> bool
+(** [is_breakout_candidate ?early_stage2_max_weeks analysis] returns true if the
+    stock shows a potential Stage 2 breakout: transitioning from Stage 1, with
+    rising MA and strong volume.
+
+    [early_stage2_max_weeks] is the early-Stage2 admission window: a fresh
+    Stage2 (no observed Stage1→Stage2 transition) qualifies only while
+    [weeks_advancing <= early_stage2_max_weeks]. Defaults to [4] — bit-identical
+    to the historical hardcoded window, so every existing caller is unchanged.
+    The screener threads [Screener.config.early_stage2_max_weeks] here so the
+    window is a tunable axis.
 
     OR-arm (Interpretation B of issue #889): a stock that has [Some r] in
     {!t.continuation} with [r.is_continuation = true] also qualifies, even when
-    the Stage1→Stage2 transition is no longer in scope ([weeks_advancing > 4]).
-    This admits the Weinstein Ch. 3 "continuation buy" pattern as a new-position
-    candidate when [config.continuation = Some _].
+    the Stage1→Stage2 transition is no longer in scope
+    ([weeks_advancing > early_stage2_max_weeks]). This admits the Weinstein Ch.
+    3 "continuation buy" pattern as a new-position candidate when
+    [config.continuation = Some _].
 
     Volume confirmation (Strong / Adequate) and the RS-not-negative-declining
     gate apply to both arms equally.

--- a/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
+++ b/trading/analysis/weinstein/stock_analysis/test/test_stock_analysis.ml
@@ -113,6 +113,66 @@ let test_breakout_candidate_false_when_no_volume_confirmation _ =
   assert_that (is_breakout_candidate result) (equal_to false)
 
 (* ------------------------------------------------------------------ *)
+(* Early-Stage2 admission window (early_stage2_max_weeks)                *)
+(* ------------------------------------------------------------------ *)
+
+(** A fresh Stage2 analysis (no observed Stage1→Stage2 predecessor) with the
+    given [weeks_advancing], Strong volume, and rising RS — so admission turns
+    solely on the early-Stage2 window arm of [is_breakout_candidate]. *)
+let fresh_stage2 ~weeks_advancing : Stock_analysis.t =
+  {
+    ticker = "X";
+    stage =
+      {
+        stage = Stage2 { weeks_advancing; late = false };
+        ma_value = 100.0;
+        ma_direction = Rising;
+        ma_slope_pct = 0.05;
+        transition = None;
+        above_ma_count = 5;
+      };
+    rs =
+      Some
+        {
+          current_rs = 1.0;
+          current_normalized = 1.0;
+          trend = Positive_rising;
+          history = [];
+        };
+    volume =
+      Some
+        {
+          confirmation = Strong 3.0;
+          event_volume = 3000;
+          avg_volume = 1000.0;
+          volume_ratio = 3.0;
+        };
+    resistance = None;
+    support = None;
+    breakout_price = Some 100.0;
+    breakdown_price = None;
+    prior_stage = None;
+    continuation = None;
+    as_of_date = as_of;
+  }
+
+(* Default window (4): weeks_advancing = 4 is admitted, 5 is rejected — pins the
+   historical hardcoded window bit-for-bit. *)
+let test_default_window_admits_4_rejects_5 _ =
+  assert_that
+    ( is_breakout_candidate (fresh_stage2 ~weeks_advancing:4),
+      is_breakout_candidate (fresh_stage2 ~weeks_advancing:5) )
+    (equal_to (true, false))
+
+(* Widened window (8): the same weeks_advancing = 5 candidate that the default
+   rejects is admitted once the window is widened to 8. *)
+let test_widened_window_admits_5 _ =
+  assert_that
+    (is_breakout_candidate ~early_stage2_max_weeks:8
+       (fresh_stage2 ~weeks_advancing:5))
+    (equal_to true)
+
+(* ------------------------------------------------------------------ *)
 (* Breakdown candidate                                                  *)
 (* ------------------------------------------------------------------ *)
 
@@ -511,6 +571,9 @@ let suite =
          >:: test_breakout_candidate_false_when_stage4;
          "test_breakout_candidate_false_when_no_volume_confirmation"
          >:: test_breakout_candidate_false_when_no_volume_confirmation;
+         "test_default_window_admits_4_rejects_5"
+         >:: test_default_window_admits_4_rejects_5;
+         "test_widened_window_admits_5" >:: test_widened_window_admits_5;
          "test_breakdown_candidate_true_with_stage3_prior"
          >:: test_breakdown_candidate_true_with_stage3_prior;
          "test_breakdown_candidate_false_for_stage2"

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -53,6 +53,7 @@ let _permissive_screener_config (config : config) : Screener.config =
     neutral_blocks_shorts = false;
     enable_slow_grind_short_gate = false;
     min_price = 0.0;
+    early_stage2_max_weeks = 4;
   }
 
 (** Whether [trend] would have admitted longs at the macro gate. *)

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -287,6 +287,24 @@ let test_default_screening_min_price_is_zero _ =
   let cfg = _default_config () in
   assert_that cfg.screening_config.min_price (float_equal 0.0)
 
+(** Deep-merge path for [screening_config.early_stage2_max_weeks] — the
+    early-Stage2 admission/scoring window. A scenario's [config_overrides] can
+    widen it (e.g. from 4 to 8) so the axis resolves through
+    [Overlay_validator.apply_overrides] without an unknown-key error. *)
+let test_override_screening_early_stage2_max_weeks _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((screening_config ((early_stage2_max_weeks 8))))")
+  in
+  assert_that merged.screening_config.early_stage2_max_weeks (equal_to 8)
+
+(** [4] (the default) is preserved when no override is applied. Pins the
+    bit-identical no-op contract documented in
+    [Screener.config.early_stage2_max_weeks]. *)
+let test_default_screening_early_stage2_max_weeks_is_four _ =
+  let cfg = _default_config () in
+  assert_that cfg.screening_config.early_stage2_max_weeks (equal_to 4)
+
 (** Fold-equivalent helper: applies a list of override sexps the same way
     [Backtest.Runner._apply_overrides] does — sequential deep-merge of each
     overlay into the running sexp, then a single [config_of_sexp] at the end.
@@ -482,6 +500,10 @@ let suite =
          >:: test_override_screening_min_price;
          "default: screening_config.min_price = 0.0"
          >:: test_default_screening_min_price_is_zero;
+         "override: screening_config.early_stage2_max_weeks round-trips \
+          through sexp" >:: test_override_screening_early_stage2_max_weeks;
+         "default: screening_config.early_stage2_max_weeks = 4"
+         >:: test_default_screening_early_stage2_max_weeks_is_four;
          "two overlays targeting same top-level field both apply"
          >:: test_two_overlays_same_top_level_field;
          "unknown top-level overlay key fails loudly (sweep-path linter)"


### PR DESCRIPTION
## What

Lifts the hardcoded early-Stage2 admission window (`weeks_advancing <= 4`) into a new config field `Screener.config.early_stage2_max_weeks` (default `4`, `[@sexp.default 4]`). Default is **bit-identical** to today's behaviour — no golden or backtest result changes.

## Why

P2 from `dev/notes/next-session-priorities-2026-07-02.md` (deferred from PR #1818). The early-breakout admission gate uses a hardcoded 4-week window while the breakout-*event* lookback is 8 weeks. Now that the live gate actually bites (post-#1818 `prior_stage` fix), whether `≤4` is right is a tuning question. Per `.claude/rules/experiment-flag-discipline.md` the knob lands as a default-preserving config field that routes through `Overlay_validator.apply_overrides`, so it is a `Variant_matrix` axis.

This is the mechanism only — NO default change, NO experiment.

## The two use sites (one knob feeds both)

They encode the same "early-Stage2 window" concept; letting them drift would be incoherent, so a single field drives both:

1. **Admission gate** — `Stock_analysis._initial_breakout_arm` (via `is_breakout_candidate ?early_stage2_max_weeks`), the gate that feeds `is_breakout_candidate` in the cascade.
2. **Scoring bonus** — `Screener_scoring._stage_long_signal` (via `score_long ?early_stage2_max_weeks`), the "Early Stage2" scoring signal window.

Both `is_breakout_candidate` and `score_long` take a `?(early_stage2_max_weeks = 4)` optional labelled arg, keeping every existing/external caller (tests, `stage_transition_scanner`) bit-identical. The screener threads `config.early_stage2_max_weeks` into both the live cascade (`_long_candidate`, `_watchlist_entry`) and the diagnostics counter (`count_long_phases` / `_long_admission`), so the phase counts track the live admission window.

**Known symmetric constant left alone (out of scope):** `screener_scoring.ml` `_stage_short_signal` has a symmetric `weeks_declining <= 4` for the short side — not touched here.

## Default-off discipline (experiment-flag-discipline.md)

- **R1 default-off:** new field carries `[@sexp.default 4]`; `4` = the prior hardcoded window, so merging changes no result.
- **R2 searchable:** real `Screener.config` field reachable via `((screening_config ((early_stage2_max_weeks N))))` through `Overlay_validator.apply_overrides` → a `Variant_matrix` `Key` axis. `[@sexp.default 4]` (not `[@sexp.option]`) keeps the field PRESENT in `sexp_of_config` so the axis key-path resolves.
- **R3:** no default flipped; not wired into any non-default config.

## Test plan

- `test_stock_analysis.ml`: default window admits `weeks_advancing=4` / rejects `5`; widened window (`8`) admits `5`.
- `test_screener.ml`: `score_long` emits the "Early Stage2" signal for a `weeks=5` candidate only when the window is widened to `8`; config sexp with an override round-trips (`4→8`); a sexp omitting the field defaults to `4`.
- `test_runner_hypothesis_overrides.ml`: `((screening_config ((early_stage2_max_weeks 8))))` resolves through the deep-merge / `config_of_sexp` path (axis reachability); default reads back as `4`.

`dune build` + `dune runtest` on the affected dirs (`stock_analysis`, `screener`, `backtest`) pass locally (the 8 backtest scenario-loading errors are pre-existing: the git-ignored `data/backtest_scenarios/smoke/*.sexp` fixtures are absent from the local container; the two new sexp-only override tests pass). `dune fmt` applied.

No changes to Portfolio/Orders/Position/Engine or `dev/status/_index.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)