### PR TITLE
feat(strategy): working cash_reserve_pct entry-funding reserve (default 0.0)

### DIFF
--- a/dev/status/cash-reserve.md
+++ b/dev/status/cash-reserve.md
@@ -1,0 +1,41 @@
+# cash-reserve
+
+Working percentage cash-reserve knob (`cash_reserve_pct`) — the **envelope-tightening**
+capital-management lever. Holds back a fraction of portfolio value from NEW entry
+funding each Friday. The honest, live-path replacement for the dead
+`Portfolio_risk.min_cash_pct` (unwired; sole consumer `check_limits` has zero
+production callers — `dev/notes/envelope-knobs-dead-2026-07-05.md`, #1861). Distinct
+from the CLOSED intra-envelope scale-in reallocation track: this *tightens* deployment
+(holds cash), it does not reallocate within a full envelope.
+
+## Status
+IN_PROGRESS
+
+## Last updated: 2026-07-06
+
+## Interface stable
+NO
+
+## Ownership
+feat-weinstein (LOCAL session, 2026-07-06). Orchestrator QCs + merges.
+
+## Completed
+- Mechanism BUILT, default-off (`cash_reserve_pct : float [@sexp.default 0.0]` on
+  `Weinstein_strategy.config`). Wired at the entry-walk seed in
+  `weinstein_strategy_screening.ml`: `spendable = max 0 (cash - cash_reserve_pct *
+  portfolio_value)` seeds the walk's `remaining_cash`. Reserve taken off the top-level
+  budget once (short-sleeve split derives from the reduced budget). Scoped to NEW
+  entries only — exits/covers/stops never blocked (#1553 lesson). experiment-flag
+  R1 (default-off, bit-identical) + R2 (axis-reachable via `Overlay_validator`) PASS.
+  Tests: config default/round-trip, behaviour off (3 longs) vs on (0.30 → 2 longs),
+  exit-exempt under reserve 0.9, axis reachability. PR open on `feat/cash-reserve-pct`.
+
+## Next Steps
+- [non-blocking] WF-CV surface `cash_reserve_pct ∈ {0.0, 0.1, 0.2, 0.3}` (per
+  `experiment-gap-closing`): does holding 10–30% cash buy enough DD/dispersion relief
+  to justify the return cost? Note the standing prior — the edge is the fat tail
+  (`project_edge_is_the_fat_tail`); a reserve reduces deployment, so expect a return
+  cost. Default stays off pending a ledger ACCEPT + confirmation grid.
+
+## Follow-up
+None

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -463,6 +463,40 @@ let test_unknown_key_error_reports_overlay_index _ =
               (equal_to true);
           ]))
 
+(* -------------------------------------------------------------------- *)
+(* cash_reserve_pct — working replacement for dead Portfolio_risk.min_cash_pct *)
+(* -------------------------------------------------------------------- *)
+
+(** [cash_reserve_pct] defaults to [0.0] when omitted from the sexp (backward
+    compat — every existing golden/baseline decodes unchanged). The working,
+    live-path replacement for the dead [Portfolio_risk.min_cash_pct]
+    (dev/notes/envelope-knobs-dead-2026-07-05.md). *)
+let test_default_cash_reserve_pct_is_zero _ =
+  let cfg = _default_config () in
+  assert_that cfg.cash_reserve_pct (float_equal 0.0)
+
+(** Deep-merge path for [cash_reserve_pct]: a
+    [--override '((cash_reserve_pct 0.30))'] round-trips through the sexp merge
+    and lands the explicit value. *)
+let test_override_cash_reserve_pct _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string "((cash_reserve_pct 0.30))")
+  in
+  assert_that merged.cash_reserve_pct (float_equal 0.30)
+
+(** Axis reachability (experiment-flag-discipline R2): the [cash_reserve_pct]
+    override sexp resolves through the {b real}
+    [Overlay_validator.apply_overrides] (the sweep / WF-CV path) with no
+    unknown-key error, and lands the value — this is what makes
+    [((cash_reserve_pct 0.30))] a valid [Variant_matrix] axis. *)
+let test_cash_reserve_pct_axis_resolves_via_overlay_validator _ =
+  let merged =
+    Backtest.Overlay_validator.apply_overrides (_default_config ())
+      [ Sexp.of_string "((cash_reserve_pct 0.30))" ]
+  in
+  assert_that merged.cash_reserve_pct (float_equal 0.30)
+
 let suite =
   "Runner_hypothesis_overrides"
   >::: [
@@ -514,6 +548,12 @@ let suite =
          >:: test_known_nested_overlay_key_succeeds;
          "error message reports overlay index for multi-overlay runs"
          >:: test_unknown_key_error_reports_overlay_index;
+         "default cash_reserve_pct is zero"
+         >:: test_default_cash_reserve_pct_is_zero;
+         "override cash_reserve_pct through sexp"
+         >:: test_override_cash_reserve_pct;
+         "cash_reserve_pct axis resolves via Overlay_validator"
+         >:: test_cash_reserve_pct_axis_resolves_via_overlay_validator;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/lib/screening_notional.ml
+++ b/trading/trading/weinstein/strategy/lib/screening_notional.ml
@@ -35,3 +35,47 @@ let initial_sector_exposures ~(positions : Position.t Map.M(String).t)
           | None -> notional
           | Some v -> v +. notional));
   acc
