### PR TITLE
docs(experiment): Portfolio_floor ablation — floor-off dominates the GME window

### DIFF
--- a/dev/backtest/floor-off-exp-2026-07-09/FINDINGS.md
+++ b/dev/backtest/floor-off-exp-2026-07-09/FINDINGS.md
@@ -1,0 +1,67 @@
+# Portfolio_floor off — the GME-window ablation (2026-07-09)
+
+User-directed experiment ("what if we get rid of it — would it make things more
+stable?"): re-run the floor pathology window with the brake disabled. No code
+change — `min_portfolio_value_fraction_of_peak` is config;
+`((portfolio_config ((force_liquidation ((min_portfolio_value_fraction_of_peak 0.0))))))`
+disables the portfolio-floor trigger (per-position force-liq stays active).
+
+**Arms:** `goldens-sp500-historical/sp500-2010-2026.sexp` (long-only, 0.30
+concentration, 364 basis, test_data store) as-is (floor 0.4 = default) vs
+floor-off. Same-session paired run; floor-on reproduced its golden pins
+exactly (1013.8% / DD 65.8 / 32 floor liqs / OPV 0).
+
+## Result — floor-off dominates every metric that matters
+
+| metric | floor ON | floor OFF | read |
+|---|---|---|---|
+| total return | 1013.8% | **2223.3%** | +1210pp |
+| Sharpe | 0.538 | **0.610** | |
+| Sortino | 0.813 | **0.865** | |
+| Calmar | 0.242 | **0.271** | better even though MaxDD is worse — return more than compensates |
+| Ulcer (time-underwater) | 33.9 | **23.6** | floor-off recovers; floor-on flatlines 5y |
+| MaxDD | **65.8%** | 78.3% | the one floor "win" — but see below |
+| trades | 410 | 588 | floor-on missed ~178 trades (2021-2025 sterilized) |
+| portfolio-floor liqs | 32 | 0 | |
+| end state | $11.1M all-cash, halted | $23.2M ($6.5M unrealized) | floor-off end is MTM-top-heavy; realized-basis ≈ $16.7M still ≫ $11.1M |
+
+**The MaxDD "win" is hollow.** Both drawdowns are measured from the same
+$28.9M GME-squeeze MTM peak (never realizable). The floor's 65.8% includes
+the damage the floor itself caused — it force-sold the entire book at the
+squeeze collapse (near the local bottom) and then re-liquidated 31 more times,
+locking the loss in. Floor-off rides the same collapse deeper on paper
+(78.3%) but keeps the book, keeps trading, and its time-underwater profile
+(Ulcer 23.6 vs 33.9) is far better. A brake whose fire = sell-everything-at-
+the-bottom + halt does not reduce risk; it converts a paper drawdown into a
+realized one and then forecloses the recovery.
+
+## Scope honesty
+
+- Single window, single path, and the window was chosen BECAUSE the floor
+  misfires here — this quantifies the harm on the worked example; it is not a
+  universe/period-robust promotion test.
+- The floor's intended value case (a true, non-recovering death spiral) does
+  not occur in any tested config: the deep top-3000 2000-2026 run fires it 0
+  times, sp500 deep arms ~1 per-position event, and the only portfolio-floor
+  fires we have ever observed are these 32 pathological ones. There is no
+  observed window where the portfolio floor helped.
+
+## Options (decision item — user)
+
+1. **Fix semantics, keep the brake** (recommended path, already in motion):
+   the P1b breaker lib's index-referenced trailing-WINDOW peak + self-
+   contained re-entry is the squeeze-immune design; port it to
+   `Force_liquidation.Peak_tracker` once the lib lands. The brake then can't
+   be poisoned by one position's MTM spike and can't sterilize a run.
+2. **Default the portfolio-floor trigger off now** (set
+   `min_portfolio_value_fraction_of_peak` default 0.4 → 0.0): defensible on
+   the evidence (never helps, catastrophically hurts once), but it is a
+   default change on a RISK-CONTROL — per experiment-flag-discipline R3 +
+   promotion-confirmation this wants more than one pathological window; and
+   it re-pins the sp500-2010-2026 golden (this experiment IS the re-pin
+   measurement if chosen).
+3. Leave as-is, documented (status quo; the golden pins the pathology loudly).
+
+Artifacts: `floor-{on,off}-actual.sexp` here; raw runs under the gitignored
+`trading/dev/backtest/scenarios-2026-07-09-160512/`; log
+`/tmp/sweeps/floor-exp-v1.log`.

--- a/dev/backtest/floor-off-exp-2026-07-09/floor-off-actual.sexp
+++ b/dev/backtest/floor-off-exp-2026-07-09/floor-off-actual.sexp
@@ -1,0 +1,7 @@
+((total_return_pct 2223.348451392781) (total_trades 588)
+ (win_rate 42.857142857142854) (sharpe_ratio 0.61010703724897264)
+ (max_drawdown_pct 78.286343392042141) (avg_holding_days 49.345238095238095)
+ (open_positions_value 18142201.35) (unrealized_pnl 6547429.4112750031)
+ (sortino_ratio_annualized 0.86521387820551676)
+ (calmar_ratio 0.27142686952893763) (ulcer_index 23.559244856631349)
+ (force_liquidations_count 0) (crashed false) (crash_message ""))

--- a/dev/backtest/floor-off-exp-2026-07-09/floor-on-actual.sexp
+++ b/dev/backtest/floor-off-exp-2026-07-09/floor-on-actual.sexp
@@ -1,0 +1,7 @@
+((total_return_pct 1013.8407105572409) (total_trades 410)
+ (win_rate 46.341463414634148) (sharpe_ratio 0.53835680123010221)
+ (max_drawdown_pct 65.829423115689622) (avg_holding_days 50.241463414634147)
+ (open_positions_value 0) (unrealized_pnl 0)
+ (sortino_ratio_annualized 0.81314975640929343)
+ (calmar_ratio 0.2416846775862172) (ulcer_index 33.949092760572626)
+ (force_liquidations_count 32) (crashed false) (crash_message ""))

--- a/dev/notes/next-session-priorities-2026-07-09.md
+++ b/dev/notes/next-session-priorities-2026-07-09.md
@@ -65,8 +65,15 @@ drafted. Main was green at rampup (postsubmits from #1893 in flight).
 ## Decision items (human)
 
 1. `check_limits` wire-or-delete (carried; DELETE now natural).
-2. `Portfolio_floor` monotonic-peak semantics (carried; the P1b design shows
-   the squeeze-robust alternative — index-referenced windowed peak).
+2. `Portfolio_floor` monotonic-peak semantics — **ablation run 2026-07-09**
+   (`dev/backtest/floor-off-exp-2026-07-09/FINDINGS.md`): on the GME window,
+   floor-OFF dominates every risk-adjusted metric (return 1013.8→2223.3%,
+   Sharpe .538→.610, Ulcer 33.9→23.6; only raw MaxDD "wins" for the floor and
+   that win is hollow — the floor's own bottom-tick liquidation is most of
+   its measured DD). No tested config shows a beneficial portfolio-floor
+   fire. Options in the FINDINGS: (1) port P1b windowed-peak semantics to the
+   engine floor (recommended), (2) default the trigger off (wants more than
+   one window per R3), (3) status quo. User call.
 3. `neutral_blocks_shorts` faithfulness flip: deep cost RE-ATTRIBUTED
    (2026-07-09 event-level decomposition) — the gate blocked exactly ONE
    Neutral-tape short in 11 deep years (CF 2006, a loser; blocking helped);


### PR DESCRIPTION
User-directed experiment (2026-07-09): disable the portfolio-floor brake on the window where it misfires (sp500-2010-2026 long-only, 0.30 concentration, 364 basis). Config-only ablation (`min_portfolio_value_fraction_of_peak 0.0`), paired same-session arms; the floor-on arm reproduced its golden pins exactly.

| metric | floor ON | floor OFF |
|---|---|---|
| return | 1013.8% | **2223.3%** |
| Sharpe / Sortino / Calmar | .538 / .813 / .242 | **.610 / .865 / .271** |
| Ulcer | 33.9 | **23.6** |
| MaxDD | **65.8%** | 78.3% |
| portfolio-floor liqs | 32 | 0 |

The MaxDD 'win' is hollow: both drawdowns measure from the same unrealizable $28.9M GME-squeeze MTM peak, and the floor's 65.8% includes the damage it caused (sell-everything at the collapse bottom, then 31 re-liquidations + 5-year halt). Time-underwater (Ulcer) strongly favors floor-off.

**No tested config shows a beneficial portfolio-floor fire** (deep top-3000 2000-2026: 0 fires; the only observed fires are these 32 pathological ones).

Decision options (human, recorded in FINDINGS + handoff): (1) port the P1b breaker's windowed-peak semantics to the engine floor — recommended; (2) default the trigger off (single pathological window is thin evidence for flipping a risk-control default per R3); (3) status quo, documented.

Scope honesty: single window, single path, chosen because the floor misfires here — harm quantification on the worked example, not a robustness test.

Docs-only (.md + 2 result .sexp artifacts under dev/backtest/) → per pr-merge-gates the QC agents add no value here; CI required. Flagging for transparency: the 2 sexp files are run artifacts (like prior FINDINGS dirs), not code or fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)