### PR TITLE
feat(all-eligible): capture decision-time features (rs/volume/stage) on candidate records

### DIFF
--- a/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/bin/test/test_all_eligible_runner.ml
@@ -231,7 +231,7 @@ let test_trades_csv_has_header_only_when_no_trades _ =
          elements_are
            [
              _has
-               "signal_date,symbol,side,entry_price,exit_date,exit_reason,return_pct,hold_days,entry_dollars,shares,pnl_dollars,cascade_score,passes_macro";
+               "signal_date,symbol,side,entry_price,exit_date,exit_reason,return_pct,hold_days,entry_dollars,shares,pnl_dollars,cascade_score,passes_macro,rs_value,rs_trend,volume_ratio,weeks_advancing,stage2_late,resistance_quality";
            ];
        ])
 

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.ml
@@ -45,6 +45,12 @@ type trade_record = {
   pnl_dollars : float;
   cascade_score : int;
   passes_macro : bool;
+  rs_value : float option; [@sexp.option]
+  rs_trend : Weinstein_types.rs_trend option; [@sexp.option]
+  volume_ratio : float option; [@sexp.option]
+  weeks_advancing : int option; [@sexp.option]
+  stage2_late : bool option; [@sexp.option]
+  resistance_quality : Weinstein_types.overhead_quality option; [@sexp.option]
 }
 [@@deriving sexp]
 
@@ -92,6 +98,12 @@ let build_trade_record ~(config : config) (sc : OT.scored_candidate) :
     pnl_dollars;
     cascade_score = entry.cascade_score;
     passes_macro = entry.passes_macro;
+    rs_value = entry.rs_value;
+    rs_trend = entry.rs_trend;
+    volume_ratio = entry.volume_ratio;
+    weeks_advancing = entry.weeks_advancing;
+    stage2_late = entry.stage2_late;
+    resistance_quality = entry.resistance_quality;
   }
 
 (* ------------------------------------------------------------------ *)