+
+type entry_walk_state = {
+  remaining_cash : float ref;
+  short_notional_acc : float ref;
+  short_notional_cap : float;
+  sector_exposure_acc : (string, float) Hashtbl.t;
+  max_sector_exposure_pct : float option;
+}
+
+let make_entry_walk_state ~cash ~(config : Weinstein_strategy_config.config)
+    ~(portfolio : Portfolio_view.t) ~portfolio_value ~sector_lookup =
+  let short_notional_acc =
+    ref (initial_short_notional portfolio.Portfolio_view.positions)
+  in
+  let short_notional_cap =
+    portfolio_value
+    *. config.portfolio_config.Portfolio_risk.max_short_notional_fraction
+  in
+  let sector_exposure_acc =
+    match sector_lookup with
+    | None -> Hashtbl.create (module String)
+    | Some lookup ->
+        initial_sector_exposures ~positions:portfolio.Portfolio_view.positions
+          ~sector_lookup:lookup
+  in
+  {
+    remaining_cash = ref cash;
+    short_notional_acc;
+    short_notional_cap;
+    sector_exposure_acc;
+    max_sector_exposure_pct =
+      config.portfolio_config.Portfolio_risk.max_sector_exposure_pct;
+  }
+
+let reserve_reduced_walk_state ~(config : Weinstein_strategy_config.config)
+    ~(portfolio : Portfolio_view.t) ~portfolio_value ~sector_lookup =
+  let spendable =
+    Float.max 0.0
+      (portfolio.Portfolio_view.cash
+      -. (config.cash_reserve_pct *. portfolio_value))
+  in
+  ( spendable,
+    make_entry_walk_state ~cash:spendable ~config ~portfolio ~portfolio_value
+      ~sector_lookup )

--- a/trading/trading/weinstein/strategy/lib/screening_notional.mli
+++ b/trading/trading/weinstein/strategy/lib/screening_notional.mli
@@ -20,3 +20,43 @@ val initial_sector_exposures :
     resolves each held symbol to its sector — same source the entry walk uses
     for new candidates; symbols it can't resolve bucket under the empty string
     (which the cap exempts). *)
