### PR TITLE
feat(warehouse): audit_bars spike-revert corrupt-bar scanner

### DIFF
--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -19,6 +19,27 @@ moved to its own track at `dev/status/backtest-perf.md`. The 12-step
 incremental-indicators refactor (the follow-on architecture for
 Tier 3) tracked separately at `dev/status/incremental-indicators.md`.
 
+## 2026-07-09 — `audit_bars` warehouse corrupt-bar scanner
+
+- [x] **`audit_bars` exe + `audit_bars_detector` lib** — scans a snapshot
+  warehouse for MSZ-class corrupt bars (one-day close spike that reverts the
+  next day, the ELCO/MSZ delisted-micro-cap artifact class) so a deep
+  re-baseline can be data-audited before it is trusted. Implements
+  recommendation #2 of `dev/notes/deep-remeasure-364-2026-07-09.md` §"MaxDD
+  59.4% is an artifact" (the MSZ 2014 1.90→25.36→1.93 spike-reverts that
+  produced a phantom +$3.3M NAV spike and a fake 59.4% MaxDD). Lives at
+  `trading/trading/backtest/snapshot_warehouse/audit_bars/{lib,bin,test}/`,
+  alongside `dump_snap`. Pure detector (`Audit_bars_detector.detect`) is
+  unit-tested (OUnit2 + Matchers): catches the MSZ shape, ignores a
+  sustained/non-reverting move, ignores high-priced names above the ceiling,
+  handles window-edge + last-bar cases. All four thresholds (`--spike-mult`
+  `--median-window` `--revert-frac` `--price-ceiling`) are CLI flags, defaults
+  5.0 / 5 / 0.5 / 5.0. **Verify:** `dune build` +
+  `dune runtest trading/backtest/snapshot_warehouse/audit_bars/`; acceptance run
+  `dune exec .../audit_bars/bin/audit_bars.exe -- /tmp/snap_top3000_1998_2026`
+  finds the known MSZ 2014 bars (2014-08-15, 2014-11-11, 2014-12-26, 2014-12-31,
+  2015-01-06) — 3797 hits across 81 symbols of 2999 scanned.
+
 ## 2026-06-16 — README top-line results module + bin
 
 - [x] **`readme_toplines` lib + bin** — computes four headline numbers over one

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/bin/audit_bars.ml
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/bin/audit_bars.ml
@@ -1,0 +1,93 @@
+(* Warehouse corrupt-bar scanner: iterate every *.snap in a snapshot-warehouse
+   directory and report MSZ-class one-day spike-revert bars (see
+   [Audit_bars_detector] and [dev/notes/deep-remeasure-364-2026-07-09.md]).
+
+   Usage:
+     audit_bars.exe <warehouse-dir>
+       [--spike-mult X] [--median-window K] [--revert-frac F] [--price-ceiling P]
+
+   Prints one CSV row per hit
+   (symbol,date,prev_close,spike_close,next_close,ratio) followed by a summary
+   line. Exit code is always 0 — it is a report, not a gate. *)
+open Core
+module Detector = Audit_bars_detector
+module Sc = Data_panel_snapshot.Snapshot_columnar
+module Snap = Data_panel_snapshot.Snapshot
+module Schema = Data_panel_snapshot.Snapshot_schema
+
+(* Reconstruct the close series of one .snap file as detector bars. Missing
+   close cells (nan) are kept: the detector's arithmetic naturally excludes
+   them from spike matches. *)
+let _bars_of_reader r =
+  match Sc.read_all r with
+  | Error e -> Error e
+  | Ok rows ->
+      Ok
+        (Array.of_list_map rows ~f:(fun row ->
+             {
+               Detector.date = row.Snap.date;
+               close =
+                 Option.value (Snap.get row Schema.Close) ~default:Float.nan;
+             }))
+
+(* Scan one file; returns [(symbol, hits)] or an error. *)
+let _scan_file ~params ~path =
+  Sc.with_reader ~path ~f:(fun r ->
+      match _bars_of_reader r with
+      | Error e -> Error e
+      | Ok bars -> Ok (Sc.symbol r, Detector.detect ~params bars))
+
+let _print_hit symbol (h : Detector.hit) =
+  printf "%s,%s,%.4f,%.4f,%.4f,%.2f\n" symbol (Date.to_string h.date)
+    h.prev_close h.spike_close h.next_close h.ratio
+
+let _snap_files dir =
+  Sys_unix.readdir dir |> Array.to_list
+  |> List.filter ~f:(fun f -> String.is_suffix f ~suffix:".snap")
+  |> List.sort ~compare:String.compare
+  |> List.map ~f:(fun f -> Filename.concat dir f)
+
+(* Scan the whole directory, printing hits as they are found; returns
+   [(hit_count, symbols_with_hits, scanned)]. *)
+let _scan_dir ~params dir =
+  let files = _snap_files dir in
+  List.fold files ~init:(0, 0, 0) ~f:(fun (hits, syms, scanned) path ->
+      match _scan_file ~params ~path with
+      | Error e ->
+          eprintf "WARN: skipping %s: %s\n" path (Status.show e);
+          (hits, syms, scanned + 1)
+      | Ok (symbol, file_hits) ->
+          List.iter file_hits ~f:(_print_hit symbol);
+          let n = List.length file_hits in
+          (hits + n, (syms + if n > 0 then 1 else 0), scanned + 1))
+
+let command =
+  Command.basic
+    ~summary:"Scan a snapshot warehouse for spike-revert corrupt bars"
+    (let%map_open.Command dir = anon ("warehouse-dir" %: string)
+     and spike_mult =
+       flag "--spike-mult"
+         (optional_with_default 5.0 float)
+         ~doc:"X spike close / surrounding-median ratio threshold (default 5.0)"
+     and median_window =
+       flag "--median-window"
+         (optional_with_default 5 int)
+         ~doc:"K half-width of the surrounding median window (default 5)"
+     and revert_frac =
+       flag "--revert-frac"
+         (optional_with_default 0.5 float)
+         ~doc:"F next-close / spike-close revert threshold (default 0.5)"
+     and price_ceiling =
+       flag "--price-ceiling"
+         (optional_with_default 5.0 float)
+         ~doc:"P only flag when surrounding median close < P (default 5.0)"
+     in
+     fun () ->
+       let params =
+         { Detector.spike_mult; median_window; revert_frac; price_ceiling }
+       in
+       printf "symbol,date,prev_close,spike_close,next_close,ratio\n";
+       let hits, syms, scanned = _scan_dir ~params dir in
+       printf "%d hits across %d symbols (of %d scanned)\n" hits syms scanned)
+
+let () = Command_unix.run command

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/bin/dune
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/bin/dune
@@ -1,0 +1,11 @@
+(executable
+ (name audit_bars)
+ (libraries
+  core
+  core_unix.command_unix
+  core_unix.sys_unix
+  status
+  trading.data_panel.snapshot
+  audit_bars_detector)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/audit_bars_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/audit_bars_detector.ml
@@ -47,29 +47,41 @@ let _surrounding_median bars ~t ~k =
   |> List.filter_map ~f:(fun j -> if j = t then None else Some bars.(j).close)
   |> _median
 
+(* The three spike-revert predicates, split out so [_check_index] reads as a
+   flat conjunction rather than nested conditionals. *)
+let _below_ceiling ~params ~median = Float.(median < params.price_ceiling)
+
+let _is_spike ~params ~median ~close =
+  Float.(close >= params.spike_mult *. median)
+
+let _reverts ~params ~close ~next_close =
+  Float.(next_close <= params.revert_frac *. close)
+
+(* Build the hit record for a qualifying spike bar [t] (guaranteed to have a
+   successor). [prev_close] is [Float.nan] when [t] is the first bar. *)
+let _make_hit bars ~t ~median =
+  let close = bars.(t).close in
+  {
+    date = bars.(t).date;
+    prev_close = (if t > 0 then bars.(t - 1).close else Float.nan);
+    spike_close = close;
+    next_close = bars.(t + 1).close;
+    ratio = close /. median;
+  }
+
 (* Test bar [t] (guaranteed to have a successor) against the spike-revert
    criteria; returns the hit when it qualifies. *)
 let _check_index bars ~params ~t =
   match _surrounding_median bars ~t ~k:params.median_window with
   | None -> None
-  | Some med ->
-      let close_t = bars.(t).close in
-      let close_next = bars.(t + 1).close in
-      let is_spike =
-        Float.(med < params.price_ceiling)
-        && Float.(close_t >= params.spike_mult *. med)
-        && Float.(close_next <= params.revert_frac *. close_t)
-      in
-      if is_spike then
-        Some
-          {
-            date = bars.(t).date;
-            prev_close = (if t > 0 then bars.(t - 1).close else Float.nan);
-            spike_close = close_t;
-            next_close = close_next;
-            ratio = close_t /. med;
-          }
-      else None
+  | Some median ->
+      let close = bars.(t).close in
+      let next_close = bars.(t + 1).close in
+      Option.some_if
+        (_below_ceiling ~params ~median
+        && _is_spike ~params ~median ~close
+        && _reverts ~params ~close ~next_close)
+        (_make_hit bars ~t ~median)
 
 let detect ~params bars =
   let n = Array.length bars in

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/audit_bars_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/audit_bars_detector.ml
@@ -1,0 +1,78 @@
+open Core
+
+type params = {
+  spike_mult : float;
+  median_window : int;
+  revert_frac : float;
+  price_ceiling : float;
+}
+[@@deriving sexp_of]
+
+let default_params =
+  {
+    spike_mult = 5.0;
+    median_window = 5;
+    revert_frac = 0.5;
+    price_ceiling = 5.0;
+  }
+
+type bar = { date : Core.Date.t; close : float } [@@deriving sexp_of]
+
+type hit = {
+  date : Core.Date.t;
+  prev_close : float;
+  spike_close : float;
+  next_close : float;
+  ratio : float;
+}
+[@@deriving sexp_of, equal]
+
+(* Median of a non-empty float list; [None] when empty. Even length averages the
+   two central order statistics. *)
+let _median = function
+  | [] -> None
+  | xs ->
+      let sorted = Array.of_list (List.sort xs ~compare:Float.compare) in
+      let n = Array.length sorted in
+      if n % 2 = 1 then Some sorted.(n / 2)
+      else Some ((sorted.((n / 2) - 1) +. sorted.(n / 2)) /. 2.0)
+
+(* Median close over the [±k] bars around [t], excluding [t] itself, clamped to
+   the array bounds. *)
+let _surrounding_median bars ~t ~k =
+  let n = Array.length bars in
+  let lo = Int.max 0 (t - k) in
+  let hi = Int.min (n - 1) (t + k) in
+  List.range lo (hi + 1)
+  |> List.filter_map ~f:(fun j -> if j = t then None else Some bars.(j).close)
+  |> _median
+
+(* Test bar [t] (guaranteed to have a successor) against the spike-revert
+   criteria; returns the hit when it qualifies. *)
+let _check_index bars ~params ~t =
+  match _surrounding_median bars ~t ~k:params.median_window with
+  | None -> None
+  | Some med ->
+      let close_t = bars.(t).close in
+      let close_next = bars.(t + 1).close in
+      let is_spike =
+        Float.(med < params.price_ceiling)
+        && Float.(close_t >= params.spike_mult *. med)
+        && Float.(close_next <= params.revert_frac *. close_t)
+      in
+      if is_spike then
+        Some
+          {
+            date = bars.(t).date;
+            prev_close = (if t > 0 then bars.(t - 1).close else Float.nan);
+            spike_close = close_t;
+            next_close = close_next;
+            ratio = close_t /. med;
+          }
+      else None
+
+let detect ~params bars =
+  let n = Array.length bars in
+  (* Last bar has no successor to check the revert against. *)
+  List.range 0 (Int.max 0 (n - 1))
+  |> List.filter_map ~f:(fun t -> _check_index bars ~params ~t)

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/audit_bars_detector.mli
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/audit_bars_detector.mli
@@ -1,0 +1,66 @@
+(** Pure detector for MSZ-class corrupt bars: one-day close spikes that revert
+    the next day, seen in raw EODHD data for delisted sub-$5 micro-caps.
+
+    Motivating artifact (see [dev/notes/deep-remeasure-364-2026-07-09.md]
+    §"MaxDD 59.4% is an artifact"): MSZ 2014-08-15 has close 1.90 -> 25.36 ->
+    1.93 the next day. A single such bar produced a phantom +$3.3M NAV spike and
+    a fake 59.4% MaxDD in a deep re-baseline. This detector flags those bars so
+    a warehouse can be data-audited before a re-measure trusts it.
+
+    The detector is a pure function over a symbol's close series — no I/O — so
+    it is unit-testable in isolation. The [bin/] executable wraps it with
+    {!Snapshot_columnar} reads over a warehouse directory. *)
+
+type params = {
+  spike_mult : float;
+      (** A bar's close must be at least [spike_mult] times the surrounding
+          median close to be a spike candidate. *)
+  median_window : int;
+      (** Half-width [k] of the surrounding window: the median is taken over the
+          [±k] bars around [t], excluding [t] itself. Must be [>= 1]. *)
+  revert_frac : float;
+      (** The next bar's close must be at most [revert_frac] times the spike
+          close for the spike to count as reverting. *)
+  price_ceiling : float;
+      (** Only flag when the surrounding median close is below [price_ceiling] —
+          the artifact class lives in sub-$5 names, so higher-priced series with
+          a legitimate large move are not flagged. *)
+}
+[@@deriving sexp_of]
+
+val default_params : params
+(** Defaults tuned to the MSZ artifact class: [spike_mult = 5.0],
+    [median_window = 5], [revert_frac = 0.5], [price_ceiling = 5.0]. *)
+
+type bar = {
+  date : Core.Date.t;  (** The trading day of this close. *)
+  close : float;  (** Raw (unadjusted) daily close. *)
+}
+[@@deriving sexp_of]
+
+type hit = {
+  date : Core.Date.t;  (** Date of the spike bar [t]. *)
+  prev_close : float;
+      (** Close of bar [t-1], or [Float.nan] when [t] is the first bar. *)
+  spike_close : float;  (** Close of the spike bar [t]. *)
+  next_close : float;  (** Close of bar [t+1] (the reverting bar). *)
+  ratio : float;
+      (** [spike_close /. surrounding_median] — how large the spike is. *)
+}
+[@@deriving sexp_of, equal]
+
+val detect : params:params -> bar array -> hit list
+(** [detect ~params bars] returns every spike-revert candidate in [bars], in
+    ascending date order.
+
+    A bar [t] is a candidate when all hold:
+    - the median close over the surrounding [±median_window] bars (excluding
+      [t]) is below [params.price_ceiling];
+    - [close_t >= params.spike_mult *. surrounding_median];
+    - [close_{t+1} <= params.revert_frac *. close_t].
+
+    The last bar is never a candidate (no [t+1] to check the revert). Near the
+    start/end of the series the surrounding window is clamped to the available
+    bars — the median is taken over whatever neighbours exist (at least one is
+    required). [bars] is assumed sorted by date ascending, as
+    {!Snapshot_columnar} delivers it. *)

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/dune
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/lib/dune
@@ -1,0 +1,5 @@
+(library
+ (name audit_bars_detector)
+ (libraries core)
+ (preprocess
+  (pps ppx_jane)))

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/test/dune
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_audit_bars)
+ (libraries core matchers ounit2 audit_bars_detector))