--- a/trading/trading/backtest/all_eligible/lib/all_eligible.mli
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible.mli
@@ -136,6 +136,26 @@ type trade_record = {
       (** Whether the macro gate at [signal_date] would have admitted this
           candidate. Records both passes and fails so consumers can split the
           aggregate by macro regime without re-running the scan. *)
+  rs_value : float option; [@sexp.option]
+      (** Normalised relative-strength value at [signal_date] — carried through
+          from [candidate_entry.rs_value]. [None] when RS was not computable.
+          [@sexp.option] so pre-existing artefacts parse (absent → [None]). *)
+  rs_trend : Weinstein_types.rs_trend option; [@sexp.option]
+      (** RS trend at [signal_date] — from [candidate_entry.rs_trend]. [None]
+          when RS was not computable. *)
+  volume_ratio : float option; [@sexp.option]
+      (** Breakout-week volume expansion ratio — from
+          [candidate_entry.volume_ratio]. [None] when no breakout bar was
+          identifiable. *)
+  weeks_advancing : int option; [@sexp.option]
+      (** Weeks advancing in Stage 2 at [signal_date] — from
+          [candidate_entry.weeks_advancing]. [None] when not [Stage2]. *)
+  stage2_late : bool option; [@sexp.option]
+      (** Stage-2 late (MA-deceleration) flag — from
+          [candidate_entry.stage2_late]. [None] when not [Stage2]. *)
+  resistance_quality : Weinstein_types.overhead_quality option; [@sexp.option]
+      (** Overhead-resistance grade — from [candidate_entry.resistance_quality].
+          [None] when no breakout price could be determined. *)
 }
 [@@deriving sexp]
 (** One row per Stage-2 entry signal. Fixed-dollar sized, naturally exited.

--- a/trading/trading/backtest/all_eligible/lib/all_eligible_runner.ml
+++ b/trading/trading/backtest/all_eligible/lib/all_eligible_runner.ml
@@ -323,7 +323,7 @@ let _resolve_universe ~fixtures_root (scenario : Scenario_lib.Scenario.t) :
 (* ---------------------------------------------------------------- *)
 
 let _csv_header =
-  "signal_date,symbol,side,entry_price,exit_date,exit_reason,return_pct,hold_days,entry_dollars,shares,pnl_dollars,cascade_score,passes_macro"
+  "signal_date,symbol,side,entry_price,exit_date,exit_reason,return_pct,hold_days,entry_dollars,shares,pnl_dollars,cascade_score,passes_macro,rs_value,rs_trend,volume_ratio,weeks_advancing,stage2_late,resistance_quality"
 
 let _side_to_string : Trading_base.Types.position_side -> string = function
   | Long -> "LONG"
@@ -334,14 +334,33 @@ let _exit_reason_to_string : OT.exit_trigger -> string = function
   | Stop_hit -> "Stop_hit"
   | End_of_run -> "End_of_run"
 
+(** Render an optional feature column: the value when present, the empty string
+    when [None] — so a missing decision-time feature reads as a blank cell
+    rather than a sentinel that downstream parsers must special-case. *)
+let _opt_to_string ~f = function Some v -> f v | None -> ""
+
+let _rs_trend_to_string (t : Weinstein_types.rs_trend) : string =
+  Sexp.to_string (Weinstein_types.sexp_of_rs_trend t)
+
+let _resistance_quality_to_string (q : Weinstein_types.overhead_quality) :
+    string =
+  Sexp.to_string (Weinstein_types.sexp_of_overhead_quality q)
+
 let _trade_to_csv_row (t : All_eligible.trade_record) : string =
-  Printf.sprintf "%s,%s,%s,%.4f,%s,%s,%.6f,%d,%.2f,%.6f,%.4f,%d,%b"
+  Printf.sprintf
+    "%s,%s,%s,%.4f,%s,%s,%.6f,%d,%.2f,%.6f,%.4f,%d,%b,%s,%s,%s,%s,%s,%s"
     (Date.to_string t.signal_date)
     t.symbol (_side_to_string t.side) t.entry_price
     (Date.to_string t.exit_date)
     (_exit_reason_to_string t.exit_reason)
     t.return_pct t.hold_days t.entry_dollars t.shares t.pnl_dollars
     t.cascade_score t.passes_macro
+    (_opt_to_string ~f:(Printf.sprintf "%.6f") t.rs_value)
+    (_opt_to_string ~f:_rs_trend_to_string t.rs_trend)
+    (_opt_to_string ~f:(Printf.sprintf "%.6f") t.volume_ratio)
+    (_opt_to_string ~f:Int.to_string t.weeks_advancing)
+    (_opt_to_string ~f:Bool.to_string t.stage2_late)
+    (_opt_to_string ~f:_resistance_quality_to_string t.resistance_quality)
 
 let write_trades_csv ~path (result : All_eligible.result) : unit =
   let lines = _csv_header :: List.map result.trades ~f:_trade_to_csv_row in

--- a/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
+++ b/trading/trading/backtest/all_eligible/test/test_all_eligible.ml
@@ -35,7 +35,9 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     ?(side = Trading_base.Types.Long) ?(entry_price = 100.0)
     ?(suggested_stop = 92.0) ?(risk_pct = 0.08)
     ?(sector = "Information Technology") ?(cascade_grade = Weinstein_types.B)
-    ?(cascade_score = 50) ?(passes_macro = true) () : OT.candidate_entry =
+    ?(cascade_score = 50) ?(passes_macro = true) ?(rs_value = None)
+    ?(rs_trend = None) ?(volume_ratio = None) ?(weeks_advancing = None)
+    ?(stage2_late = None) ?(resistance_quality = None) () : OT.candidate_entry =
   {
     symbol;
     entry_week;
@@ -47,6 +49,12 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     cascade_grade;
     cascade_score;
     passes_macro;
+    rs_value;
+    rs_trend;
+    volume_ratio;
+    weeks_advancing;
+    stage2_late;
+    resistance_quality;
   }
 
 (** Build a synthetic [scored_candidate] from explicit per-trade outcome fields.
@@ -147,6 +155,73 @@ let test_build_trade_record_short _ =
          field
            (fun (t : AE.trade_record) -> t.exit_reason)
            (equal_to OT.Stop_hit);
+       ])
+
+let test_build_trade_record_threads_features _ =
+  (* The decision-time features on the [candidate_entry] are carried verbatim
+     onto the [trade_record] so downstream multivariate analysis reads them
+     from the flat per-trade row. *)
+  let candidate =
+    make_candidate ~symbol:"AAPL" ~entry_price:100.0 ~suggested_stop:92.0
+      ~rs_value:(Some 0.42) ~rs_trend:(Some Weinstein_types.Positive_rising)
+      ~volume_ratio:(Some 2.1) ~weeks_advancing:(Some 3)
+      ~stage2_late:(Some false)
+      ~resistance_quality:(Some Weinstein_types.Virgin_territory) ()
+  in
+  let scored : OT.scored_candidate =
+    {
+      entry = candidate;
+      exit_week = _date "2024-02-09";
+      exit_price = 130.0;
+      exit_trigger = OT.End_of_run;
+      raw_return_pct = 0.30;
+      hold_weeks = 3;
+      initial_risk_per_share = 8.0;
+      r_multiple = 3.75;
+    }
+  in
+  let trade = AE.build_trade_record ~config:AE.default_config scored in
+  assert_that trade
+    (all_of
+       [
+         field
+           (fun (t : AE.trade_record) -> t.rs_value)
+           (is_some_and (float_equal 0.42));
+         field
+           (fun (t : AE.trade_record) -> t.rs_trend)
+           (is_some_and (equal_to Weinstein_types.Positive_rising));
+         field
+           (fun (t : AE.trade_record) -> t.volume_ratio)
+           (is_some_and (float_equal 2.1));
+         field
+           (fun (t : AE.trade_record) -> t.weeks_advancing)
+           (is_some_and (equal_to 3));
+         field
+           (fun (t : AE.trade_record) -> t.stage2_late)
+           (is_some_and (equal_to false));
+         field
+           (fun (t : AE.trade_record) -> t.resistance_quality)
+           (is_some_and (equal_to Weinstein_types.Virgin_territory));
+       ])
+
+let test_build_trade_record_features_none_default _ =
+  (* When the candidate carries no features (the [make_candidate] default of
+     [None] across the board — the shape of a legacy candidate), the trade
+     record surfaces [None], not a sentinel. *)
+  let scored =
+    make_scored ~exit_week:(_date "2024-02-09") ~exit_price:130.0
+      ~exit_trigger:OT.End_of_run ()
+  in
+  let trade = AE.build_trade_record ~config:AE.default_config scored in
+  assert_that trade
+    (all_of
+       [
+         field (fun (t : AE.trade_record) -> t.rs_value) is_none;
+         field (fun (t : AE.trade_record) -> t.rs_trend) is_none;
+         field (fun (t : AE.trade_record) -> t.volume_ratio) is_none;
+         field (fun (t : AE.trade_record) -> t.weeks_advancing) is_none;
+         field (fun (t : AE.trade_record) -> t.stage2_late) is_none;
+         field (fun (t : AE.trade_record) -> t.resistance_quality) is_none;
        ])
 
 let test_custom_entry_dollars _ =
