### PR TITLE
docs(correction): armon deep delta is 2010 single-event noise; catstop is the distributed deep value

### DIFF
--- a/dev/notes/next-session-priorities-2026-07-09.md
+++ b/dev/notes/next-session-priorities-2026-07-09.md
@@ -25,9 +25,12 @@ drafted. Main was green at rampup (postsubmits from #1893 in flight).
      dominates both gates. WHY: deep short value is **hedge-shaped** (early-
      bear NAV smoothing), and the gates block exactly those hedges (grind's
      8-week confirm too slow). Gates stay default-off axes.
-   - **Arming speed (#1708) NOT inert deep** (contradicts 06-22 expectation):
-     cat10+armon 283.1% vs cat10 266.6% vs base 251.4%, DD flat; isolation arm
-     clean. Promising → see P1-next.
+   - **Arming speed (#1708): deep verdict CORRECTED after decomposition** —
+     armon is inert 2000-2009 incl. 2008 (year-end equity identical,
+     confirming the 06-22 fold story); its whole +16.5pp = ONE 2010
+     divergence whose sign flips vs the 06-22 WF-CV 2010 fold → noise.
+     **catstop 0.10 is the real deep value and it's distributed** (2001-02
+     +5.9%, 2008 +3.1% incremental) → see P1-next.
 3. **P1b design doc**: `dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md`
    — breaker state machine, index-referenced windowed peak (squeeze-immune, the
    GME lesson), asymmetric fast/slow re-entry, eval plan vs TR-SPY.
@@ -39,12 +42,13 @@ drafted. Main was green at rampup (postsubmits from #1893 in flight).
 
 ## P1 — next (priority order)
 
-1. **Arming-speed deep WF-CV** — the screens gave the missing macro-regime
-   cell as a point estimate; run the fold-distribution version (walk-forward
-   spec on the 2000-2010/2000-2026 deep base, axes: catastrophic_stop_pct
-   {0,0.10} × fast_v_arm_on_rate_alone {false,true}) before any
-   `catstop+armon` preset-promotion conversation (promotion-confirmation grid
-   needs it anyway; W2 citation = crash tail-insurance).
+1. **catstop deep WF-CV** — `catastrophic_stop_pct {0, 0.10}` axis on the
+   deep 2000-2026 base (the 06-22 arming-speed WF-CV had catstop ON in BOTH
+   arms, so catstop itself has never had its own fold-distribution evidence).
+   The deep screen shows distributed bear-window value (2001-02, 2008) →
+   promotion-grid conversation if the WF-CV confirms (trader-dial, W2 = crash
+   tail-insurance). armon drops priority (deep delta = one sign-unstable 2010
+   event; its 06-22 weak ACCEPT stands as-is).
 2. **P1b build mandate (user):** the circuit-breaker sleeve design is drafted;
    build is default-off + behavior-relevant → wants an explicit go. The
    faithful-short screen's forward guidance STRENGTHENS the case (hedge-shaped

--- a/dev/notes/p1a-deep-short-screens-364-2026-07-09.md
+++ b/dev/notes/p1a-deep-short-screens-364-2026-07-09.md
@@ -47,6 +47,14 @@ Findings:
    the slow-grind gate's 8-week confirmation arrives after the hedge window.
 4. **Gate subsumption:** arm 04 ≡ arm 03 bit-identically — grind-gated shorts
    are already Bearish-tape-only; `neutral_blocks_shorts` adds nothing on top.
+4b. **Year-by-year decomposition (the single-event check that corrected
+   Screen 2) — Screen 1's delta is DISTRIBUTED, two episodes:** ungated-vs-
+   long-only accrues +11.2% through 2001 (dot-com bear: JNS/ISRG/LH) and a
+   second +9pp leg across 2008-09 (GENZ/TEL/PM/SNI), ending +12.7%. The
+   grind-gated arm tracks long-only almost exactly through 2007 (the gate
+   blocked ALL the 2001-style early-bear hedges) and only captures the
+   late-2008 confirmed-cascade shorts. i.e. grind gate ≈ "2008-only shorts" —
+   it misses the entire first bear. Robust shape, verdict unchanged.
 5. **Bug (small, filed):** the shorts-OFF reference logged 1 SHORT trade
    (LH 2001-06-13→16, laggard_rotation exit, +$2.8k). A short leaked past
    `enable_short_side=false` — needs a look at the laggard-rotation path.
@@ -79,28 +87,35 @@ fast_v_arm_on_rate_alone {false, true}.
 | **d2-02 cat10 armon** | **283.1%** | **38.8%** | armon adds +16.5pp on top, DD flat |
 | d2-03 cat0 armon | 251.4% | 40.6% | ≡ baseline exactly (isolation clean) |
 
-Findings:
+Findings (CORRECTED 2026-07-09 after year-by-year decomposition — the first
+version of this section overclaimed "arming speed NOT inert deep"):
 
-1. **Arming speed is NOT inert in the deep window** — contradicts the 06-22
-   expectation ("fast-V-specific, inert in 2008 cascade"). The 2008 cascade
-   (and/or 2000-02 legs) contains rate-detectable fast episodes where the MA
-   confirmation delay costs; rate-alone arming lets the catastrophic stop fire
-   earlier: +16.5pp over catstop-armoff at identical MaxDD.
-2. **catstop 0.10 itself helps deep** (+15.2pp, −1.8pp DD) — consistent with
-   its tail-insurance design (sanctioned winner-touching exception).
+1. **catstop 0.10 is the real deep value, and it is DISTRIBUTED**: year-end
+   equity vs cat0 baseline shows +3.7% through 2001, +5.9% through 2002, a
+   further +3.1% incremental in 2008, +4.3% cumulative by 2010. The stop fired
+   usefully across the deep bears (where the falling-MA precondition was
+   already satisfied → the default arming sufficed). Consistent tail-insurance
+   value, not a single lucky event.
+2. **armon (rate-alone arming) is INERT 2000-2009 — including 2008**:
+   armoff/armon year-end equities are IDENTICAL through 2009. This CONFIRMS
+   the 06-22 WF-CV fold story (fold-008 byte-identical) on the new basis. The
+   entire +16.5pp endpoint gap is ONE divergence in 2010 (+4.5% that year —
+   the May-2010 flash-crash era), and the 06-22 WF-CV's 2010 fold had armon
+   NEGATIVE (−0.77pp whipsaw). Single event, sign-unstable across
+   path/basis → **path-dependent noise, not deep edge.** armon's value case
+   remains exactly what the 06-22 ledger said: fast-V crashes from highs
+   (2020, 2018-Q4), where the MA precondition lags.
 3. **Wiring isolation is clean:** armon without catstop is bit-identical to
    baseline (the flag only routes through stop arming).
 
-**Verdict (calibrated):** promising — this was the missing macro-regime cell
-for the arming-speed mechanism (#1708 already carries a weak WF-CV ACCEPT from
-2026-06-22 + the adlive re-run 06-24). Combined cells now: 2018-21 (helps the
-2020 fast-V), 2013-17 bull (inert), 2000-2010 deep (helps, +2.9pp/yr, DD flat).
-Escalation path per `promotion-confirmation.md`: a deep-window WF-CV (fold
-distribution, not this single path) is the remaining evidence before a
-`catstop=0.10 + armon=true` preset-promotion conversation. Note this is a
-PRESET/tail-insurance promotion (trader-dial), so it also needs the
-`weinstein-faithful-core` W2 citation (book: protect against the crash that
-invalidates the stage read).
+**Verdict (calibrated, corrected):** the deep cell supports **catstop**, not
+armon. catstop 0.10 has never had its own WF-CV axis (the 06-22 arming-speed
+WF-CV had catstop ON in both arms) — the natural next surface is
+`catastrophic_stop_pct {0, 0.10}` WF-CV on the deep base, which would give
+catstop the fold-distribution evidence for a promotion-grid conversation
+(trader-dial, `weinstein-faithful-core` W2: protect against the crash that
+invalidates the stage read). armon keeps its weak 06-22 ACCEPT unchanged and
+drops back to fast-V-specific insurance; no new escalation from this screen.
 
 ## Both screens — basis note
 


### PR DESCRIPTION
Docs-only correction to #1894's P1a Screen-2 verdict, after year-by-year decomposition of the arm deltas:

- **armon is inert 2000-2009 including 2008** (year-end equity bit-identical to armoff) — confirming the 06-22 WF-CV fold-008 byte-identical finding on the new basis. The entire +16.5pp endpoint gap is ONE 2010 divergence (+4.5% that year, May-2010 flash-crash era), and the 06-22 WF-CV 2010 fold had armon NEGATIVE (−0.77pp). Single event, sign-unstable → path-dependent noise, not a deep edge. The original 'arming speed NOT inert deep' claim was wrong.
- **catstop 0.10 is the real deep value and it is distributed** (2001-02 +5.9%, 2008 +3.1% incremental, +15.2pp total / −1.8pp DD) — and it has never had its own WF-CV axis (the 06-22 arming-speed WF-CV had catstop ON in both arms). Next surface: `catastrophic_stop_pct {0, 0.10}` on the deep base.
- Handoff P1-next re-pointed at the catstop WF-CV; armon drops priority (its 06-22 weak ACCEPT stands unchanged).

Docs-only (2 .md files) → QC gates skipped per pr-merge-gates carve-out; CI required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)