--- a/trading/trading/backtest/snapshot_warehouse/audit_bars/test/test_audit_bars.ml
+++ b/trading/trading/backtest/snapshot_warehouse/audit_bars/test/test_audit_bars.ml
@@ -1,0 +1,83 @@
+open OUnit2
+open Core
+open Matchers
+module Detector = Audit_bars_detector
+
+let base = Date.of_string "2014-01-01"
+
+(* Build a bar array from a close series, one bar per successive calendar day. *)
+let make_bars closes =
+  Array.of_list_mapi closes ~f:(fun i close ->
+      { Detector.date = Date.add_days base i; close })
+
+let params = Detector.default_params
+
+(* The MSZ 2014-08-15 shape: flat ~1.9 baseline, one 25.36 spike, 1.93 revert. *)
+let test_detects_msz_shape _ =
+  let bars =
+    make_bars [ 1.9; 1.9; 1.9; 1.9; 1.9; 25.36; 1.93; 1.9; 1.9; 1.9; 1.9 ]
+  in
+  assert_that
+    (Detector.detect ~params bars)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun h -> h.Detector.date) (equal_to (Date.add_days base 5));
+             field (fun h -> h.Detector.prev_close) (float_equal 1.9);
+             field (fun h -> h.Detector.spike_close) (float_equal 25.36);
+             field (fun h -> h.Detector.next_close) (float_equal 1.93);
+             field
+               (fun h -> h.Detector.ratio)
+               (is_between (module Float_ord) ~low:13.0 ~high:14.0);
+           ];
+       ])
+
+(* A spike whose next bar stays elevated is not a revert -> not flagged. *)
+let test_no_revert_not_flagged _ =
+  let bars = make_bars [ 2.0; 2.0; 2.0; 2.0; 2.0; 20.0; 18.0 ] in
+  assert_that (Detector.detect ~params bars) (elements_are [])
+
+(* Same spike-then-revert shape but at a high price level (median >= ceiling):
+   a legitimate large move, not the sub-$5 artifact -> not flagged. *)
+let test_high_priced_above_ceiling_not_flagged _ =
+  let bars =
+    make_bars
+      [ 100.0; 100.0; 100.0; 100.0; 100.0; 600.0; 105.0; 100.0; 100.0; 100.0 ]
+  in
+  assert_that (Detector.detect ~params bars) (elements_are [])
+
+(* Spike near the start of the series: fewer left-neighbours, still detected. *)
+let test_window_edge_start_detected _ =
+  let bars = make_bars [ 1.9; 25.36; 1.93; 1.9; 1.9; 1.9 ] in
+  assert_that
+    (Detector.detect ~params bars)
+    (elements_are
+       [
+         all_of
+           [
+             field (fun h -> h.Detector.date) (equal_to (Date.add_days base 1));
+             field (fun h -> h.Detector.prev_close) (float_equal 1.9);
+             field (fun h -> h.Detector.spike_close) (float_equal 25.36);
+             field (fun h -> h.Detector.next_close) (float_equal 1.93);
+           ];
+       ])
+
+(* A spike on the final bar has no successor to check the revert -> not flagged. *)
+let test_last_bar_not_flagged _ =
+  let bars = make_bars [ 1.9; 1.9; 1.9; 1.9; 1.9; 25.36 ] in
+  assert_that (Detector.detect ~params bars) (elements_are [])
+
+let suite =
+  "Audit_bars detector tests"
+  >::: [
+         "detects MSZ shape" >:: test_detects_msz_shape;
+         "no revert -> not flagged" >:: test_no_revert_not_flagged;
+         "high-priced above ceiling -> not flagged"
+         >:: test_high_priced_above_ceiling_not_flagged;
+         "window edge at start still detected"
+         >:: test_window_edge_start_detected;
+         "spike on last bar not flagged" >:: test_last_bar_not_flagged;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

New `audit_bars` executable + `audit_bars_detector` library that scan a snapshot
warehouse for **MSZ-class corrupt bars** — one-day close spikes that revert the
next day (the ELCO/MSZ delisted-micro-cap artifact class in raw EODHD data). This
lets deep re-baselines be **data-audited before they are trusted**.

Implements recommendation #2 of
`dev/notes/deep-remeasure-364-2026-07-09.md` §"MaxDD 59.4% is an artifact": MSZ
(a delisted micro-cap) has recurring one-day 13× spike-revert bars in the
warehouse (e.g. 2014-08-15: close 1.90 → 25.36 → 1.93 next day; `adjusted_close`
spikes identically → it is a raw-data artifact, not a split). One such bar
produced a phantom +$3.3M NAV spike and a fake 59.4% MaxDD in the 364-basis deep
re-measure.

User-approved 2026-07-09.

## Where

`trading/trading/backtest/snapshot_warehouse/audit_bars/{lib,bin,test}/` —
alongside the existing `dump_snap` inspector; reads `.snap` files via the same
`Snapshot_columnar` path.

- `lib/audit_bars_detector.{ml,mli}` — pure, I/O-free spike-revert detector.
- `bin/audit_bars.ml` — CLI that iterates every `*.snap` in a directory and
  prints a CSV of hits + a summary line.
- `test/test_audit_bars.ml` — OUnit2 + Matchers unit tests on the pure detector.

## Detector

A bar `t` is a spike-revert candidate when:
- `close_t >= spike_mult × median(close over the surrounding ±k bars, excluding t)`, and
- `close_{t+1} <= revert_frac × close_t`, and
- the surrounding median close `< price_ceiling` (the artifact class lives in sub-$5 names).

All four thresholds are CLI flags with defaults `--spike-mult 5.0`,
`--median-window 5`, `--revert-frac 0.5`, `--price-ceiling 5.0` (no hardcoding).
The last bar is never flagged (no successor to check the revert); the window is
clamped at series edges.

CLI:
```
audit_bars.exe <warehouse-dir> [--spike-mult X] [--median-window K] [--revert-frac F] [--price-ceiling P]
```
Prints `symbol,date,prev_close,spike_close,next_close,ratio` per hit and a
`N hits across M symbols (of S scanned)` summary. Exit code is always 0 — it is a
report, not a gate.

## Test plan

`dune runtest trading/backtest/snapshot_warehouse/audit_bars/` — 5 tests, all
pass:
- detects the MSZ shape (1.90 / 25.36 / 1.93);
- does **not** flag a spike whose next bar stays elevated (no revert);
- does **not** flag the same shape at a high price level (median ≥ ceiling — a
  legitimate large move, not the sub-$5 artifact);
- detects a spike near the start of the series (clamped window);
- does **not** flag a spike on the final bar (no successor).

## Acceptance run (against the container warehouse)

```
dune exec trading/backtest/snapshot_warehouse/audit_bars/bin/audit_bars.exe -- /tmp/snap_top3000_1998_2026
```
Finds the known MSZ 2014 bars — including **2014-08-15, 2014-11-11, 2014-12-26**
(2014-12-24 is Christmas Eve; the actual trading-day spike-revert bar is 12-26),
**2014-12-31, 2015-01-06**. Sample MSZ hits:
```
MSZ,2014-08-15,1.9000,25.3600,1.9300,13.31
MSZ,2014-11-11,2.1700,25.6000,2.1300,11.66
MSZ,2014-12-26,25.5200,25.5900,2.2400,11.53
MSZ,2014-12-31,2.2200,25.3300,2.1800,11.36
MSZ,2015-01-06,2.1800,25.4100,2.1800,11.42
```
Summary: **3797 hits across 81 symbols (of 2999 scanned)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