@@ -789,6 +864,10 @@ let suite =
   >::: [
          "build_trade_record long arithmetic" >:: test_build_trade_record_long;
          "build_trade_record short arithmetic" >:: test_build_trade_record_short;
+         "build_trade_record threads decision-time features"
+         >:: test_build_trade_record_threads_features;
+         "build_trade_record surfaces None features as None"
+         >:: test_build_trade_record_features_none_default;
          "custom entry_dollars sizes shares + pnl" >:: test_custom_entry_dollars;
          "three signals — all taken regardless of cash"
          >:: test_three_signals_all_taken_no_cash_gate;

--- a/trading/trading/backtest/optimal/lib/dune
+++ b/trading/trading/backtest/optimal/lib/dune
@@ -8,11 +8,14 @@
   trading.simulation
   types
   weinstein.data_source
+  weinstein.resistance
+  weinstein.rs
   weinstein.screener
   weinstein.snapshot_runtime
   weinstein.stage
   weinstein.stock_analysis
   weinstein.types
+  weinstein.volume
   weinstein_trading.stops
   backtest)
  (preprocess

--- a/trading/trading/backtest/optimal/lib/optimal_types.ml
+++ b/trading/trading/backtest/optimal/lib/optimal_types.ml
@@ -15,6 +15,12 @@ type candidate_entry = {
   cascade_grade : Weinstein_types.grade;
   cascade_score : int;
   passes_macro : bool;
+  rs_value : float option; [@sexp.option]
+  rs_trend : Weinstein_types.rs_trend option; [@sexp.option]
+  volume_ratio : float option; [@sexp.option]
+  weeks_advancing : int option; [@sexp.option]
+  stage2_late : bool option; [@sexp.option]
+  resistance_quality : Weinstein_types.overhead_quality option; [@sexp.option]
 }
 [@@deriving sexp]
 

--- a/trading/trading/backtest/optimal/lib/optimal_types.mli
+++ b/trading/trading/backtest/optimal/lib/optimal_types.mli
@@ -63,6 +63,33 @@ type candidate_entry = {
           candidate. The scanner records both passes and fails so the renderer
           can produce two report variants — constrained (macro gate kept) and
           relaxed (macro gate dropped). *)
+  rs_value : float option; [@sexp.option]
+      (** Normalised relative-strength value at [entry_week] — sourced from
+          [analysis.rs.current_normalized] (the {!Rs.result} the cascade
+          computed). [None] when RS was not computable (insufficient benchmark
+          history; see {!Stock_analysis.t.rs}). [@sexp.option] so on-disk
+          artefacts written before this field existed still parse (absent →
+          [None]). *)
+  rs_trend : Weinstein_types.rs_trend option; [@sexp.option]
+      (** Classified RS trend at [entry_week] — [analysis.rs.trend]. [None] when
+          RS was not computable. *)
+  volume_ratio : float option; [@sexp.option]
+      (** Breakout-week volume expansion ratio — [analysis.volume.volume_ratio]
+          (the {!Volume.result} the cascade computed). [None] when no breakout
+          bar was identifiable (see {!Stock_analysis.t.volume}). *)
+  weeks_advancing : int option; [@sexp.option]
+      (** Weeks the stock has been advancing in Stage 2 at [entry_week] — the
+          [weeks_advancing] field of [analysis.stage.stage] when it is a
+          [Stage2]. [None] when the classification is not [Stage2]. *)
+  stage2_late : bool option; [@sexp.option]
+      (** The [late] MA-deceleration flag of [analysis.stage.stage] when it is a
+          [Stage2] (still-hold-but-no-longer-a-buy warning). [None] when the
+          classification is not [Stage2]. *)
+  resistance_quality : Weinstein_types.overhead_quality option; [@sexp.option]
+      (** Overhead-resistance grade above the breakout —
+          [analysis.resistance.quality] (the {!Resistance.result} the cascade
+          computed). [None] when no breakout price could be determined (see
+          {!Stock_analysis.t.resistance}). *)
 }
 [@@deriving sexp]
 (** One row per (symbol, week) where the system's structural breakout condition

--- a/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/lib/stage_transition_scanner.ml
@@ -61,10 +61,24 @@ let _passes_long_macro = function
   | Weinstein_types.Bullish | Neutral -> true
   | Bearish -> false
 
+(** [(weeks_advancing, late)] of a [Stage2] classification, [(None, None)]
+    otherwise. Mirrors {!Trade_audit_recorder._weeks_advancing_of_stage} — the
+    two Stage2-only fields the counterfactual surfaces for the multivariate
+    screen. *)
+let _stage2_fields : Weinstein_types.stage -> int option * bool option =
+  function
+  | Stage2 { weeks_advancing; late } -> (Some weeks_advancing, Some late)
+  | Stage1 _ | Stage3 _ | Stage4 _ -> (None, None)
+
 (** Project one {!Screener.scored_candidate} (long side) into an
-    {!Optimal_types.candidate_entry}, stamping the actual macro at [date]. *)
+    {!Optimal_types.candidate_entry}, stamping the actual macro at [date] and
+    the decision-time features from [sc.analysis]. The feature projections
+    mirror {!Trade_audit_recorder._entry_decision_of_event} field-for-field so
+    the two audit surfaces read the same values. *)
 let _candidate_of_scored ~date ~passes_macro (sc : Screener.scored_candidate) :
     Optimal_types.candidate_entry =
