### PR TITLE
docs+fixtures: 364-basis deep topline + P1a deep short screens + P1b breaker design

### DIFF
--- a/dev/backtest/DEEP_RESULTS.md
+++ b/dev/backtest/DEEP_RESULTS.md
@@ -13,6 +13,20 @@ names — they are NOT bankable as realized P&L. See the caveats column + the
 liquidity-overlay row. The honest comparison is *vs the index over the same window*
 and *realized vs MTM*, not the raw absolute.
 
+> ⚠ **Warmup-basis warning (2026-07-08):** every block below EXCEPT the
+> "364 basis" section was measured on the pre-#1890 **210-day warmup** basis
+> (RS-starved first 22 weeks). Absolute numbers are NOT comparable to runs made
+> after 2026-07-08. Relative comparisons within a block remain valid.
+
+## Broad — top-3000 PIT-2000, 2000-01-01 .. 2026-04-30 (26.3y), **364 basis**, Cell-E 0.14 + catstop 0.10
+
+First deep re-measure on the RS-honest basis (2026-07-09; full record:
+`dev/notes/deep-remeasure-364-2026-07-09.md`).
+
+| Sleeve / config | Total return (MTM) | Realized-basis | Sharpe | MaxDD | Scenario sexp | Notes |
+|---|---|---|---|---|---|---|
+| **Long-only + catstop 0.10** | **+2062.6%** (12.4%/yr) | **≈ +475%** (6.9%/yr) | 0.417 | 59.4% raw / **50.3% despiked** | `goldens-sp500-historical/top3000-2000-2026-catstop.sexp` | MTM headline = AXTI open position ($15.3M of $20.1M OPV). Raw MaxDD is an **MSZ corrupt-bar artifact** (recurring 13× one-day spike-revert bars in a delisted micro-cap, ELCO-class); despiked DD = real 2021-02→2025-05 underwater. Same-window **SPY TR +686.6% (8.15%/yr)** — realized still below TR-SPY. 0 portfolio-floor liqs; 5 zombie stale holds (stale-exit flag off). |
+
 ## Broad — top-3000 PIT-1998, 1998-01-01 .. 2026-04-30 (28.3y), Cell-E 0.14 concentration
 
 | Sleeve / config | Total return | CAGR | Sharpe | MaxDD | Worst day | Scenario sexp | Notes |

