### PR TITLE
docs(correction): neutral-gate deep delta = path noise, true edge cost ~0

### DIFF
--- a/dev/notes/next-session-priorities-2026-07-09.md
+++ b/dev/notes/next-session-priorities-2026-07-09.md
@@ -67,8 +67,12 @@ drafted. Main was green at rampup (postsubmits from #1893 in flight).
 1. `check_limits` wire-or-delete (carried; DELETE now natural).
 2. `Portfolio_floor` monotonic-peak semantics (carried; the P1b design shows
    the squeeze-robust alternative — index-referenced windowed peak).
-3. `neutral_blocks_shorts` faithfulness flip: deep cost now quantified
-   (−8.6pp return, +7.8pp MaxDD on 2000-2010). Mandate call.
+3. `neutral_blocks_shorts` faithfulness flip: deep cost RE-ATTRIBUTED
+   (2026-07-09 event-level decomposition) — the gate blocked exactly ONE
+   Neutral-tape short in 11 deep years (CF 2006, a loser; blocking helped);
+   the −8.6pp arm delta is post-divergence path noise, true edge cost ≈ 0.
+   Flip is cheap on faithfulness + squeeze-asymmetry grounds; realized
+   benefit also tiny. Mandate call, analysis complete both ways.
 
 ## Bugs / small follow-ups found this session
 

--- a/dev/notes/p1a-deep-short-screens-364-2026-07-09.md
+++ b/dev/notes/p1a-deep-short-screens-364-2026-07-09.md
@@ -37,6 +37,20 @@ Findings:
 2. **But the UN-GATED baseline dominates every gated arm.** Each gate reduces
    return and worsens DD vs ungated (neutral: −8.6pp ret / +7.8pp DD; grind:
    −23.8pp / +5.9pp).
+   **⚠ Attribution correction (2026-07-09, event-level decomposition):** the
+   NEUTRAL arm's delta is NOT mechanism cost. In 11 deep years the neutral
+   gate blocked exactly ONE short — CF Jun-2006, Neutral-tape, a −$31.4k
+   loser in the ungated arm — and blocking it HELPED (neutral arm +3.4%
+   ahead by end-2006). The end-of-window −8.6pp is post-divergence path
+   noise (2008 screening differences: neutral arm caught SMS −$53.0k where
+   ungated caught PM −$4.1k; different recovery-entry timing), and part of
+   its +7.8pp DD is a higher-2007-peak artifact (same GFC trough episode,
+   peak 3% higher). Every 2001-02/2008 hedge (JNS, PRU, GENZ, TEL) had a
+   Bearish tape — the neutral gate touches none of them. **Deep verdict per
+   gate: grind gate = real mechanism cost (blocks the 2001 early-bear
+   hedges); neutral gate = near-inert, noise-sized either way.** This
+   matters for the `neutral_blocks_shorts` faithfulness-flip decision: its
+   true deep edge cost is ≈0, not −8.6pp.
 3. **The WHY is hedge-shaped, not P&L-shaped.** Gated arms have BETTER direct
    short P&L (+$247k on 7 trades vs +$223k on 16) yet lower total return and
    worse DD. The blocked shorts (JNS 2001-02 → +$42k held 10 months, TEL


### PR DESCRIPTION
Third rigor correction of the 07-09 session (same rule each time: decompose arm deltas event-level before believing them).

The faithful-short deep screen note attributed −8.6pp return / +7.8pp MaxDD to `neutral_blocks_shorts` as deep-window gate cost. Event-level decomposition shows:

- The neutral gate blocked exactly **one** short in 11 deep years: CF Jun-2006 (Neutral tape), a **−$31.4k loser** in the ungated arm — blocking it HELPED (+3.4% by end-2006).
- The end-of-window −8.6pp is **post-divergence path noise**: once paths differ, 2008 screening diverges (neutral arm caught SMS −$53.0k where ungated caught PM −$4.1k) and recovery-entry timing differs. Part of the +7.8pp DD is a higher-2007-peak artifact (same GFC trough episode, peak 3% higher).
- Every 2001-02/2008 hedge (JNS, PRU, GENZ, TEL) had a **Bearish** tape — untouched by the neutral gate.

Per-gate deep verdict: **grind gate = real mechanism cost** (blocks the entire 2001 bear's hedges); **neutral gate = near-inert, noise-sized either way**. This changes the `neutral_blocks_shorts` faithfulness-flip decision input: true deep edge cost ≈ 0, not −8.6pp. Handoff decision-item 3 updated accordingly.

Docs-only (2 .md) → QC skipped per pr-merge-gates; CI required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)