### PR TITLE
docs(experiment): feature-screen — passes_macro mechanism correction + bull-proxy robustness (null holds)

### DIFF
--- a/dev/experiments/feature-screen-2026-07-08/FINDINGS.md
+++ b/dev/experiments/feature-screen-2026-07-08/FINDINGS.md
@@ -94,9 +94,19 @@ per-ticket mean at flat total — the capacity question, not a selection one.
   robust direction (optimism can only overstate signal, and there is none).
 - **Complete-case**: 26.9% of tickets lack RS (young/short-history names +
   the warmup artifact, `project_rs_warmup_gap` — ~1.6% of a 26y window).
-- **passes_macro degenerate** (all-true): the scanner path ran without
-  breadth/A-D inputs → macro never Bearish. Harness note; does not affect
-  the within-population regressions (it was excluded as constant).
+- **passes_macro ≡ true BY DESIGN, and it survives a robustness check**
+  (correction 2026-07-08, prompted by user review): the all-eligible runner
+  deliberately hardcodes `macro_trend = Neutral` every Friday
+  (`all_eligible_runner.ml:231`; doc comment: "this diagnostic doesn't
+  consume one") — NOT missing breadth data as first written. Consequence:
+  the population includes tickets from macro-Bearish weeks the live gate
+  (spine #6) would veto, so the null was initially answered on the UNGATED
+  population. **Robustness refit** excluding bear stretches (2000-03..2003-06,
+  2007-10..2009-06, 2020-02..2020-06, 2022) as a date-proxy for the gate,
+  n = 78,727: R² = 0.0045, AUC = 0.763, identical signs, same
+  frequency/magnitude tradeoff (Positive_rising +0.50 logit / −11.9
+  return-pp). The closure is not an artifact of pooling bear-week tickets.
+  (`report-grade-F-bullproxy.md`.)
 - **weeks_advancing ≡ 1 by construction** (the scanner fires at the
   Stage1→2 transition) — this population cannot test entry-freshness; that
   axis was separately validated (early_stage2 ≤ 4, 2026-07-06).

--- a/dev/experiments/feature-screen-2026-07-08/report-grade-F-bullproxy.md
+++ b/dev/experiments/feature-screen-2026-07-08/report-grade-F-bullproxy.md
@@ -1,0 +1,75 @@
+feature_screen: 111895 rows, 78727 complete-case; report (stdout)
+# Feature screen — all-eligible trades
+
+Rows parsed: 111895; complete-case rows (full fit): 78727.
+
+## Feature coverage (pre complete-case)
+
+| Feature | Present | Total | % |
+|---|---|---|---|
+| cascade_score | 111895 | 111895 | 100.0% |
+| rs_value | 78831 | 111895 | 70.5% |
+| volume_ratio | 111895 | 111895 | 100.0% |
+| rs_trend | 78831 | 111895 | 70.5% |
+| resistance_quality | 111782 | 111895 | 99.9% |
+
+## OLS — return_pct on features (HC1-robust SE)
+
+n = 78727, p = 11, R² = 0.004547
+
+| term | coef | se | t |
+|---|---|---|---|
+| intercept | +6.250907 | 2.863848 | +2.183 |
+| cascade_score | -1.860958 | 3.178503 | -0.585 |
+| rs_value | +22.498070 | 12.148994 | +1.852 |
+| volume_ratio | -0.694433 | 0.566661 | -1.225 |
+| rs_trend=Positive_rising | -11.870070 | 5.542458 | -2.142 |
+| rs_trend=Positive_flat | -9.403553 | 3.862485 | -2.435 |
+| rs_trend=Negative_improving | +0.720789 | 2.208177 | +0.326 |
+| rs_trend=Bearish_crossover | -0.800054 | 1.985400 | -0.403 |
+| resistance_quality=Clean | +3.269826 | 4.540809 | +0.720 |
+| resistance_quality=Moderate_resistance | -2.062427 | 2.299263 | -0.897 |
+| resistance_quality=Heavy_resistance | -2.121769 | 3.366320 | -0.630 |
+
+## Logistic — P(win) on features
+
+n = 78727, p = 11, in-sample AUC = 0.7625, converged = true
+
+| term | coef | se | z |
+|---|---|---|---|
+| intercept | -3.384755 | 0.074738 | -45.289 |
+| cascade_score | +0.058798 | 0.039528 | +1.488 |
+| rs_value | +0.342322 | 0.020058 | +17.067 |
+| volume_ratio | -0.030742 | 0.024060 | -1.278 |
+| rs_trend=Positive_rising | +0.496127 | 0.043866 | +11.310 |
+| rs_trend=Positive_flat | -0.283088 | 0.072941 | -3.881 |
+| rs_trend=Negative_improving | -1.408749 | 0.101083 | -13.936 |
+| rs_trend=Bearish_crossover | -1.490514 | 0.160174 | -9.306 |
+| resistance_quality=Clean | +1.332380 | 0.046919 | +28.398 |
+| resistance_quality=Moderate_resistance | +1.166145 | 0.051634 | +22.585 |
+| resistance_quality=Heavy_resistance | +1.327603 | 0.065602 | +20.237 |
+
+## Era-split coefficient sign stability (OLS)
+
+Eras: 2000-2008, 2009-2017, 2018-2026 (`.` = era not fit; sign order matches header)
+
+| term | full | 2000-2008 | 2009-2017 | 2018-2026 | stable |
+|---|---|---|---|---|---|
+| intercept | + | + + + | yes |
+| cascade_score | - | - - - | yes |
+| rs_value | + | + + + | yes |
+| volume_ratio | - | - - - | yes |
+| rs_trend=Positive_rising | - | - - - | yes |
+| rs_trend=Positive_flat | - | - - - | yes |
+| rs_trend=Negative_improving | + | - + + | NO |
+| rs_trend=Bearish_crossover | - | - - - | yes |
+| resistance_quality=Clean | + | + + - | NO |
+| resistance_quality=Moderate_resistance | - | - - - | yes |
+| resistance_quality=Heavy_resistance | - | - - - | yes |
+
+## Screen-rigor caveats
+
+- IN-SAMPLE fit only — no out-of-sample / walk-forward validation. R² and AUC are optimistic by construction.
+- COMPLETE-CASE bias: rows missing any selected feature are dropped; the coverage table above quantifies the loss. Stage-2-only features (weeks_advancing, stage2_late) and RS features are the None-heavy ones.
+- SURVIVORSHIP / population: the all-eligible CSV reflects the universe snapshot it was generated from; delisted-name coverage is bounded by the source snapshot.
+- This is a READ-ONLY SCREEN. It can support a no-build DECISION or an escalate-to-WF-CV decision; it CANNOT claim causal or deployable alpha. A mechanism is only rejected by the real test (default-off flag + walk-forward CV + confirmation grid).


### PR DESCRIPTION
## What

User review flagged the passes_macro caveat in the feature-screen FINDINGS. Two corrections:

1. **Mechanism**: `passes_macro ≡ true` is BY DESIGN — `all_eligible_runner` hardcodes `macro_trend = Neutral` per Friday (all_eligible_runner.ml:231) — not missing breadth data as first written.
2. **Substance**: that means the powered null was answered on the UNGATED population (includes tickets from macro-Bearish weeks the live gate vetoes). Ran the robustness refit excluding bear stretches (date-proxy for the gate), n=78,727: **R² = 0.0045, AUC = 0.763, identical signs and frequency/magnitude tradeoff** — the closure is not an artifact of pooling bear-week tickets. New artifact: report-grade-F-bullproxy.md.

Docs-only; CI-only gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)