+  let analysis = sc.analysis in
+  let weeks_advancing, stage2_late = _stage2_fields analysis.stage.stage in
   {
     symbol = sc.ticker;
     entry_week = date;
@@ -76,6 +90,16 @@ let _candidate_of_scored ~date ~passes_macro (sc : Screener.scored_candidate) :
     cascade_grade = sc.grade;
     cascade_score = sc.score;
     passes_macro;
+    rs_value =
+      Option.map analysis.rs ~f:(fun (r : Rs.result) -> r.current_normalized);
+    rs_trend = Option.map analysis.rs ~f:(fun (r : Rs.result) -> r.trend);
+    volume_ratio =
+      Option.map analysis.volume ~f:(fun (v : Volume.result) -> v.volume_ratio);
+    weeks_advancing;
+    stage2_late;
+    resistance_quality =
+      Option.map analysis.resistance ~f:(fun (r : Resistance.result) ->
+          r.quality);
   }
 
 let scan_week ~config (week : week_input) : Optimal_types.candidate_entry list =

--- a/trading/trading/backtest/optimal/test/dune
+++ b/trading/trading/backtest/optimal/test/dune
@@ -24,6 +24,7 @@
   weinstein.stage
   weinstein.rs
   weinstein.volume
+  weinstein.resistance
   weinstein_trading.stops
   backtest
   backtest_optimal)