--- a/dev/notes/deep-remeasure-364-2026-07-09.md
+++ b/dev/notes/deep-remeasure-364-2026-07-09.md
@@ -1,0 +1,88 @@
+# Deep top-3000 re-measure on the 364 (RS-honest) basis — 2026-07-09
+
+The user-directed overnight run from `next-session-priorities-2026-07-08-PM.md`
+(§End-of-session overnight run). First deep top-3000 measurement on the
+warmup-364 basis (#1890); replaces the stale 210-basis references (917.9% /
++1552%).
+
+**Scenario:** `goldens-sp500-historical/top3000-2000-2026-catstop.sexp` —
+top-3000-2000 PIT, 2000-01-01..2026-04-30 (26.3y), long-only, Cell-E 0.14
+concentration, catastrophic_stop 0.10, stage3-force-exit hyst-1, laggard hyst-2.
+Snapshot mode against the rebuilt `/tmp/snap_top3000_1998_2026` (364-window,
+2999 snaps). Liquidity overlay OFF, stale-exit flag OFF (defaults). Wall 73 min.
+
+## Headline vs honest split
+
+| measure | value | per-yr |
+|---|---|---|
+| Total return (MTM) | **+2062.6%** ($21.63M) | 12.4% |
+| — of which terminal unrealized MTM | $15.88M (AXTI alone $15.3M) | |
+| **Realized-basis end equity** (cash + open cost basis) | **≈ $5.75M ≈ +475%** | 6.9% |
+| SPY TOTAL-RETURN same window (adj close 91.13→716.81) | **+686.6%** | 8.15% |
+| SPX raw price same window | +395.4% | 6.3% |
+| Sharpe / Sortino / Calmar / Ulcer | 0.417 / 0.449 / 0.208 / 26.5 | |
+| Trades / win% / avg hold | 984 / 35.9% / 47.8d | |
+| Force liqs | 5 (all per-position; **0 portfolio-floor**) | |
+
+Same shape as the 28y broad block in `DEEP_RESULTS.md`: the MTM headline is one
+open fat-tail monster (AXTI, entered 2025-06-28 @ $2.19, marks $79.22 = $15.3M
+of the $20.1M OPV); the realized number sits **below TR-SPY**. The RS-honest
+basis lifts the deep broad number a lot (210-basis 28y long-only was +721%
+MTM / this 26y run is +2063% MTM) but does not change the honest structural
+conclusion: realized < TR-SPY, edge concentrated in the fat tail.
+
+## MaxDD 59.4% is an artifact — MSZ corrupt bars (new ELCO-class instance)
+
+The reported MaxDD (peak 2014-08-15) traces to **recurring corrupt one-day bars
+in MSZ**, a delisted micro-cap held 2014-08-02→2015-01-10 (141,467 sh @ ~$1.90):
+
+- 2014-08-15 bar: 1.90 → **25.32/25.38/25.28/25.36** → 1.90 next day (13.3×,
+  adjusted_close spikes identically → raw EODHD artifact, in the warehouse too).
+- Same spike-revert on 2014-11-11, 2014-12-24+26, 2014-12-31, 2015-01-06 —
+  each a one/two-day +130-140% NAV blip ($2.3M → $5.6-5.8M → back).
+- Realized MSZ P&L was ordinary (+$63.7k); the damage is measurement-only
+  (phantom NAV peaks → phantom drawdowns).
+
+**Despiked (11-day-median filter) MaxDD = 50.3%**, peak 2021-02-09 → trough
+2025-05-14: a REAL 4-year underwater stretch from the meme-era MTM peak
+($12.3M Feb-2021 → ~$6.1M May-2025), followed by the AXTI 2025-26 moonshot.
+That is the honest tail picture at 0.14 concentration on this basis.
+
+Follow-ups this suggests:
+1. **Liquidity overlay validation case #2** — MSZ at ~$60k/day dollar-ADV would
+   be entry-gated by the default-off overlay (#1760), removing both the phantom
+   DD and the position. (ELCO was case #1, short side; MSZ is long side +
+   corrupt-bar flavor.)
+2. **Data-quality screen** on the warehouse: one-day ≥5× spike-revert bars in
+   sub-$5 names are detectable mechanically; worth a small audit exe before the
+   next deep re-baseline. Filed as a follow-up in the P1 track, not built.
+
+## Zombie stale holds (stale-exit flag OFF)
+
+5 open "positions" at run end are delisted zombies marked at last close: IN1
+(last bar 2005-02-25!), BVSN (2020), VIAS (2014), MGI, DSPG. The default-off
+stale-exit flag (#1487) exists for exactly this; their residual marks are small
+vs AXTI but nonzero. Any future promoted-config deep run should consider arming
+it alongside the liquidity overlay for the honest-tradeable variant.
+
+## Relative-verdict sanity
+
+Nothing here re-litigates ledger verdicts (baseline and variants were equally
+RS-starved pre-364; relative comparisons stand). This run refreshes the
+ABSOLUTE topline only. Per the 2026-07-08 rule: do not mix pre-07-08 absolute
+numbers with post-07-08 runs.
+
+## Reproduce
+
+```bash
+docker exec -d trading-1-dev bash -c 'cd /workspaces/trading-1/trading && eval $(opam env) && \
+  export TRADING_DATA_DIR=/workspaces/trading-1/trading/test_data && \
+  ./_build/default/trading/backtest/scenarios/scenario_runner.exe \
+    --dir <staged dir with top3000-2000-2026-catstop.sexp> \
+    --snapshot-dir /tmp/snap_top3000_1998_2026 --parallel 1 --no-emit-all-eligible'
+```
+
+Raw outputs (gitignored): `trading/dev/backtest/scenarios-2026-07-09-032112/top3000-2000-2026-catstop-deep/`.
+Note the fixtures-root gotcha: without `TRADING_DATA_DIR=test_data` the
+scenario's `universe_path` resolves against `data/backtest_scenarios` and
+crashes (first launch attempt did exactly that).

--- a/dev/notes/next-session-priorities-2026-07-09.md
+++ b/dev/notes/next-session-priorities-2026-07-09.md
@@ -1,0 +1,80 @@
+# Next-session priorities — 2026-07-09
+
+**Supersedes** `next-session-priorities-2026-07-08-PM.md`. Both of its P1a/P1
+run-items are DONE (overnight autonomous session 07-08→09); P1b design is
+drafted. Main was green at rampup (postsubmits from #1893 in flight).
+
+## What the overnight session shipped
+
+1. **Deep top-3000 re-measure on the 364 basis** (the user-directed overnight
+   run — it had NOT been launched at the prior handoff; launched + completed
+   this session, 73 min). `dev/notes/deep-remeasure-364-2026-07-09.md` +
+   DEEP_RESULTS.md §364-basis:
+   - MTM **+2062.6%** (12.4%/yr) but $15.3M of $21.6M end equity = ONE open
+     AXTI position; **realized-basis ≈ +475% (6.9%/yr) < SPY TOTAL-RETURN
+     +686.6% (8.15%/yr)** same window. Honest structural picture unchanged.
+   - **Raw MaxDD 59.4% is FAKE** — MSZ (delisted micro-cap) has recurring
+     corrupt 13× one-day spike-revert bars (raw EODHD, in the warehouse).
+     Despiked MaxDD **50.3%** = real 2021-02→2025-05 underwater. MSZ =
+     liquidity-overlay validation case #2 (ELCO was #1).
+   - 0 portfolio-floor liqs at 0.14 conc; 5 zombie stale holds (#1487 off).
+2. **P1a deep re-screens** (2000-2010, sp500-2000 PIT, real mechanisms, 364
+   basis) — `dev/notes/p1a-deep-short-screens-364-2026-07-09.md`:
+   - **Faithful-short gates: no window where they add edge.** Short leg IS
+     deep-additive (ungated 296%/DD30.7 vs long-only 251%/40.6) but UNGATED
+     dominates both gates. WHY: deep short value is **hedge-shaped** (early-
+     bear NAV smoothing), and the gates block exactly those hedges (grind's
+     8-week confirm too slow). Gates stay default-off axes.
+   - **Arming speed (#1708) NOT inert deep** (contradicts 06-22 expectation):
+     cat10+armon 283.1% vs cat10 266.6% vs base 251.4%, DD flat; isolation arm
+     clean. Promising → see P1-next.
+3. **P1b design doc**: `dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md`
+   — breaker state machine, index-referenced windowed peak (squeeze-immune, the
+   GME lesson), asymmetric fast/slow re-entry, eval plan vs TR-SPY.
+4. **Carried breadth fix**: re-fetched unicorn NYSE advn/decln (13,873 rows,
+   1965→2020-02 upstream end) into `data/breadth/` — the 2 local-only
+   `ad_bars` test failures now pass.
+5. New fixtures: `experiments/build2-arming-speed-deep-screen-2026-07-08/`
+   (4 arms, committed with this PR).
+
+## P1 — next (priority order)
+
+1. **Arming-speed deep WF-CV** — the screens gave the missing macro-regime
+   cell as a point estimate; run the fold-distribution version (walk-forward
+   spec on the 2000-2010/2000-2026 deep base, axes: catastrophic_stop_pct
+   {0,0.10} × fast_v_arm_on_rate_alone {false,true}) before any
+   `catstop+armon` preset-promotion conversation (promotion-confirmation grid
+   needs it anyway; W2 citation = crash tail-insurance).
+2. **P1b build mandate (user):** the circuit-breaker sleeve design is drafted;
+   build is default-off + behavior-relevant → wants an explicit go. The
+   faithful-short screen's forward guidance STRENGTHENS the case (hedge-shaped
+   crash protection is the working lever class; per-trade gates are not).
+3. **P1c blending stays PARKED** until P1b produces a floor worth blending.
+
+## Decision items (human)
+
+1. `check_limits` wire-or-delete (carried; DELETE now natural).
+2. `Portfolio_floor` monotonic-peak semantics (carried; the P1b design shows
+   the squeeze-robust alternative — index-referenced windowed peak).
+3. `neutral_blocks_shorts` faithfulness flip: deep cost now quantified
+   (−8.6pp return, +7.8pp MaxDD on 2000-2010). Mandate call.
+
+## Bugs / small follow-ups found this session
+
+- **Short leaked past `enable_short_side=false`**: LH 2001-06-13→16, SHORT,
+  laggard_rotation exit, in the faithful-short 00 long-only reference run.
+  The laggard-rotation path appears to bypass the short flag. Small but a
+  correctness bug — worth a feat-agent one-shot with a pinning test.
+- **MSZ-class corrupt bars**: mechanical warehouse audit idea — flag ≥5×
+  one-day spike-revert bars in sub-$5 names before the next deep re-baseline.
+- `write_ledger_entry.exe` doesn't regen `index.sexp` (carried).
+- `feature_screen` constant-feature failwith nit (carried).
+- goldens-small still at 0.14 concentration override (carried, intentional).
+
+## Standing constraints (unchanged)
+
+Entry-selection CLOSED (powered null); scale-in / reallocation / envelope /
+stop-tuning closed. Weinstein spine fixed. Open frontier: **floor quality
+(fast circuit breaker + hedge-shaped shorts) → then blending; capacity/breadth
+economics.** Comparators TOTAL-RETURN always. All pre-2026-07-08 absolute
+numbers are 210-basis — re-measure before citing.

--- a/dev/notes/p1a-deep-short-screens-364-2026-07-09.md
+++ b/dev/notes/p1a-deep-short-screens-364-2026-07-09.md
@@ -1,0 +1,109 @@
+# P1a — deep re-screens of the faithful-short gates + arming speed (364 basis)
+
+2026-07-09. Executes P1a of `next-session-priorities-2026-07-08-PM.md`. Both
+screens run the REAL mechanisms (flags built in #1696/#1708) on the deep window
+they were flagged NEEDS-DEEP-DATA for: **2000-01-01..2010-12-31, sp500-2000 PIT
+(515 names), CSV mode vs the restored deep `data/` store, warmup-364 basis.**
+All arms fresh same-basis (no stale-baseline mixing).
+
+**Scope honesty (screen-rigor):** the estimand is faithful (actual rule, actual
+realized backtest P&L — not a forward-return proxy), but this is a SINGLE
+window × SINGLE universe × SINGLE path per arm — a grid *cell*, not a WF-CV.
+It cannot reject a mechanism; it prices the deep-window cell that was missing.
+sp500-2000 PIT is survivor-tinted; it hits all arms equally, relative reads
+stand. n(shorts) is tiny (7-16 per arm over 11y) — trade-level power is near
+zero; the load-bearing signal is the portfolio path, which is exactly what the
+mechanisms act on.
+
+Raw outputs (gitignored): `dev/backtest/scenarios-2026-07-09-{052354,...}/`.
+Logs: `/tmp/sweeps/p1a-{faithful-short,arming-speed}-deep-364.log`.
+
+## Screen 1 — faithful-short gates (`experiments/faithful-short-deep-screen-2026-06-22`)
+
+| arm | return | Sharpe | MaxDD | Ulcer | Calmar | shorts (n, realized) |
+|---|---|---|---|---|---|---|
+| 00 long-only reference | 251.3% | 0.798 | 40.6% | 15.7 | 0.298 | (1 leaked, see bug) |
+| **01 ungated long-short** | **296.0%** | **0.869** | **30.7%** | **10.8** | **0.434** | 16, +$223k |
+| 02 neutral_blocks_shorts | 287.5% | 0.844 | 38.5% | 14.4 | 0.340 | 15, +$196k |
+| 03 slow_grind gate | 272.2% | 0.826 | 36.6% | 14.6 | 0.346 | 7, +$247k |
+| 04 both gates | = 03 exactly | | | | | 7, +$247k |
+
+Findings:
+
+1. **The short leg IS additive in the deep window** — the hypothesis that sent
+   this to deep data is confirmed: every long-short arm beats the long-only
+   reference on return AND every risk metric (baseline: +44.8pp return, DD
+   40.6→30.7, Ulcer 15.7→10.8).
+2. **But the UN-GATED baseline dominates every gated arm.** Each gate reduces
+   return and worsens DD vs ungated (neutral: −8.6pp ret / +7.8pp DD; grind:
+   −23.8pp / +5.9pp).
+3. **The WHY is hedge-shaped, not P&L-shaped.** Gated arms have BETTER direct
+   short P&L (+$247k on 7 trades vs +$223k on 16) yet lower total return and
+   worse DD. The blocked shorts (JNS 2001-02 → +$42k held 10 months, TEL
+   Jan-2008, PRU Jul-2002, PM Oct-2008, PFG Oct-2002) are **early-bear hedges**:
+   they smooth NAV exactly when the long book bleeds, and the smoothing
+   compounds through the recovery. Per-trade gating evaluates the wrong
+   estimand — the deep value of shorts is portfolio-level NAV insurance, and
+   the slow-grind gate's 8-week confirmation arrives after the hedge window.
+4. **Gate subsumption:** arm 04 ≡ arm 03 bit-identically — grind-gated shorts
+   are already Bearish-tape-only; `neutral_blocks_shorts` adds nothing on top.
+5. **Bug (small, filed):** the shorts-OFF reference logged 1 SHORT trade
+   (LH 2001-06-13→16, laggard_rotation exit, +$2.8k). A short leaked past
+   `enable_short_side=false` — needs a look at the laggard-rotation path.
+
+**Verdict (calibrated):** no-flip / no-build-priority for both gates on EDGE
+grounds. Evidence across cells is now: 2010-26 → gates admit ~0 shorts (inert);
+2000-2010 → gates tax the crash hedge. There is no window where they add edge.
+They stay default-off axes. The `neutral_blocks_shorts` faithfulness flip
+(2026-06-22 §Decision) remains a mandate call — now with its deep cost
+quantified (−8.6pp return, +7.8pp MaxDD on the one window shorts matter).
+This is a screen-cell decision, not a WF-CV rejection.
+
+**Forward guidance (what the why rules in/out):** if the floor-quality program
+wants short-side crash protection, build it **hedge-shaped** (portfolio-level
+overlay — index short / basket short sized to long exposure during confirmed
+declines), not per-trade short-selection gates. This feeds P1b: the circuit
+breaker's "exit to cash" and a hedge overlay are the same lever class (NAV
+smoothing in declines), and this screen says that class has real deep-window
+value (+45pp / −10pp DD worth on 2000-2010 sp500).
+
+## Screen 2 — arming speed (`experiments/build2-arming-speed-deep-screen-2026-07-08`, NEW fixtures)
+
+Long-only, same window/universe. 2×2: catastrophic_stop_pct {0, 0.10} ×
+fast_v_arm_on_rate_alone {false, true}.
+
+| arm | return | MaxDD | Result |
+|---|---|---|---|
+| d2-00 cat0 armoff (baseline) | 251.4% | 40.6% | |
+| d2-01 cat10 armoff | 266.6% | 38.8% | catstop alone +15.2pp, −1.8pp DD |
+| **d2-02 cat10 armon** | **283.1%** | **38.8%** | armon adds +16.5pp on top, DD flat |
+| d2-03 cat0 armon | 251.4% | 40.6% | ≡ baseline exactly (isolation clean) |
+
+Findings:
+
+1. **Arming speed is NOT inert in the deep window** — contradicts the 06-22
+   expectation ("fast-V-specific, inert in 2008 cascade"). The 2008 cascade
+   (and/or 2000-02 legs) contains rate-detectable fast episodes where the MA
+   confirmation delay costs; rate-alone arming lets the catastrophic stop fire
+   earlier: +16.5pp over catstop-armoff at identical MaxDD.
+2. **catstop 0.10 itself helps deep** (+15.2pp, −1.8pp DD) — consistent with
+   its tail-insurance design (sanctioned winner-touching exception).
+3. **Wiring isolation is clean:** armon without catstop is bit-identical to
+   baseline (the flag only routes through stop arming).
+
+**Verdict (calibrated):** promising — this was the missing macro-regime cell
+for the arming-speed mechanism (#1708 already carries a weak WF-CV ACCEPT from
+2026-06-22 + the adlive re-run 06-24). Combined cells now: 2018-21 (helps the
+2020 fast-V), 2013-17 bull (inert), 2000-2010 deep (helps, +2.9pp/yr, DD flat).
+Escalation path per `promotion-confirmation.md`: a deep-window WF-CV (fold
+distribution, not this single path) is the remaining evidence before a
+`catstop=0.10 + armon=true` preset-promotion conversation. Note this is a
+PRESET/tail-insurance promotion (trader-dial), so it also needs the
+`weinstein-faithful-core` W2 citation (book: protect against the crash that
+invalidates the stage read).
+
+## Both screens — basis note
+
+Numbers are NOT comparable to the 06-22 screen absolutes (210 basis, and the
+old runs predate the deep-store restore). Relative reads within each screen are
+same-basis and clean.

--- a/dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md
+++ b/dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md
@@ -1,0 +1,139 @@
+# Fast circuit-breaker SPY sleeve — design (P1b of the floor-quality program)
+
+**Status: DESIGN (no code).** Drafted 2026-07-08 PM session, per
+`next-session-priorities-2026-07-08-PM.md` P1b and the user steer recorded in
+`memory/project_floor_quality_program`: *"timed SPY is worse than SPY; if we
+can have a better timed SPY (long-only with a quick and accurate circuit
+breaker), that by itself is more valuable as the floor sleeve."*
+
+## Goal and success bar
+
+A long-only SPY floor sleeve that:
+
+1. **Matches TOTAL-RETURN SPY over the full window** (2000-2026). The
+   comparator is adjusted-close / dividend-inclusive SPY — never raw close
+   (standing rule, 2026-07-08).
+2. **Cuts the left tail**: materially reduces the deep crash drawdowns
+   (2000-02, 2008, 2020, 2022) without giving the savings back in whipsaw.
+
+Explicitly NOT the bar: Calmar / Sharpe optimization. The 70/30 barbell
+already showed the blend frontier buys Calmar at ~55pp/26y per 10pp of floor
+(`barbell-on-stocks-2026-06-02.md`); the program scoreboard is absolute
+return + start-date robustness.
+
+## Why the existing timed-SPY floor fails the bar
+
+`Spy_only_weinstein_strategy` is full Weinstein stage timing on SPY: enter
+Stage 2, exit Stage 3→4 rollover or trailing stop. Deep 2000-2026: 386.9% /
+18.8% DD vs BAH-SPY 394% **raw close** — i.e. it loses to raw-close SPY and
+loses harder to TR-SPY. Two structural reasons:
+
+- **It times everything.** Stage exits fire in ordinary chop, not just
+  crashes. Every false exit is an upside tax on the one instrument whose
+  long-run drift is the whole return. (The index sleeve's "winner" IS the
+  buy-and-hold position — per `project_edge_is_the_fat_tail`, touching it
+  needs the tail-RISK-insurance exception, which means rare, crash-gated
+  interventions only.)
+- **Both its exit and its re-entry wait for weekly-MA confirmation.** In a
+  fast V (2020) the MA rolls over weeks after the crash (exit at the bottom)
+  and confirms re-entry weeks after the bottom (miss the rebound). The
+  factor-lens finding (realized edge ~ forward index DD, r=−0.79) says the
+  value of being out is concentrated in a few forward-DD regimes — everything
+  else is drag.
+
+Design consequence: **default-in-market; the breaker is a rare intervention,
+asymmetric by decline character, with fast re-entry.**
+
+## Signal inventory (all already built, all config-gated)
+
+| ingredient | what it gives the breaker |
+|---|---|
+| `Decline_character.classify` (#1692) | `Fast_v` / `Slow_grind` / `Not_declining` on the index, pure + lookahead-free |
+| `fast_v_ignores_ma_filter` (#1708) | arming speed: rate-alone fast-V detection before the MA confirms (the 2020 fix) |
+| A-D-live breadth (`project_ad_default_flip`) | breadth-led distribution detection — the confirmed short-TIMING edge; feeds `Slow_grind` via the A-D-lead leg |
+| catastrophic-stop machinery (#1695) | precedent for an absolute-drop trigger armed only on `Fast_v` |
+| factor-lens r=−0.79 | evidence that forward-DD regimes are detectable enough to be worth gating on |
+
+## Breaker state machine (proposal)
+
+Two states, `In_market` / `Out_of_market`, evaluated at DAILY cadence (weekly
+cadence is the source of the 2020 lag; the whole point is speed).
+
+**Exit triggers (any one fires → sell to cash):**
+
+- **T1 fast-crash rate**: index drawdown over a short trailing window ≥
+  `fast_exit_rate_pct` (decline-character `Fast_v` semantics with
+  rate-alone arming — no MA precondition).
+- **T2 breadth-led distribution**: `Slow_grind` classification (A-D line
+  leading the index down) sustained `grind_confirm_weeks` — the slow bear is
+  where early exit pays (2000-02, 2008); confirmation cost is low because the
+  decline itself is slow.
+- **T3 absolute floor**: index close below `(1 − floor_drop_pct) ×`
+  **trailing-window high** — the catastrophic backstop.
+
+**Re-entry triggers (asymmetric by which exit fired):**
+
+- After **T1/T3 (fast crash)**: fast re-entry — index recovers
+  `fast_reentry_recover_pct` off the post-exit low (or above a short MA),
+  DAYS cadence. A V-bounce missed is the floor's biggest historical tax.
+- After **T2 (slow grind)**: Weinstein-style re-entry (price above a turning
+  weekly MA). Grind bottoms are slow; confirmation is cheap there.
+
+**Semantics requirements (the GME lesson — MUST-HAVE, from
+`warmup-364-repin-2026-07-08.md` §Findings):**
+
+1. **The peak is an INDEX-PRICE trailing-window high, never a monotonic NAV
+   high-water mark.** `Force_liquidation.Peak_tracker` is monotonic over NAV;
+   one position's parabolic MTM spike (GME Jan-2021, $28.9M peak) set a floor
+   the run could never re-clear → 32 repeat liquidations, strategy dead for 5
+   years. An index-referenced, windowed peak decays by construction and
+   cannot be poisoned by position-level MTM. (For a single-SPY sleeve
+   NAV≈index anyway, but the interface must be index-referenced so the
+   breaker generalizes to the engine side without inheriting the pathology.)
+2. **No halt-until-macro-flip.** Re-entry is self-contained in the state
+   machine. The engine `Portfolio_floor`'s Bearish→non-Bearish reset is the
+   second half of the GME sterilization (reset fires, NAV still under the
+   un-decayed floor, refires). The engine-side fix is decision item 2 in the
+   handoff (human call) — separate from this sleeve.
+
+## Build shape (when mandated — default-off per experiment-flag-discipline)
+
+- **Pure breaker lib** in `analysis/weinstein/macro/` (e.g.
+  `index_circuit_breaker.ml`): `state → weekly/daily index view → A-D macro →
+  state * action`. Pure, lookahead-free, all thresholds in a config record —
+  same pattern as `Decline_character`.
+- **Thin sleeve strategy** alongside `Spy_only_weinstein_strategy` (build
+  alongside, don't modify): buy-and-hold SPY + breaker consumption. Sizing
+  all-cash like the BAH benchmark.
+- Every threshold above is a config field → `Variant_matrix` axis on day one
+  (R2). Nothing hardcoded.
+- **Adjusted-close bars for both the sleeve and the comparator** — out-of-
+  market periods forgo dividends and that cost must be counted honestly.
+
+## Evaluation plan (in order)
+
+1. **Lens screen vs TR-SPY, 2000-2026** (cheap, read-only after build):
+   full-window return + per-episode table (2000-02, 2008, 2011, 2015-16,
+   2018Q4, 2020, 2022): drawdown captured vs avoided, days out of market,
+   number of interventions (should be SMALL — single digits per decade),
+   per-intervention whipsaw cost distribution (not just the mean, per
+   `mechanism-validation-rigor`).
+2. **WF-CV as a surface** (`experiment-gap-closing`): trigger thresholds as
+   axes; Deflated Sharpe; fold gate.
+3. **Promotion grid** (`promotion-confirmation`): must include a deep
+   bear-regime cell (2000-02 + 2008) — a bull-only grid can only certify a
+   bull artifact.
+4. Only after a floor beats TR-SPY-with-smaller-tail: **P1c blending**
+   (barbell gates un-park).
+
+## Open questions (human input welcome, not blocking design)
+
+- Threshold priors: `fast_exit_rate_pct` — decline-character's
+  `fast_v_min_rate_pct` default is 0.08/4wk; the breaker likely wants a
+  faster window (daily rate). Start the surface wide.
+- Should T2 (slow-grind exit) also partially de-risk (e.g. 50%) instead of
+  binary exit? Binary first — fewer knobs, honest read; partial is a
+  follow-on axis.
+- Sleeve instrument: SPY price bars + adjusted for comparator, or trade
+  adjusted series directly? Needs a data-layer check on dividend handling in
+  the simulator before build.

--- a/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-00-cat0-armoff.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-00-cat0-armoff.sexp
@@ -1,0 +1,26 @@
+;; Build-2 arming-speed DEEP screen — baseline: no catastrophic stop, arm-on-rate-alone off.
+;; Long-only, sp500-2000 PIT universe, 2000-2010 (spans the 2000-02 dot-com grind
+;; and the 2008 GFC cascade). Deep companion to
+;; experiments/build2-arming-speed-screen-2026-06-22 (which covered the 2020
+;; fast-V + 2013-2017 bull); #1708 screened NEEDS-DEEP-DATA there. 364-warmup
+;; basis (2026-07-08). CSV mode reads gitignored data/ (deep fetch).
+((name "d2-00-cat0-armoff")
+ (description "Build-2 arming-speed DEEP: catastrophic stop OFF, arm-on-rate-alone OFF. Long-only sp500-2000 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct ((min -90.0) (max 5000.0))) (total_trades ((min 1) (max 5000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-01-cat10-armoff.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-01-cat10-armoff.sexp
@@ -1,0 +1,27 @@
+;; Build-2 arming-speed DEEP screen — catastrophic_stop_pct=0.10, arm-on-rate-alone off.
+;; Long-only, sp500-2000 PIT universe, 2000-2010 (spans the 2000-02 dot-com grind
+;; and the 2008 GFC cascade). Deep companion to
+;; experiments/build2-arming-speed-screen-2026-06-22 (which covered the 2020
+;; fast-V + 2013-2017 bull); #1708 screened NEEDS-DEEP-DATA there. 364-warmup
+;; basis (2026-07-08). CSV mode reads gitignored data/ (deep fetch).
+((name "d2-01-cat10-armoff")
+ (description "Build-2 arming-speed DEEP: catastrophic_stop_pct=0.10, arm-on-rate-alone OFF. Long-only sp500-2000 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((stops_config ((catastrophic_stop_pct 0.10))))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct ((min -90.0) (max 5000.0))) (total_trades ((min 1) (max 5000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-02-cat10-armon.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-02-cat10-armon.sexp
@@ -1,0 +1,28 @@
+;; Build-2 arming-speed DEEP screen — catastrophic_stop_pct=0.10, fast_v_arm_on_rate_alone=true.
+;; Long-only, sp500-2000 PIT universe, 2000-2010 (spans the 2000-02 dot-com grind
+;; and the 2008 GFC cascade). Deep companion to
+;; experiments/build2-arming-speed-screen-2026-06-22 (which covered the 2020
+;; fast-V + 2013-2017 bull); #1708 screened NEEDS-DEEP-DATA there. 364-warmup
+;; basis (2026-07-08). CSV mode reads gitignored data/ (deep fetch).
+((name "d2-02-cat10-armon")
+ (description "Build-2 arming-speed DEEP: catastrophic_stop_pct=0.10, arm-on-rate-alone ON. Long-only sp500-2000 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((fast_v_arm_on_rate_alone true))
+   ((stops_config ((catastrophic_stop_pct 0.10))))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct ((min -90.0) (max 5000.0))) (total_trades ((min 1) (max 5000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))

--- a/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-03-cat0-armon.sexp
+++ b/trading/test_data/backtest_scenarios/experiments/build2-arming-speed-deep-screen-2026-07-08/d2-03-cat0-armon.sexp
@@ -1,0 +1,27 @@
+;; Build-2 arming-speed DEEP screen — arm-on-rate-alone alone (catastrophic stop off; expect ~= baseline).
+;; Long-only, sp500-2000 PIT universe, 2000-2010 (spans the 2000-02 dot-com grind
+;; and the 2008 GFC cascade). Deep companion to
+;; experiments/build2-arming-speed-screen-2026-06-22 (which covered the 2020
+;; fast-V + 2013-2017 bull); #1708 screened NEEDS-DEEP-DATA there. 364-warmup
+;; basis (2026-07-08). CSV mode reads gitignored data/ (deep fetch).
+((name "d2-03-cat0-armon")
+ (description "Build-2 arming-speed DEEP: catastrophic stop OFF, arm-on-rate-alone ON (isolation). Long-only sp500-2000 2000-2010.")
+ (period ((start_date 2000-01-01) (end_date 2010-12-31)))
+ (universe_path "universes/sp500-historical/sp500-2000-01-01.sexp")
+ (universe_size 515)
+ (config_overrides
+  (((enable_short_side false))
+   ((fast_v_arm_on_rate_alone true))
+   ((portfolio_config ((max_position_pct_long 0.14))))
+   ((portfolio_config ((max_long_exposure_pct 0.70))))
+   ((portfolio_config ((min_cash_pct 0.30))))
+   ((enable_stage3_force_exit true))
+   ((stage3_force_exit_config ((hysteresis_weeks 1))))
+   ((enable_laggard_rotation true))
+   ((laggard_rotation_config ((hysteresis_weeks 2))))))
+ (expected
+  ((total_return_pct ((min -90.0) (max 5000.0))) (total_trades ((min 1) (max 5000)))
+   (win_rate ((min 0.0) (max 100.0))) (sharpe_ratio ((min -3.0) (max 5.0)))
+   (max_drawdown_pct ((min 0.0) (max 90.0))) (avg_holding_days ((min 0.0) (max 800.0)))
+   (sortino_ratio_annualized ((min -3.0) (max 10.0))) (calmar_ratio ((min -3.0) (max 5.0)))
+   (ulcer_index ((min 0.0) (max 60.0))) (open_positions_value ((min -1.0e12) (max 1.0e12))))))


### PR DESCRIPTION
## What

Overnight autonomous session (2026-07-08 PM → 07-09) executing `next-session-priorities-2026-07-08-PM.md`.

### 1. Deep top-3000 re-measure on the 364 basis (the user-directed overnight run)
- `dev/notes/deep-remeasure-364-2026-07-09.md` + DEEP_RESULTS.md §364-basis + staleness warning on all 210-basis blocks.
- MTM **+2062.6%** (12.4%/yr) but $15.3M of $21.6M end equity is one open AXTI position; **realized-basis ≈ +475% (6.9%/yr) < SPY TOTAL-RETURN +686.6% (8.15%/yr)** same window.
- **Raw MaxDD 59.4% is fake**: MSZ (delisted micro-cap) has recurring corrupt 13× one-day spike-revert bars in raw EODHD (in the warehouse). Despiked MaxDD **50.3%** = real 2021-02→2025-05 underwater. MSZ = liquidity-overlay validation case #2.

### 2. P1a deep re-screens (2000-2010, sp500-2000 PIT, 364 basis, real mechanisms)
- `dev/notes/p1a-deep-short-screens-364-2026-07-09.md` (screen-rigor calibrated: single cell, not WF-CV).
- **Faithful-short gates (#1696): no window where they add edge.** Short leg IS deep-additive (ungated 296%/DD30.7 vs long-only 251%/40.6) but ungated dominates both gated arms. Why: deep short value is hedge-shaped (early-bear NAV smoothing); the gates block exactly those hedges. Gates stay default-off axes.
- **Arming speed (#1708) NOT inert deep**: cat10+armon 283.1% vs cat10 266.6% vs base 251.4%, DD flat; isolation arm bit-identical to baseline. Next: deep WF-CV.
- Bug found (filed in handoff): 1 SHORT leaked past `enable_short_side=false` (LH 2001-06-13, laggard_rotation exit).

### 3. P1b design doc
`dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md` — breaker state machine with **index-referenced trailing-window peak** (squeeze-immune; the GME Portfolio_floor lesson), asymmetric fast/slow re-entry, eval vs TR-SPY.

### 4. Fixtures
`experiments/build2-arming-speed-deep-screen-2026-07-08/` — 4 arms (2×2 catstop × armon), deep companion to the 06-22 screen dir. Data-only sexp fixtures; not loaded by any dune test.

### Also this session (not in this diff)
- Re-fetched unicorn NYSE advn/decln into gitignored `data/breadth/` (13,873 rows) — the 2 carried local-only ad_bars test failures now pass.

## Test plan
Docs + experiment fixtures only; no code. CI (linters incl. status-file integrity) is the gate. Fixture sexps mirror the committed 06-22 screen dir format and were exercised by the actual screen runs recorded in the notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)