+
+type entry_walk_state = {
+  remaining_cash : float ref;
+  short_notional_acc : float ref;
+  short_notional_cap : float;
+  sector_exposure_acc : (string, float) Hashtbl.t;
+  max_sector_exposure_pct : float option;
+}
+(** Bundle of per-Friday entry-walk accumulators + caps, seeded from the
+    portfolio and config. The accumulators are mutated in-place by the gates
+    inside [Entry_audit_capture.classify_candidate] as the walk funds
+    candidates. *)
+
+val make_entry_walk_state :
+  cash:float ->
+  config:Weinstein_strategy_config.config ->
+  portfolio:Portfolio_view.t ->
+  portfolio_value:float ->
+  sector_lookup:(string -> string option) option ->
+  entry_walk_state
+(** Seed an {!entry_walk_state}: [remaining_cash] starts at [cash], the
+    short-notional accumulator at the portfolio's open [Holding] short notional,
+    and the sector-exposure accumulator at held positions' notional (empty when
+    [sector_lookup] is [None]). Caps come from [config.portfolio_config]. *)
+
+val reserve_reduced_walk_state :
+  config:Weinstein_strategy_config.config ->
+  portfolio:Portfolio_view.t ->
+  portfolio_value:float ->
+  sector_lookup:(string -> string option) option ->
+  float * entry_walk_state
+(** Cash-reserve knob: hold back [config.cash_reserve_pct] of portfolio value
+    from the per-Friday entry-funding budget and seed the walk state with the
+    remainder — [spendable = max 0 (cash - cash_reserve_pct * portfolio_value)],
+    returned alongside the state. Default [0.0] => [spendable = cash],
+    bit-identical to baseline. The reserve is subtracted exactly once here (off
+    the top-level budget); the short-sleeve split derives from [spendable] so it
+    is never charged twice. Scoped to NEW entries only — exits/covers/stops do
+    not flow through the entry walk. See
+    [Weinstein_strategy_config.cash_reserve_pct]. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -556,6 +556,12 @@ type config = {
       [@sexp.default Scale_in_detector.default_config]
       (** Scale-in knobs; only consulted when [enable_scale_in = true]. See
           [Weinstein_strategy_config] and {!Scale_in_detector}. *)
+  cash_reserve_pct : float; [@sexp.default 0.0]
+      (** Fraction of current portfolio value held back from NEW entry funding
+          each Friday; default [0.0] is a no-op (bit-identical to baseline). The
+          working replacement for the dead [Portfolio_risk.min_cash_pct]. Scoped
+          to entries only — exits are never blocked. See
+          [Weinstein_strategy_config]. *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -150,6 +150,11 @@ type config = {
       [@sexp.default Scale_in_detector.default_config]
       (** Scale-in knobs (initial fraction, add trigger, gates); only consulted
           when [enable_scale_in = true]. See [.mli]. *)
+  cash_reserve_pct : float; [@sexp.default 0.0]
+      (** Fraction of current portfolio value held back from NEW entry funding
+          each Friday; default [0.0] is a no-op (bit-identical to baseline). The
+          working replacement for the dead [Portfolio_risk.min_cash_pct]. See
+          [.mli]. *)
 }
 [@@deriving sexp]
 
@@ -208,6 +213,7 @@ let default_config ~universe ~index_symbol =
     liquidity_config = Liquidity_config.default_config;
     enable_scale_in = false;
     scale_in_config = Scale_in_detector.default_config;
+    cash_reserve_pct = 0.0;
   }
 
 let name = "Weinstein"

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -485,6 +485,53 @@ type config = {
           addressable as a [Variant_matrix] dot-path axis, e.g.
           [((key (scale_in_config add_trigger)) (values (Pullback Either)))].
           See {!Scale_in_detector}. *)
+  cash_reserve_pct : float; [@sexp.default 0.0]
+      (** Fraction of {e current portfolio value} held back from NEW entry
+          funding on each Friday entry walk
+          ({!Weinstein_strategy.entries_from_candidates}). The per-Friday
+          spendable cash is
+          [max 0 (portfolio.cash - cash_reserve_pct * portfolio_value)]; the
+          reserve is taken off the top-level entry budget exactly once (in the
+          reserved-short-sleeve path the same reduced budget is split between
+          the long and short walks, so it is never charged twice).
+
+          {b The working replacement for the dead
+             [Portfolio_risk.min_cash_pct].} Per
+          [dev/notes/envelope-knobs-dead-2026-07-05.md] (merged #1861),
+          [Portfolio_risk.min_cash_pct] is unwired — its sole consumer
+          [Portfolio_risk.check_limits] has zero production callers, so
+          backtests run at ~89-99% deployment with no cash-reserve mechanism at
+          all. This field is the honest, live-path reserve: it is consumed at
+          the one seam that actually gates entry funding (the entry-walk
+          [remaining_cash]).
+
+          {b Scope — entries only.} The reserve narrows only NEW entry funding.
+          Exits, covers, stop orders, and force-liquidations do not flow through
+          the entry walk and are structurally unaffected, so a reserve can never
+          block an exit (the #1553 exit-fill-reject lesson). A held position
+          always exits on its stop/stage/liquidity signal regardless of the
+          reserve.
+
+          {b Semantics.}
+          - [0.0] (default): {b bit-identical to baseline} —
+            [spendable = portfolio.cash], so every existing golden/baseline
+            replays unchanged (experiment-flag-discipline R1).
+          - [> 0.0]: a candidate whose cost fits within [portfolio.cash] but not
+            within the reduced [spendable] budget is rejected exactly as an
+            [Insufficient_cash] skip; candidates that fit within [spendable] are
+            admitted normally.
+
+          {b Faithfulness} (W1/W2, [.claude/rules/weinstein-faithful-core.md]).
+          A portfolio-risk / capital-preservation dial that {e tightens}
+          deployment — it holds cash back in exactly the spirit of the book's
+          "when in doubt, stay out" caution, without touching any spine item
+          (stage classification, the Stage-2-only buy rule, breakout+volume
+          entry, stops, the macro/sector gate are all unchanged). Searchable as
+          a single-component [Variant_matrix] axis
+          ([((cash_reserve_pct) (values (0.0 0.1 0.2 0.3)))]). Default-off until
+          an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md] +
+          [.claude/rules/promotion-confirmation.md]). *)
 }
 [@@deriving sexp]
 (** Complete Weinstein strategy configuration. All parameters configurable for

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -24,59 +24,10 @@ let held_symbols (portfolio : Portfolio_view.t) =
       | Entering _ | Holding _ | Exiting _ -> Some p.symbol
       | Closed _ -> None)
 
-(* Bundle of per-Friday entry-walk accumulators + caps, seeded from
-   [portfolio] and [config]. Factored out of [entries_from_candidates] to
-   keep that function under the line cap; the accumulators are mutated
-   in-place by the gates inside [Entry_audit_capture.classify_candidate]. *)
-type _entry_walk_state = {
-  remaining_cash : float ref;
-  short_notional_acc : float ref;
-  short_notional_cap : float;
-  sector_exposure_acc : (string, float) Hashtbl.t;
-  max_sector_exposure_pct : float option;
-}
-(** Generate CreateEntering transitions for screener candidates. Tracks
-    remaining cash to avoid generating orders that exceed funds.
-
-    Public (see .mli) so callers running custom screening out-of-band can feed
-    candidates through the same entry pipeline the strategy uses.
-
-    The walk produces a tagged decision list (see
-    {!Entry_audit_capture.candidate_decision}). After the walk, kept candidates
-    are emitted to [audit_recorder.record_entry] with the rivals they outranked
-    — this is the PR-2 entry-capture site. The output transition list (in
-    original screener order) is bit-equivalent to the pre-audit shape: same
-    candidates, same transitions, same side-effects on [stop_states] and
-    [remaining_cash]. *)
-
-let _make_entry_walk_state ~cash ~config ~portfolio ~portfolio_value
-    ~sector_lookup =
-  let short_notional_acc =
-    ref
-      (Screening_notional.initial_short_notional
-         portfolio.Portfolio_view.positions)
-  in
-  let short_notional_cap =
-    portfolio_value *. config.portfolio_config.max_short_notional_fraction
-  in
-  let sector_exposure_acc =
-    match sector_lookup with
-    | None -> Hashtbl.create (module String)
-    | Some lookup ->
-        Screening_notional.initial_sector_exposures
-          ~positions:portfolio.Portfolio_view.positions ~sector_lookup:lookup
-  in
-  {
-    remaining_cash = ref cash;
-    short_notional_acc;
-    short_notional_cap;
-    sector_exposure_acc;
-    max_sector_exposure_pct = config.portfolio_config.max_sector_exposure_pct;
-  }
-
 (** Classify one [candidate] through the entry gates against [state], pairing it
     with its decision. Mutates [state]'s accumulators in-place. *)
-let _classify_one ~held_set ~make_entry ~portfolio_value ~state candidate =
+let _classify_one ~held_set ~make_entry ~portfolio_value
+    ~(state : Screening_notional.entry_walk_state) candidate =
   ( candidate,
     Entry_audit_capture.classify_candidate ~held_set ~make_entry
       ~remaining_cash:state.remaining_cash
@@ -99,8 +50,9 @@ let _classify_candidates ~held_set ~make_entry ~portfolio_value ~state
     shared [short_notional_acc] / [sector_exposure_acc] in [state] so the caps
     apply across both sides. Returns the [(index, candidate, decision)] triples
     keyed by the candidate's position in the original list. *)
-let _walk_side ~held_set ~make_entry ~portfolio_value ~state ~side_cash
-    indexed_candidates =
+let _walk_side ~held_set ~make_entry ~portfolio_value
+    ~(state : Screening_notional.entry_walk_state) ~side_cash indexed_candidates
+    =
   let side_state = { state with remaining_cash = ref side_cash } in
   let decisions =
     _classify_candidates ~held_set ~make_entry ~portfolio_value
@@ -131,24 +83,19 @@ let _sleeve_decisions ~held_set ~make_entry ~portfolio_value ~state ~long_cash
   |> List.sort ~compare:(fun (i, _, _) (j, _, _) -> Int.compare i j)
   |> List.map ~f:(fun (_, c, d) -> (c, d))
 
-(* Cash-reserve knob: hold back [cash_reserve_pct] of portfolio value from the
-   per-Friday entry-funding budget. Default [0.0] => [spendable = cash],
-   bit-identical to baseline. The reserve is subtracted once here (off the
-   top-level budget); the sleeve split in [entries_from_candidates] derives
-   from [spendable] so it is never charged twice. Scoped to NEW entries only —
-   exits/covers/stops do not flow through this walk. See
-   [Weinstein_strategy_config.cash_reserve_pct]. *)
-let _reserve_reduced_walk_state ~config ~portfolio ~portfolio_value
-    ~sector_lookup =
-  let spendable =
-    Float.max 0.0
-      (portfolio.Portfolio_view.cash
-      -. (config.cash_reserve_pct *. portfolio_value))
-  in
-  ( spendable,
-    _make_entry_walk_state ~cash:spendable ~config ~portfolio ~portfolio_value
-      ~sector_lookup )
+(** Generate CreateEntering transitions for screener candidates. Tracks
+    remaining cash to avoid generating orders that exceed funds.
 
+    Public (see .mli) so callers running custom screening out-of-band can feed
+    candidates through the same entry pipeline the strategy uses.
+
+    The walk produces a tagged decision list (see
+    {!Entry_audit_capture.candidate_decision}). After the walk, kept candidates
+    are emitted to [audit_recorder.record_entry] with the rivals they outranked
+    — this is the PR-2 entry-capture site. The output transition list (in
+    original screener order) is bit-equivalent to the pre-audit shape: same
+    candidates, same transitions, same side-effects on [stop_states] and
+    [remaining_cash]. *)
 let entries_from_candidates ?sector_lookup ~config ~candidates ~stop_states
     ~bar_reader ~(portfolio : Portfolio_view.t) ~get_price ~current_date
     ?(audit_recorder = Audit_recorder.noop) ?macro () =
@@ -165,8 +112,8 @@ let entries_from_candidates ?sector_lookup ~config ~candidates ~stop_states
       ~portfolio_value ~current_date cand
   in
   let spendable, state =
-    _reserve_reduced_walk_state ~config ~portfolio ~portfolio_value
-      ~sector_lookup
+    Screening_notional.reserve_reduced_walk_state ~config ~portfolio
+      ~portfolio_value ~sector_lookup
   in
   let decisions =
     if Float.( <= ) config.short_sleeve_fraction 0.0 then

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -146,9 +146,20 @@ let entries_from_candidates ?sector_lookup ~config ~candidates ~stop_states
       ~initial_stop_buffer:config.initial_stop_buffer ~stop_states ~bar_reader
       ~portfolio_value ~current_date cand
   in
+  (* Cash-reserve knob: hold back [cash_reserve_pct] of portfolio value from the
+     per-Friday entry-funding budget. Default [0.0] => [spendable = cash],
+     bit-identical to baseline. The reserve is subtracted once here (off the
+     top-level budget); the sleeve split below derives from [spendable] so it is
+     never charged twice. Scoped to NEW entries only — exits/covers/stops do not
+     flow through this walk. See [Weinstein_strategy_config.cash_reserve_pct]. *)
+  let spendable =
+    Float.max 0.0
+      (portfolio.Portfolio_view.cash
+      -. (config.cash_reserve_pct *. portfolio_value))
+  in
   let state =
-    _make_entry_walk_state ~cash:portfolio.Portfolio_view.cash ~config
-      ~portfolio ~portfolio_value ~sector_lookup
+    _make_entry_walk_state ~cash:spendable ~config ~portfolio ~portfolio_value
+      ~sector_lookup
   in
   let decisions =
     if Float.( <= ) config.short_sleeve_fraction 0.0 then
@@ -157,12 +168,11 @@ let entries_from_candidates ?sector_lookup ~config ~candidates ~stop_states
       _classify_candidates ~held_set ~make_entry ~portfolio_value ~state
         candidates
     else
-      (* Reserved short sleeve: partition the cash budget between a long and a
-         short walk that share [state]'s notional/sector accumulators. *)
+      (* Reserved short sleeve: partition the (reserve-reduced) cash budget
+         between a long and a short walk that share [state]'s notional/sector
+         accumulators. *)
       let short_budget = portfolio_value *. config.short_sleeve_fraction in
-      let long_cash =
-        Float.max 0.0 (portfolio.Portfolio_view.cash -. short_budget)
-      in
+      let long_cash = Float.max 0.0 (spendable -. short_budget) in
       _sleeve_decisions ~held_set ~make_entry ~portfolio_value ~state ~long_cash
         ~short_budget candidates
   in

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_screening.ml
@@ -131,6 +131,24 @@ let _sleeve_decisions ~held_set ~make_entry ~portfolio_value ~state ~long_cash
   |> List.sort ~compare:(fun (i, _, _) (j, _, _) -> Int.compare i j)
   |> List.map ~f:(fun (_, c, d) -> (c, d))
 
+(* Cash-reserve knob: hold back [cash_reserve_pct] of portfolio value from the
+   per-Friday entry-funding budget. Default [0.0] => [spendable = cash],
+   bit-identical to baseline. The reserve is subtracted once here (off the
+   top-level budget); the sleeve split in [entries_from_candidates] derives
+   from [spendable] so it is never charged twice. Scoped to NEW entries only —
+   exits/covers/stops do not flow through this walk. See
+   [Weinstein_strategy_config.cash_reserve_pct]. *)
+let _reserve_reduced_walk_state ~config ~portfolio ~portfolio_value
+    ~sector_lookup =
+  let spendable =
+    Float.max 0.0
+      (portfolio.Portfolio_view.cash
+      -. (config.cash_reserve_pct *. portfolio_value))
+  in
+  ( spendable,
+    _make_entry_walk_state ~cash:spendable ~config ~portfolio ~portfolio_value
+      ~sector_lookup )
+
 let entries_from_candidates ?sector_lookup ~config ~candidates ~stop_states
     ~bar_reader ~(portfolio : Portfolio_view.t) ~get_price ~current_date
     ?(audit_recorder = Audit_recorder.noop) ?macro () =
@@ -146,19 +164,8 @@ let entries_from_candidates ?sector_lookup ~config ~candidates ~stop_states
       ~initial_stop_buffer:config.initial_stop_buffer ~stop_states ~bar_reader
       ~portfolio_value ~current_date cand
   in
-  (* Cash-reserve knob: hold back [cash_reserve_pct] of portfolio value from the
-     per-Friday entry-funding budget. Default [0.0] => [spendable = cash],
-     bit-identical to baseline. The reserve is subtracted once here (off the
-     top-level budget); the sleeve split below derives from [spendable] so it is
-     never charged twice. Scoped to NEW entries only — exits/covers/stops do not
-     flow through this walk. See [Weinstein_strategy_config.cash_reserve_pct]. *)
-  let spendable =
-    Float.max 0.0
-      (portfolio.Portfolio_view.cash
-      -. (config.cash_reserve_pct *. portfolio_value))
-  in
-  let state =
-    _make_entry_walk_state ~cash:spendable ~config ~portfolio ~portfolio_value
+  let spendable, state =
+    _reserve_reduced_walk_state ~config ~portfolio ~portfolio_value
       ~sector_lookup
   in
   let decisions =

--- a/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_weinstein_strategy.ml
@@ -769,6 +769,117 @@ let test_short_sleeve_short_notional_cap_binds _ =
     (equal_to 0)
 
 (* ------------------------------------------------------------------ *)
+(* Cash reserve (cash_reserve_pct)                                     *)
+(* ------------------------------------------------------------------ *)
+
+(** Three longs at $100 (each sized to $9k by the 0.30 per-position cap on a
+    $30k portfolio) fed at $30k cash. Shared by the reserve-off and reserve-on
+    tests so they exercise identical inputs, isolating the [cash_reserve_pct]
+    effect on how many entries the walk funds. *)
+let _reserve_candidates () =
+  let long ticker =
+    make_scored_candidate ~ticker ~side:Trading_base.Types.Long ~entry:100.0
+      ~stop:92.0 ~grade:Weinstein_types.C
+  in
+  [ long "LNGA"; long "LNGB"; long "LNGC" ]
+
+let _reserve_portfolio : Trading_strategy.Portfolio_view.t =
+  { cash = 30_000.0; positions = String.Map.empty }
+
+let _reserve_get_price =
+  get_price_of
+    [
+      ("LNGA", make_bar "2024-01-05" 100.0);
+      ("LNGB", make_bar "2024-01-05" 100.0);
+      ("LNGC", make_bar "2024-01-05" 100.0);
+    ]
+
+let _run_reserve_entries cfg =
+  let stop_states = ref String.Map.empty in
+  entries_from_candidates ~config:cfg ~candidates:(_reserve_candidates ())
+    ~stop_states ~bar_reader:(Bar_reader.empty ()) ~portfolio:_reserve_portfolio
+    ~get_price:_reserve_get_price
+    ~current_date:(Date.of_string "2024-01-05")
+    ()
+
+(** Default [cash_reserve_pct = 0.0]: [spendable = cash = $30k], so all three
+    $9k longs fit ($27k < $30k) — bit-identical to the pre-knob entry walk. *)
+let test_cash_reserve_default_admits_all_longs _ =
+  let cfg = default_config ~universe:[ "X" ] ~index_symbol:"GSPCX" in
+  let transitions = _run_reserve_entries cfg in
+  assert_that
+    (_count_entering_side transitions Trading_base.Types.Long)
+    (equal_to 3)
+
+(** [cash_reserve_pct = 0.30] holds back $9k (0.30 * $30k PV), so the walk funds
+    against [spendable = $21k]: two $9k longs fit ($18k) but the third ($27k
+    cumulative) does not — it costs within cash ($30k) yet not within the
+    reduced budget, so it is rejected exactly as an Insufficient_cash skip. Pins
+    the count flip vs the reserve-off baseline. *)
+let test_cash_reserve_active_reduces_admitted_longs _ =
+  let cfg =
+    {
+      (default_config ~universe:[ "X" ] ~index_symbol:"GSPCX") with
+      cash_reserve_pct = 0.30;
+    }
+  in
+  let transitions = _run_reserve_entries cfg in
+  assert_that
+    (_count_entering_side transitions Trading_base.Types.Long)
+    (equal_to 2)
+
+(** A held position that hits its stop still emits a [TriggerExit] under an
+    extreme [cash_reserve_pct = 0.9]. Exits do not flow through the entry walk,
+    so the reserve — which narrows only NEW entry funding — can never block an
+    exit (the #1553 exit-fill-reject lesson). Mirrors
+    [test_stop_hit_emits_trigger_exit] with the reserve dialled to 0.9. *)
+let test_cash_reserve_never_blocks_exit _ =
+  let ticker = "AAPL" in
+  let date = Date.of_string "2024-01-05" in
+  let stop_state =
+    Weinstein_stops.Initial { stop_level = 90.0; reference_level = 95.0 }
+  in
+  let initial_stop_states = String.Map.singleton ticker stop_state in
+  let (module S) =
+    make ~initial_stop_states { cfg with cash_reserve_pct = 0.9 }
+  in
+  let pos = make_holding_pos ticker 100.0 date in
+  let positions = String.Map.singleton ticker pos in
+  let bar =
+    { (make_bar "2024-01-12" 95.0) with Types.Daily_price.low_price = 85.0 }
+  in
+  let result =
+    S.on_market_close
+      ~get_price:
+        (get_price_of
+           [ (ticker, bar); ("GSPCX", make_bar "2024-01-12" 4500.0) ])
+      ~get_indicator:empty_get_indicator
+      ~portfolio:{ cash = 100000.0; positions }
+  in
+  assert_that result
+    (is_ok_and_holds
+       (field
+          (fun o -> o.Trading_strategy.Strategy_interface.transitions)
+          (elements_are
+             [
+               all_of
+                 [
+                   field
+                     (fun (tr : Trading_strategy.Position.transition) ->
+                       tr.position_id)
+                     (equal_to ticker);
+                   field
+                     (fun (tr : Trading_strategy.Position.transition) ->
+                       tr.kind)
+                     (matching
+                        (function
+                          | Trading_strategy.Position.TriggerExit _ -> Some ()
+                          | _ -> None)
+                        (equal_to ()));
+                 ];
+             ])))
+
+(* ------------------------------------------------------------------ *)
 (* Stage 4-5 PR-A: lazy stage filter — survivors_for_screening         *)
 (* ------------------------------------------------------------------ *)
 
@@ -1464,6 +1575,12 @@ let () =
            >:: test_short_sleeve_active_admits_short;
            "short sleeve: short-notional cap still binds"
            >:: test_short_sleeve_short_notional_cap_binds;
+           "cash reserve default (0.0) admits all longs"
+           >:: test_cash_reserve_default_admits_all_longs;
+           "cash reserve active (0.30) reduces admitted longs"
+           >:: test_cash_reserve_active_reduces_admitted_longs;
+           "cash reserve never blocks exit"
+           >:: test_cash_reserve_never_blocks_exit;
            "survivors_for_screening filters by stage"
            >:: test_survivors_for_screening_filters_by_stage;
            "survivors_for_screening drops Stage1 and Stage3"


### PR DESCRIPTION
## What

Adds a working percentage cash-reserve knob `cash_reserve_pct : float [@sexp.default 0.0]` to `Weinstein_strategy.config`. On each Friday entry walk the spendable budget is reduced to `max 0 (portfolio.cash - cash_reserve_pct * portfolio_value)`, so a configured fraction of portfolio value is held back from **new entry funding**.

## Why

`Portfolio_risk.min_cash_pct` is dead code — its sole consumer `Portfolio_risk.check_limits` has **zero production callers** (`dev/notes/envelope-knobs-dead-2026-07-05.md`, merged #1861). Backtests run at ~89–99% deployment with **no cash-reserve mechanism at all**. This knob is the honest, live-path reserve, consumed at the one seam that actually gates entry funding (the entry-walk `remaining_cash`). It lets the reserve question — does holding 10–30% cash improve risk-adjusted results? — actually be tested as a WF-CV surface.

## Design / scope

- Wired at the entry-walk seed in `weinstein_strategy_screening.ml` (`_make_entry_walk_state ~cash:spendable`). `portfolio_value` is the figure the walk already computes (`Portfolio_view.portfolio_value ~get_price`) — no new valuation.
- Reserve taken off the **top-level budget once**. In the reserved-short-sleeve path (`short_sleeve_fraction > 0`) the long/short split derives from the reduced `spendable`, so it is never charged twice.
- **Entries only.** Exits, covers, stop orders, and force-liquidations do not flow through the entry walk and are structurally unaffected — a reserve can never block an exit (the #1553 exit-fill-reject lesson).
- No changes to `Portfolio_risk` (dead fields left alone), no core-module changes (Portfolio/Orders/Position/Engine).

## experiment-flag-discipline compliance

- **R1 (default-off):** `[@sexp.default 0.0]`; `spendable = cash` at 0.0 → bit-identical to baseline, every golden/baseline replays unchanged.
- **R2 (searchable):** real top-level `config` float field, resolves through `Overlay_validator.apply_overrides`; `((cash_reserve_pct 0.30))` is a valid `Variant_matrix` axis (pinned by a test against the real validator).
- **R3:** not wired into any default/preset; stays default-off pending a ledger ACCEPT + confirmation grid.

Faithfulness (W1/W2): a portfolio-risk / capital-preservation dial that *tightens* deployment; no spine item touched (stage classification, Stage-2-only buy, breakout+volume, stops, macro/sector gate all unchanged).

## Test plan

`test_weinstein_strategy.ml` (34/34 OK):
- reserve off (0.0) admits all 3 longs (bit-identical baseline);
- reserve on (0.30) funds against reduced $21k budget → 2 of 3 longs (third fits within cash but not the reserve-reduced budget → Insufficient_cash-equivalent);
- exit not blocked: held position hits stop under `cash_reserve_pct = 0.9` → `TriggerExit` still emitted.

`test_runner_hypothesis_overrides.ml` (27/27 OK):
- config default `0.0`; sexp round-trips explicit `0.30`;
- axis reachability through the real `Overlay_validator.apply_overrides`.

`dune build` + `dune build @fmt` (per-file ocamlformat verified) clean; both target suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)