--- a/trading/trading/backtest/optimal/test/test_optimal_portfolio_filler.ml
+++ b/trading/trading/backtest/optimal/test/test_optimal_portfolio_filler.ml
@@ -42,6 +42,12 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     cascade_grade;
     cascade_score;
     passes_macro;
+    rs_value = None;
+    rs_trend = None;
+    volume_ratio = None;
+    weeks_advancing = None;
+    stage2_late = None;
+    resistance_quality = None;
   }
 
 (** Build a synthetic [scored_candidate]. The R-multiple is given directly so

--- a/trading/trading/backtest/optimal/test/test_outcome_scorer.ml
+++ b/trading/trading/backtest/optimal/test/test_outcome_scorer.ml
@@ -43,6 +43,12 @@ let make_candidate ?(symbol = "AAPL") ?(entry_week = _date "2024-01-19")
     cascade_grade;
     cascade_score;
     passes_macro;
+    rs_value = None;
+    rs_trend = None;
+    volume_ratio = None;
+    weeks_advancing = None;
+    stage2_late = None;
+    resistance_quality = None;
   }
 
 (** Build a synthetic [Daily_price.t] for a weekly bar. The weekly walker only

--- a/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
+++ b/trading/trading/backtest/optimal/test/test_stage_transition_scanner.ml
@@ -46,6 +46,7 @@ let make_analysis ?(ticker = "AAPL")
     ?(ma_value = 100.0) ?(ma_direction = Weinstein_types.Rising)
     ?(ma_slope_pct = 0.02) ?(volume_quality = Some (Weinstein_types.Strong 2.5))
     ?(rs_trend = Some Weinstein_types.Positive_rising)
+    ?(resistance : Resistance.result option = None)
     ?(breakout_price = Some 105.0) ?(as_of_date = _date "2024-01-19") () :
     Stock_analysis.t =
   let stage : Stage.result =
@@ -77,7 +78,7 @@ let make_analysis ?(ticker = "AAPL")
     stage;
     rs;
     volume;
-    resistance = None;
+    resistance;
     support = None;
     breakout_price;
     breakdown_price = None;
@@ -128,6 +129,12 @@ let test_candidate_entry_sexp_round_trip _ =
       cascade_grade = A;
       cascade_score = 75;
       passes_macro = true;
+      rs_value = Some 0.5;
+      rs_trend = Some Weinstein_types.Positive_rising;
+      volume_ratio = Some 2.5;
+      weeks_advancing = Some 2;
+      stage2_late = Some false;
+      resistance_quality = Some Weinstein_types.Clean;
     }
   in
   let round = OT.candidate_entry_of_sexp (OT.sexp_of_candidate_entry entry) in
@@ -142,6 +149,24 @@ let test_candidate_entry_sexp_round_trip _ =
            (fun (e : OT.candidate_entry) -> e.cascade_grade)
            (equal_to Weinstein_types.A);
          field (fun (e : OT.candidate_entry) -> e.passes_macro) (equal_to true);
+         field
+           (fun (e : OT.candidate_entry) -> e.rs_value)
+           (is_some_and (float_equal 0.5));
+         field
+           (fun (e : OT.candidate_entry) -> e.rs_trend)
+           (is_some_and (equal_to Weinstein_types.Positive_rising));
+         field
+           (fun (e : OT.candidate_entry) -> e.volume_ratio)
+           (is_some_and (float_equal 2.5));
+         field
+           (fun (e : OT.candidate_entry) -> e.weeks_advancing)
+           (is_some_and (equal_to 2));
+         field
+           (fun (e : OT.candidate_entry) -> e.stage2_late)
+           (is_some_and (equal_to false));
+         field
+           (fun (e : OT.candidate_entry) -> e.resistance_quality)
+           (is_some_and (equal_to Weinstein_types.Clean));
        ])
 
 let test_scored_candidate_sexp_round_trip _ =
@@ -157,6 +182,12 @@ let test_scored_candidate_sexp_round_trip _ =
       cascade_grade = B;
       cascade_score = 60;
       passes_macro = true;
+      rs_value = None;
+      rs_trend = None;
+      volume_ratio = None;
+      weeks_advancing = None;
+      stage2_late = None;
+      resistance_quality = None;
     }
   in
   let scored : OT.scored_candidate =
@@ -526,6 +557,111 @@ let test_scan_week_emits_entry_and_stop_consistent _ =
        ])
 
 (* ------------------------------------------------------------------ *)
+(* Decision-time feature projection                                     *)
+(* ------------------------------------------------------------------ *)
+
+let _single_week_scan ~analysis : OT.candidate_entry list =
+  S.scan_week ~config:default_config
+    {
+      date = _date "2024-01-19";
+      macro_trend = Bullish;
+      analyses = [ analysis ];
+      sector_map =
+        make_sector_map [ ("AAPL", "Information Technology", Strong) ];
+    }
+
+let test_scan_week_projects_all_features _ =
+  (* A Stage2 breakout candidate with RS, volume, and resistance present:
+     every decision-time feature is projected from [sc.analysis]. Stage2
+     with weeks_advancing=3, late=true; RS Positive_rising normalized 0.5;
+     volume Strong 2.5 → volume_ratio 2.5; resistance quality Clean. *)
+  let analysis =
+    make_analysis ~ticker:"AAPL"
+      ~stage_value:(Stage2 { weeks_advancing = 3; late = true })
+      ~volume_quality:(Some (Strong 2.5)) ~rs_trend:(Some Positive_rising)
+      ~resistance:
+        (Some
+           {
+             Resistance.quality = Clean;
+             breakout_price = 105.0;
+             zones_above = [];
+             nearest_zone = None;
+           })
+      ()
+  in
+  assert_that
+    (_single_week_scan ~analysis)
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (c : OT.candidate_entry) -> c.rs_value)
+               (is_some_and (float_equal 0.5));
+             field
+               (fun (c : OT.candidate_entry) -> c.rs_trend)
+               (is_some_and (equal_to Weinstein_types.Positive_rising));
+             field
+               (fun (c : OT.candidate_entry) -> c.volume_ratio)
+               (is_some_and (float_equal 2.5));
+             field
+               (fun (c : OT.candidate_entry) -> c.weeks_advancing)
+               (is_some_and (equal_to 3));
+             field
+               (fun (c : OT.candidate_entry) -> c.stage2_late)
+               (is_some_and (equal_to true));
+             field
+               (fun (c : OT.candidate_entry) -> c.resistance_quality)
+               (is_some_and (equal_to Weinstein_types.Clean));
+           ];
+       ])
+
+let test_scan_week_projects_none_when_absent _ =
+  (* RS and resistance are [None] on the analysis (rs_trend:None → rs=None;
+     resistance defaults to None); the projection preserves [None] rather
+     than substituting a sentinel. Volume stays Strong so the candidate is
+     still a breakout (RS None does not disqualify). *)
+  let analysis = make_analysis ~ticker:"AAPL" ~rs_trend:None () in
+  assert_that
+    (_single_week_scan ~analysis)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun (c : OT.candidate_entry) -> c.rs_value) is_none;
+             field (fun (c : OT.candidate_entry) -> c.rs_trend) is_none;
+             field
+               (fun (c : OT.candidate_entry) -> c.resistance_quality)
+               is_none;
+           ];
+       ])
+
+let test_candidate_entry_legacy_sexp_parses _ =
+  (* Backward-compat: a [candidate_entry] sexp written before the feature
+     fields existed (i.e. without rs_value / rs_trend / volume_ratio /
+     weeks_advancing / stage2_late / resistance_quality) must still parse —
+     the absent [@sexp.option] fields default to [None]. *)
+  let legacy_sexp =
+    Sexp.of_string
+      "((symbol AAPL) (entry_week 2024-01-19) (side Long) (entry_price 105.5) \
+       (suggested_stop 97.06) (risk_pct 0.08) (sector \"Information \
+       Technology\") (cascade_grade A) (cascade_score 75) (passes_macro true))"
+  in
+  assert_that
+    (OT.candidate_entry_of_sexp legacy_sexp)
+    (all_of
+       [
+         field (fun (e : OT.candidate_entry) -> e.symbol) (equal_to "AAPL");
+         field (fun (e : OT.candidate_entry) -> e.cascade_score) (equal_to 75);
+         field (fun (e : OT.candidate_entry) -> e.rs_value) is_none;
+         field (fun (e : OT.candidate_entry) -> e.rs_trend) is_none;
+         field (fun (e : OT.candidate_entry) -> e.volume_ratio) is_none;
+         field (fun (e : OT.candidate_entry) -> e.weeks_advancing) is_none;
+         field (fun (e : OT.candidate_entry) -> e.stage2_late) is_none;
+         field (fun (e : OT.candidate_entry) -> e.resistance_quality) is_none;
+       ])
+
+(* ------------------------------------------------------------------ *)
 (* Scanner: scan_panel — multi-week aggregation                         *)
 (* ------------------------------------------------------------------ *)
 
@@ -610,6 +746,12 @@ let suite =
          >:: test_scan_week_empty_analyses;
          "scan_week entry/stop/risk match screener formulas"
          >:: test_scan_week_emits_entry_and_stop_consistent;
+         "scan_week projects all decision-time features"
+         >:: test_scan_week_projects_all_features;
+         "scan_week projects None when RS / resistance absent"
+         >:: test_scan_week_projects_none_when_absent;
+         "candidate_entry legacy sexp (no feature fields) parses"
+         >:: test_candidate_entry_legacy_sexp_parses;
          "scan_panel concatenates per-week output in order"
          >:: test_scan_panel_concatenates_in_order;
          "scan_panel empty weeks → empty output" >:: test_scan_panel_empty_weeks;


### PR DESCRIPTION
## What

Extends the optimal-lens / all-eligible candidate records with the decision-time
features already computed in `Screener.scored_candidate.analysis`
(`Stock_analysis.t`), so the upcoming multivariate screen (P0a/P0b of
`dev/notes/next-session-priorities-2026-07-07.md`) can regress counterfactual
outcome on the full per-ticket feature vector.

Six new **option-typed, `[@sexp.option]`** fields added to
`Backtest_optimal.Optimal_types.candidate_entry` and threaded onto
`Backtest_all_eligible.All_eligible.trade_record` + the trades CSV:

| field | source (`analysis`) |
|---|---|
| `rs_value : float option` | `analysis.rs.current_normalized` |
| `rs_trend : Weinstein_types.rs_trend option` | `analysis.rs.trend` |
| `volume_ratio : float option` | `analysis.volume.volume_ratio` |
| `weeks_advancing : int option` | `analysis.stage.stage` when `Stage2` |
| `stage2_late : bool option` | `Stage2`'s `late` flag |
| `resistance_quality : Weinstein_types.overhead_quality option` | `analysis.resistance.quality` |

The projection in `Stage_transition_scanner._candidate_of_scored` mirrors
`Backtest.Trade_audit_recorder._entry_decision_of_event` field-for-field, so the
two audit surfaces read identical values. `None` is preserved (never a sentinel)
when a sub-analysis was not computable.

CSV: `all_eligible_runner` emits six new columns
(`rs_value,rs_trend,volume_ratio,weeks_advancing,stage2_late,resistance_quality`),
empty string for `None`.

## Why

Today the records carry only score/grade/sector/risk_pct/passes_macro — the
multivariate screen needs rs/volume/stage/resistance too. The features are
already in hand at capture time; this PR only captures what the analysis
computed. The RS-warmup gap (rs frequently `None` in short windows) is a
separate, explicitly out-of-scope item — this PR captures `None` faithfully.

## Backward compatibility

All new fields use `[@sexp.option]`, so on-disk artefact sexps written before
these fields existed still parse (absent → `None`). Pinned by
`test_candidate_entry_legacy_sexp_parses`.

## Test plan

`dune build && dune runtest` on `trading/backtest/optimal` +
`trading/backtest/all_eligible` — green (exit 0), zero warnings, `dune fmt`
clean. New tests:
- scanner projects all six features from `sc.analysis` (present case)
- scanner preserves `None` when RS / resistance absent
- legacy sexp (no feature fields) parses → all `None`
- round-trip test extended to cover the new fields (Some + None cases)
- `All_eligible.build_trade_record` threads features through (Some + None)
- runner CSV header pin updated to the 19-column header

Not in scope: `warmup_days` change, ADV/liquidity capture, any `weinstein/` or
`analysis/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
