### PR TITLE
feat(macro): index circuit-breaker pure lib (P1b step 1, no consumers)

### DIFF
--- a/dev/status/_index.md
+++ b/dev/status/_index.md
@@ -54,6 +54,7 @@ Each row: one line; deeper task detail in the linked status file.
 | [weekly-snapshot](weekly-snapshot.md) | IN_PROGRESS | feat-weinstein | — | snapshot fast-input path (#1784) + corrected 5-wk picks (#1781) MERGED; next: large-warehouse multi-week sweep (data-gated); live-cycle human-gated |
 | [walk-forward-cv](walk-forward-cv.md) | MERGED | feat-backtest | — | — |
 | [data-foundations](data-foundations.md) | IN_PROGRESS | feat-data | — | eligibility builder (#1594) + live refresh (#1595) + staleness guard (#1790) MERGED; next: ADR $-vol policy artifact (human-gated; largely subsumed) |
+| [floor-quality](floor-quality.md) | IN_PROGRESS | feat-weinstein | feat/circuit-breaker-lib | P1b step 1: pure index circuit-breaker lib (default-off, axis-ready, no consumers); next: thin SPY sleeve consumer, then lens screen vs TR-SPY |
 
 ## How to use
 

--- a/dev/status/floor-quality.md
+++ b/dev/status/floor-quality.md
@@ -1,0 +1,40 @@
+# Status: floor-quality
+
+## Last updated: 2026-07-09
+
+## Status
+IN_PROGRESS
+
+## Scope
+The floor-quality program (P0 per `memory/project_floor_quality_program`): build
+a better SPY floor sleeve than raw stage-timed SPY — a long-only sleeve with a
+quick, accurate circuit breaker that matches TOTAL-RETURN SPY over 2000-2026
+while cutting the deep-crash left tail. Design authority:
+`dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md` (P1b).
+
+## Completed
+- **P1b step 1 — pure index circuit-breaker lib** (branch
+  `feat/circuit-breaker-lib`): new module
+  `analysis/weinstein/macro/lib/index_circuit_breaker.{ml,mli}` + OUnit2 tests.
+  A pure, lookahead-free two-state machine (`In_market` / `Out_of_market`) with
+  three exit triggers (T1 fast-crash, T2 confirmed breadth-led slow-grind, T3
+  absolute-floor on a **trailing-window** high) and asymmetric self-contained
+  re-entry (fast recovery off post-exit low after fast/floor exits;
+  Weinstein-style price-above-turning-MA after a grind exit). Reuses
+  `Decline_character.classify` for the fast-V / slow-grind character read. Every
+  threshold is a config field with `[@sexp.default …]` → axis-ready. No consumer
+  wiring; changes no behaviour anywhere. Encodes the two GME-pathology lessons
+  (decaying windowed peak, no halt-until-external-reset) per
+  `dev/notes/warmup-364-repin-2026-07-08.md` §Findings.
+
+## In Progress
+- (none — awaiting review/merge of P1b step 1)
+
+## Next Steps
+1. **P1b step 2 — thin sleeve strategy** consuming the breaker (buy-and-hold SPY
+   + breaker), alongside `Spy_only_weinstein_strategy`, adjusted-close bars for
+   both sleeve and comparator. Follow-up dispatch.
+2. **P1b step 3 — lens screen** vs TR-SPY 2000-2026 (per-episode drawdown
+   captured/avoided, days out, intervention count, whipsaw cost distribution).
+3. **P1b step 4 — WF-CV surface** over the breaker thresholds, then a deep
+   bear-regime promotion grid (`promotion-confirmation.md`) before any default.

--- a/dev/status/floor-quality.md
+++ b/dev/status/floor-quality.md
@@ -5,6 +5,9 @@
 ## Status
 IN_PROGRESS
 
+## Interface stable
+NO
+
 ## Scope
 The floor-quality program (P0 per `memory/project_floor_quality_program`): build
 a better SPY floor sleeve than raw stage-timed SPY — a long-only sleeve with a

--- a/trading/analysis/weinstein/macro/lib/decline_character.ml
+++ b/trading/analysis/weinstein/macro/lib/decline_character.ml
@@ -12,7 +12,7 @@ type config = {
   trailing_high_lookback_weeks : int;
   fast_v_ignores_ma_filter : bool; [@sexp.default false]
 }
-[@@deriving sexp]
+[@@deriving show, eq, sexp]
 
 let default_config =
   {

--- a/trading/analysis/weinstein/macro/lib/decline_character.mli
+++ b/trading/analysis/weinstein/macro/lib/decline_character.mli
@@ -96,7 +96,7 @@ type config = {
           tail-RISK-insurance exception ([weinstein-faithful-core.md]), not a
           spine change. *)
 }
-[@@deriving sexp]
+[@@deriving show, eq, sexp]
 (** Tunable thresholds for {!classify}. Every threshold is a config field (no
     hardcoded magic numbers) so the signal is gridable as a [Variant_matrix]
     axis once a consumer wires it. Defaults reflect the illustrative thresholds

--- a/trading/analysis/weinstein/macro/lib/index_circuit_breaker.ml
+++ b/trading/analysis/weinstein/macro/lib/index_circuit_breaker.ml
@@ -18,19 +18,14 @@ type action = Hold | Exit of exit_reason | Re_enter
 
 type config = {
   decline_config : Decline_character.config;
-      [@sexp.default
-        {
-          Decline_character.default_config with
-          fast_v_ignores_ma_filter = true;
-        }]
-  fast_exit_rate_pct : float; [@sexp.default 0.08]
-  fast_exit_lookback_bars : int; [@sexp.default 4]
-  grind_confirm_weeks : int; [@sexp.default 3]
-  floor_drop_pct : float; [@sexp.default 0.20]
-  floor_peak_lookback_bars : int; [@sexp.default 52]
-  fast_reentry_recover_pct : float; [@sexp.default 0.05]
-  slow_reentry_ma_weeks : int; [@sexp.default 30]
-  slow_reentry_ma_rising_lookback : int; [@sexp.default 4]
+  fast_exit_rate_pct : float;
+  fast_exit_lookback_bars : int;
+  grind_confirm_weeks : int;
+  floor_drop_pct : float;
+  floor_peak_lookback_bars : int;
+  fast_reentry_recover_pct : float;
+  slow_reentry_ma_weeks : int;
+  slow_reentry_ma_rising_lookback : int;
 }
 [@@deriving show, eq, sexp]
 

--- a/trading/analysis/weinstein/macro/lib/index_circuit_breaker.ml
+++ b/trading/analysis/weinstein/macro/lib/index_circuit_breaker.ml
@@ -1,0 +1,215 @@
+open Core
+open Types
+
+type exit_reason = Fast_crash | Slow_grind | Absolute_floor
+[@@deriving show, eq, sexp]
+
+type state =
+  | In_market of { grind_streak : int }
+  | Out_of_market of {
+      exited_on : exit_reason;
+      exit_date : Date.t;
+      post_exit_low : float;
+    }
+[@@deriving show, eq, sexp]
+
+type action = Hold | Exit of exit_reason | Re_enter
+[@@deriving show, eq, sexp]
+
+type config = {
+  decline_config : Decline_character.config;
+      [@sexp.default
+        {
+          Decline_character.default_config with
+          fast_v_ignores_ma_filter = true;
+        }]
+  fast_exit_rate_pct : float; [@sexp.default 0.08]
+  fast_exit_lookback_bars : int; [@sexp.default 4]
+  grind_confirm_weeks : int; [@sexp.default 3]
+  floor_drop_pct : float; [@sexp.default 0.20]
+  floor_peak_lookback_bars : int; [@sexp.default 52]
+  fast_reentry_recover_pct : float; [@sexp.default 0.05]
+  slow_reentry_ma_weeks : int; [@sexp.default 30]
+  slow_reentry_ma_rising_lookback : int; [@sexp.default 4]
+}
+[@@deriving show, eq, sexp]
+
+let default_config =
+  {
+    decline_config =
+      { Decline_character.default_config with fast_v_ignores_ma_filter = true };
+    fast_exit_rate_pct = 0.08;
+    fast_exit_lookback_bars = 4;
+    grind_confirm_weeks = 3;
+    floor_drop_pct = 0.20;
+    floor_peak_lookback_bars = 52;
+    fast_reentry_recover_pct = 0.05;
+    slow_reentry_ma_weeks = 30;
+    slow_reentry_ma_rising_lookback = 4;
+  }
+
+let in_market = In_market { grind_streak = 0 }
+
+(* The most recent index bar, or [None] when there are no bars. *)
+let _current_bar (bars : Daily_price.t list) : Daily_price.t option =
+  List.last bars
+
+(* Positive drawdown [(reference - now) / reference]; [None] when [reference] is
+   non-positive. A helper so callers avoid a nested [else]. *)
+let _drawdown_fraction ~(reference : float) ~(now : float) : float option =
+  if Float.( <= ) reference 0.0 then None
+  else Some ((reference -. now) /. reference)
+
+(* Trailing drawdown [(close[-1-lookback] - close[-1]) / close[-1-lookback]] as a
+   positive fraction (negative if the index rose). [None] when there are too few
+   bars or the reference close is non-positive. Reads only the last bar and the
+   bar [lookback] bars earlier — lookahead-free. *)
+let _trailing_drawdown (bars : Daily_price.t list) ~(lookback : int) :
+    float option =
+  let n = List.length bars in
+  if n <= lookback || lookback < 0 then None
+  else
+    let arr = Array.of_list bars in
+    _drawdown_fraction ~reference:arr.(n - 1 - lookback).Daily_price.close_price
+      ~now:arr.(n - 1).Daily_price.close_price
+
+(* Highest close over the trailing [lookback] window (current bar inclusive). A
+   WINDOWED high that decays as bars scroll out — never a monotonic high-water
+   mark (the GME lesson; see the .mli). *)
+let _trailing_peak (bars : Daily_price.t list) ~(lookback : int) : float =
+  let window = List.drop bars (Int.max 0 (List.length bars - lookback)) in
+  List.fold window ~init:0.0 ~f:(fun acc b ->
+      Float.max acc b.Daily_price.close_price)
+
+(* Simple mean of [close_price] over the [period] bars ending at [end_idx]
+   (inclusive, 0-based into [arr]). [None] when the window does not fit. *)
+let _ma_ending (arr : Daily_price.t array) ~(period : int) ~(end_idx : int) :
+    float option =
+  if period <= 0 || end_idx < 0 || end_idx - period + 1 < 0 then None
+  else
+    let sum = ref 0.0 in
+    for i = end_idx - period + 1 to end_idx do
+      sum := !sum +. arr.(i).Daily_price.close_price
+    done;
+    Some (!sum /. Float.of_int period)
+
+(* T1: a steep short-window drawdown with fast-V character (no A-D breadth lead,
+   per {!Decline_character.classify}). *)
+let _fast_crash (bars : Daily_price.t list) (character : Decline_character.t)
+    ~(config : config) : bool =
+  match character with
+  | Decline_character.Fast_v ->
+      _trailing_drawdown bars ~lookback:config.fast_exit_lookback_bars
+      |> Option.exists ~f:(fun dd -> Float.( >= ) dd config.fast_exit_rate_pct)
+  | Decline_character.Slow_grind | Decline_character.Not_declining -> false
+
+(* T3: the index close is below [(1 - floor_drop_pct)] times the trailing-window
+   high — the catastrophic backstop, keyed to a DECAYING windowed peak. *)
+let _floor_breached (bars : Daily_price.t list) ~(config : config)
+    ~(now : float) : bool =
+  let peak = _trailing_peak bars ~lookback:config.floor_peak_lookback_bars in
+  Float.( > ) peak 0.0
+  && Float.( < ) now ((1.0 -. config.floor_drop_pct) *. peak)
+
+(* Enter [Out_of_market] on [reason] at [current], seeding [post_exit_low] with
+   the exit-bar close. *)
+let _exit_to (reason : exit_reason) (current : Daily_price.t) : state =
+  Out_of_market
+    {
+      exited_on = reason;
+      exit_date = current.Daily_price.date;
+      post_exit_low = current.Daily_price.close_price;
+    }
+
+(* The T1/T3 immediate exits (fast-crash, then absolute floor) as a direct
+   else-if chain; [None] when neither fires. *)
+let _immediate_exit ~(config : config) (character : Decline_character.t)
+    (current : Daily_price.t) (index_bars : Daily_price.t list) :
+    (state * action) option =
+  if _fast_crash index_bars character ~config then
+    Some (_exit_to Fast_crash current, Exit Fast_crash)
+  else if
+    _floor_breached index_bars ~config ~now:current.Daily_price.close_price
+  then Some (_exit_to Absolute_floor current, Exit Absolute_floor)
+  else None
+
+(* Advance the grind streak (T2): count consecutive [Slow_grind] steps and fire
+   the slow-grind exit once [grind_confirm_weeks] is reached, else hold. *)
+let _grind_step ~(config : config) ~(grind_streak : int)
+    (character : Decline_character.t) (current : Daily_price.t) : state * action
+    =
+  let streak =
+    match character with
+    | Decline_character.Slow_grind -> grind_streak + 1
+    | Decline_character.Fast_v | Decline_character.Not_declining -> 0
+  in
+  if streak >= config.grind_confirm_weeks then
+    (_exit_to Slow_grind current, Exit Slow_grind)
+  else (In_market { grind_streak = streak }, Hold)
+
+(* The [In_market] branch: T1/T3 immediate exits take precedence, else the
+   confirmed-slow-grind (T2) / hold decision. *)
+let _step_in_market ~(config : config) ~(grind_streak : int)
+    ~(ad_macro : Macro.result) ~(index_bars : Daily_price.t list) :
+    state * action =
+  match _current_bar index_bars with
+  | None -> (In_market { grind_streak }, Hold)
+  | Some current -> (
+      let character =
+        Decline_character.classify ~config:config.decline_config ~macro:ad_macro
+          ~index_bars
+      in
+      match _immediate_exit ~config character current index_bars with
+      | Some result -> result
+      | None -> _grind_step ~config ~grind_streak character current)
+
+(* Weinstein-style slow re-entry: current close above a turning
+   [slow_reentry_ma_weeks] MA (its value now above its value
+   [slow_reentry_ma_rising_lookback] bars earlier). *)
+let _slow_reentry (index_bars : Daily_price.t list) ~(config : config)
+    ~(now : float) : bool =
+  let arr = Array.of_list index_bars in
+  let last = Array.length arr - 1 in
+  let ma_now =
+    _ma_ending arr ~period:config.slow_reentry_ma_weeks ~end_idx:last
+  in
+  let ma_prev =
+    _ma_ending arr ~period:config.slow_reentry_ma_weeks
+      ~end_idx:(last - config.slow_reentry_ma_rising_lookback)
+  in
+  match (ma_now, ma_prev) with
+  | Some ma_now, Some ma_prev ->
+      Float.( > ) now ma_now && Float.( > ) ma_now ma_prev
+  | _ -> false
+
+(* Re-entry signal, asymmetric by which trigger fired the exit. *)
+let _reentry (index_bars : Daily_price.t list) ~(config : config)
+    ~(exited_on : exit_reason) ~(low : float) ~(now : float) : bool =
+  match exited_on with
+  | Fast_crash | Absolute_floor ->
+      Float.( >= ) now (low *. (1.0 +. config.fast_reentry_recover_pct))
+  | Slow_grind -> _slow_reentry index_bars ~config ~now
+
+(* The [Out_of_market] branch: lower [post_exit_low] to include the current
+   close, then re-enter if the (asymmetric) re-entry rule fires. Self-contained —
+   never waits on an external macro flip. *)
+let _step_out_of_market ~(config : config) ~(exited_on : exit_reason)
+    ~(exit_date : Date.t) ~(post_exit_low : float)
+    ~(index_bars : Daily_price.t list) : state * action =
+  match _current_bar index_bars with
+  | None -> (Out_of_market { exited_on; exit_date; post_exit_low }, Hold)
+  | Some current ->
+      let now = current.Daily_price.close_price in
+      let low = Float.min post_exit_low now in
+      if _reentry index_bars ~config ~exited_on ~low ~now then
+        (in_market, Re_enter)
+      else (Out_of_market { exited_on; exit_date; post_exit_low = low }, Hold)
+
+let step ~(config : config) ~(state : state) ~(index_bars : Daily_price.t list)
+    ~(ad_macro : Macro.result) : state * action =
+  match state with
+  | In_market { grind_streak } ->
+      _step_in_market ~config ~grind_streak ~ad_macro ~index_bars
+  | Out_of_market { exited_on; exit_date; post_exit_low } ->
+      _step_out_of_market ~config ~exited_on ~exit_date ~post_exit_low
+        ~index_bars

--- a/trading/analysis/weinstein/macro/lib/index_circuit_breaker.mli
+++ b/trading/analysis/weinstein/macro/lib/index_circuit_breaker.mli
@@ -1,0 +1,210 @@
+open Types
+
+(** Index circuit-breaker — a pure, lookahead-free two-state machine that
+    decides when a long-only index (SPY) floor sleeve should sell to cash and
+    when it should re-enter.
+
+    Design authority: [dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md]
+    (P1b of the floor-quality program), user mandate 2026-07-09. This module is
+    {b step 1} of that plan: the pure lib only. The thin sleeve strategy that
+    consumes it (buy-and-hold SPY + breaker) is a separate follow-up and is NOT
+    built here — this module changes no behaviour anywhere on its own.
+
+    {b Why this exists}: full Weinstein stage-timing on SPY
+    ([Spy_only_weinstein_strategy]) times {e everything}, so every false stage
+    exit is an upside tax on the one instrument whose long-run drift is the
+    whole return (the index sleeve's "winner" IS the buy-and-hold position — per
+    [project_edge_is_the_fat_tail], touching it needs the tail-RISK-insurance
+    exception, i.e. rare, crash-gated interventions only). The breaker is
+    instead {b default-in-market}: a rare intervention, asymmetric by decline
+    character, with fast re-entry.
+
+    {b Faithfulness / spine}: this does not change any Weinstein spine rule
+    ([weinstein-faithful-core.md]). For a single-instrument index sleeve the
+    macro gate collapses to the instrument itself; the breaker is a
+    tail-RISK-insurance exit/re-entry overlay, not a new buy rule. Every
+    threshold is a config field (no hardcoded magic numbers) so it is an
+    experiment axis on day one ([experiment-flag-discipline.md] R2).
+
+    {b Lookahead-free}: every decision reads only the current and earlier index
+    bars plus the current-week macro read. No future bar is ever consulted. All
+    functions are pure: same inputs always produce the same output.
+
+    {b The two load-bearing semantics (from the design doc §"Semantics
+       requirements — the GME lesson", non-negotiable, see
+       [dev/notes/warmup-364-repin-2026-07-08.md] §Findings)}:
+
+    - {b The T3 floor peak is a TRAILING-WINDOW high of INDEX PRICE, never a
+         monotonic high-water mark.} The engine's
+      [Force_liquidation.Peak_tracker] is monotonic over NAV; GME's Jan-2021
+      parabolic MTM spike ($28.9M) set a floor the run could never re-clear,
+      sterilizing the strategy for 5 years (32 repeat liquidations). A
+      trailing-window high of index price {b decays by construction} once the
+      spike scrolls out of the window, so it cannot be poisoned by a single
+      position's unrealized mark. See {!config.floor_peak_lookback_bars}.
+    - {b Re-entry is self-contained in the state machine — there is no
+         halt-until-external-reset.} The engine [Portfolio_floor]'s
+      Bearish→non-Bearish reset was the second half of the GME sterilization
+      (the reset fired while NAV was still under the un-decayed floor, so it
+      refired). Here, an {!Out_of_market} state re-enters purely from subsequent
+      index behaviour (recovery off the post-exit low, or price above a turning
+      MA) — it never waits on an external macro flip. *)
+
+type exit_reason =
+  | Fast_crash
+      (** T1: a steep short-window index drawdown with fast-V character (no
+          Advance-Decline breadth lead). Arms {b fast} re-entry. *)
+  | Slow_grind
+      (** T2: a sustained breadth-led distribution decline (A-D line leading the
+          index down), confirmed over several weeks. Arms {b slow},
+          Weinstein-style re-entry (grind bottoms are slow; confirmation is
+          cheap there). *)
+  | Absolute_floor
+      (** T3: the catastrophic backstop — the index closed below a fraction of
+          its {b trailing-window} high (a decaying reference, never a monotonic
+          high-water mark). Arms {b fast} re-entry. *)
+[@@deriving show, eq, sexp]
+
+type state =
+  | In_market of { grind_streak : int }
+      (** Holding the index. [grind_streak] is the number of consecutive steps
+          most recently classified [Slow_grind] (0 when the last step was not a
+          grind); the T2 exit fires when it reaches
+          {!config.grind_confirm_weeks}. A fresh sleeve starts at {!in_market}
+          ([grind_streak = 0]). *)
+  | Out_of_market of {
+      exited_on : exit_reason;
+          (** Which trigger caused the exit — selects the re-entry rule
+              (asymmetric re-entry). *)
+      exit_date : Core.Date.t;  (** Date of the bar on which the exit fired. *)
+      post_exit_low : float;
+          (** Lowest index close observed from the exit bar through the current
+              bar (inclusive). Monotonically non-increasing while out of market;
+              the fast re-entry threshold is measured as a recovery
+              {b off this low}, so a deeper crash lowers the bar the index must
+              clear to re-enter. *)
+    }
+[@@deriving show, eq, sexp]
+
+type action =
+  | Hold  (** No transition this step (stay in the current state). *)
+  | Exit of exit_reason  (** Sell the index to cash this step. *)
+  | Re_enter  (** Buy the index back this step. *)
+[@@deriving show, eq, sexp]
+
+type config = {
+  decline_config : Decline_character.config;
+      (** Threaded into {!Decline_character.classify} to read the fast-V /
+          slow-grind {b character} of the index each step. The breaker's default
+          sets [fast_v_ignores_ma_filter = true] so the fast-V path arms on rate
+          alone (the 2020 fix: a V-crash falls before the weekly MA rolls over).
+          Exposed so its own thresholds are tunable as axes too. *)
+  fast_exit_rate_pct : float;
+      (** T1 threshold: the trailing index drawdown over
+          {!fast_exit_lookback_bars} must be at least this positive fraction
+          (e.g. 0.08 = 8%) for a fast-crash exit, {b in addition to} the step
+          being classified [Fast_v]. Default: 0.08. *)
+  fast_exit_lookback_bars : int;
+      (** T1 window (bars) over which the fast-exit drawdown is measured.
+          Default: 4. *)
+  grind_confirm_weeks : int;
+      (** T2 confirmation: the step must be classified [Slow_grind] this many
+          consecutive times before the slow-grind exit fires. A slow bear is
+          where early exit pays and confirmation is cheap (the decline is slow).
+          Default: 3. *)
+  floor_drop_pct : float;
+      (** T3 threshold: an exit fires when the current index close is below
+          [(1 -. floor_drop_pct)] times the {b trailing-window} high. Default:
+          0.20. *)
+  floor_peak_lookback_bars : int;
+      (** T3 window (bars) over which the trailing high is taken. This is what
+          makes the floor {b decay} — the reference high is the max close over
+          only the last [floor_peak_lookback_bars] bars, never an all-time
+          high-water mark, so a parabolic spike cannot poison it once it scrolls
+          out of the window (the GME lesson). Default: 52. *)
+  fast_reentry_recover_pct : float;
+      (** Fast re-entry threshold (after a [Fast_crash] or [Absolute_floor]
+          exit): re-enter when the current close has recovered at least this
+          fraction {b off the post-exit low} (e.g. 0.05 = 5% above the low). A
+          missed V-bounce is the floor's biggest historical tax, so this is
+          deliberately quick. Default: 0.05. *)
+  slow_reentry_ma_weeks : int;
+      (** Slow re-entry (after a [Slow_grind] exit): the period of the simple MA
+          of index close the price must be above. Weinstein-style re-entry above
+          a turning weekly MA. Default: 30. *)
+  slow_reentry_ma_rising_lookback : int;
+      (** Slow re-entry: the MA must be {b turning up} — its value now must
+          exceed its value this many bars earlier — before re-entry fires.
+          Default: 4. *)
+}
+[@@deriving show, eq, sexp]
+(** Every trigger threshold, all config fields (no hardcoded constants) so the
+    breaker is expressible as a [Variant_matrix] axis the day a consumer wires
+    it. Each field carries a [[@sexp.default ...]] so a partial sexp parses
+    against {!default_config}. *)
+
+val default_config : config
+(** [default_config] returns the design-doc reference priors (see the field
+    docs). These are {b priors to search}, not a validated configuration: the
+    plan calls for a WF-CV surface + a deep bear-regime promotion grid before
+    any of these values is trusted as a default. *)
+
+val in_market : state
+(** [in_market] is the fresh sleeve state: [In_market { grind_streak = 0 }]. *)
+
+val step :
+  config:config ->
+  state:state ->
+  index_bars:Daily_price.t list ->
+  ad_macro:Macro.result ->
+  state * action
+(** [step ~config ~state ~index_bars ~ad_macro] advances the breaker one bar and
+    returns the next state paired with the action to take {b this} bar.
+
+    @param index_bars
+      Trailing index bars up to and including the current bar, chronological
+      oldest-first. Closes are read as [close_price] (matching
+      {!Decline_character}); a caller wanting a dividend-adjusted read supplies
+      an adjusted series. Read at the current bar and earlier offsets only —
+      never the future.
+    @param ad_macro
+      The already-computed macro result for the current week, threaded into
+      {!Decline_character.classify} for the fast-V / slow-grind character read.
+      Only consulted while {!In_market} (re-entry is decided from index bars
+      alone).
+
+    Transition rules (thresholds from [config]):
+
+    {ul
+     {- {b In_market} — exits are checked in precedence order:
+        + {b T1 fast-crash} ([Fast_crash]): the step classifies [Fast_v] AND the
+          trailing drawdown over [fast_exit_lookback_bars] ≥
+          [fast_exit_rate_pct].
+        + {b T3 absolute floor} ([Absolute_floor]): the current close is below
+          [(1 -. floor_drop_pct)] × the trailing-window high over
+          [floor_peak_lookback_bars].
+        + {b T2 slow-grind} ([Slow_grind]): the step classifies [Slow_grind] and
+          has done so for [grind_confirm_weeks] consecutive steps.
+
+        Otherwise [Hold], carrying the updated [grind_streak].
+     }
+    }
+
+    {ul
+     {- {b Out_of_market} — [post_exit_low] is first lowered to include the
+        current close, then re-entry is checked by the exit reason (asymmetric
+        re-entry):
+        - After [Fast_crash] / [Absolute_floor]: [Re_enter] when the current
+          close ≥ [post_exit_low] × [(1 +. fast_reentry_recover_pct)].
+        - After [Slow_grind]: [Re_enter] when the current close is above the
+          [slow_reentry_ma_weeks] MA {b and} that MA is rising (its value now
+          exceeds its value [slow_reentry_ma_rising_lookback] bars earlier).
+
+        Otherwise [Hold], carrying the lowered [post_exit_low]. Re-entry is
+        fully self-contained: it never waits on an external macro flip (the GME
+        [Portfolio_floor] anti-pattern this design deliberately avoids).
+     }
+    }
+
+    Empty [index_bars] (no current bar) is a safe no-op: the state is returned
+    unchanged with [Hold]. Pure and lookahead-free. *)

--- a/trading/analysis/weinstein/macro/lib/index_circuit_breaker.mli
+++ b/trading/analysis/weinstein/macro/lib/index_circuit_breaker.mli
@@ -140,8 +140,9 @@ type config = {
 [@@deriving show, eq, sexp]
 (** Every trigger threshold, all config fields (no hardcoded constants) so the
     breaker is expressible as a [Variant_matrix] axis the day a consumer wires
-    it. Each field carries a [[@sexp.default ...]] so a partial sexp parses
-    against {!default_config}. *)
+    it. Derives [sexp] for round-trip; a full record is expected on parse (the
+    reference values live in {!default_config}), consistent with
+    {!Decline_character.config}. *)
 
 val default_config : config
 (** [default_config] returns the design-doc reference priors (see the field

--- a/trading/analysis/weinstein/macro/test/dune
+++ b/trading/analysis/weinstein/macro/test/dune
@@ -1,6 +1,14 @@
 (tests
- (names test_macro test_ad_bars_aggregation test_decline_character)
- (modules test_macro test_ad_bars_aggregation test_decline_character)
+ (names
+  test_macro
+  test_ad_bars_aggregation
+  test_decline_character
+  test_index_circuit_breaker)
+ (modules
+  test_macro
+  test_ad_bars_aggregation
+  test_decline_character
+  test_index_circuit_breaker)
  (libraries macro weinstein_types stage types core ounit2 matchers))
 
 (test

--- a/trading/analysis/weinstein/macro/test/test_index_circuit_breaker.ml
+++ b/trading/analysis/weinstein/macro/test/test_index_circuit_breaker.ml
@@ -1,0 +1,286 @@
+open OUnit2
+open Core
+open Matchers
+open Types
+module Cb = Index_circuit_breaker
+
+let cfg = Cb.default_config
+
+(* ------------------------------------------------------------------ *)
+(* Inline fixture builders                                             *)
+(* ------------------------------------------------------------------ *)
+
+let make_bar date close =
+  {
+    Daily_price.date = Date.of_string date;
+    open_price = close;
+    high_price = close *. 1.01;
+    low_price = close *. 0.99;
+    close_price = close;
+    adjusted_close = close;
+    volume = 100_000;
+    active_through = None;
+  }
+
+(* Weekly bars from a price list, 7 days apart starting 2020-01-06. *)
+let weekly_bars prices =
+  let base = Date.of_string "2020-01-06" in
+  List.mapi prices ~f:(fun i p ->
+      make_bar (Date.to_string (Date.add_days base (i * 7))) p)
+
+(* A macro result carrying just the stage MA + A-D reading the classifier reads. *)
+let macro_result ~ma_value ~ma_direction ~ad_signal : Macro.result =
+  {
+    index_stage =
+      {
+        stage = Weinstein_types.Stage4 { weeks_declining = 1 };
+        ma_value;
+        ma_direction;
+        ma_slope_pct = 0.0;
+        transition = None;
+        above_ma_count = 0;
+      };
+    indicators =
+      [ { name = "A-D Line"; signal = ad_signal; weight = 2.0; detail = "t" } ];
+    trend = Weinstein_types.Bearish;
+    confidence = 0.2;
+    regime_changed = false;
+    rationale = [];
+  }
+
+(* A tape that is not in a decline and has no breadth lead — irrelevant while
+   Out_of_market (re-entry reads only the index bars). *)
+let quiet_macro =
+  macro_result ~ma_value:50.0 ~ma_direction:Weinstein_types.Rising
+    ~ad_signal:`Neutral
+
+(* Matcher: [Out_of_market] whose [exited_on] equals [r]. *)
+let out_reason r =
+  matching ~msg:"Out_of_market with reason"
+    (function
+      | Cb.Out_of_market { exited_on; _ } -> Some exited_on
+      | Cb.In_market _ -> None)
+    (equal_to r)
+
+(* Matcher: [Out_of_market] whose [post_exit_low] equals [v]. *)
+let out_low v =
+  matching ~msg:"Out_of_market post_exit_low"
+    (function
+      | Cb.Out_of_market { post_exit_low; _ } -> Some post_exit_low
+      | Cb.In_market _ -> None)
+    (float_equal v)
+
+(* ------------------------------------------------------------------ *)
+(* Exit triggers                                                       *)
+(* ------------------------------------------------------------------ *)
+
+(* T1: a steep 4-week drawdown (~12%) with fast-V character (rising MA, no A-D
+   lead) fires a fast-crash exit that seeds post_exit_low at the exit close. The
+   drop stays above the 20% floor, so T1 — not T3 — is the trigger. *)
+let test_fast_crash_exit _ =
+  let index_bars =
+    weekly_bars (List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 96.0; 92.0; 88.0 ])
+  in
+  let macro =
+    macro_result ~ma_value:70.0 ~ma_direction:Weinstein_types.Rising
+      ~ad_signal:`Neutral
+  in
+  assert_that
+    (Cb.step ~config:cfg ~state:Cb.in_market ~index_bars ~ad_macro:macro)
+    (all_of
+       [
+         field snd (equal_to (Cb.Exit Cb.Fast_crash));
+         field fst (all_of [ out_reason Cb.Fast_crash; out_low 88.0 ]);
+       ])
+
+(* T2: a shallow breadth-led grind must be sustained [grind_confirm_weeks] (3)
+   consecutive steps before the slow-grind exit fires — the first two steps hold
+   with a rising grind streak. *)
+let test_slow_grind_exit_after_confirm _ =
+  let index_bars =
+    weekly_bars (List.init 20 ~f:(fun i -> 100.0 -. (Float.of_int i *. 0.2)))
+  in
+  let macro =
+    macro_result ~ma_value:101.0 ~ma_direction:Weinstein_types.Declining
+      ~ad_signal:`Bearish
+  in
+  let s1, a1 =
+    Cb.step ~config:cfg ~state:Cb.in_market ~index_bars ~ad_macro:macro
+  in
+  let s2, a2 = Cb.step ~config:cfg ~state:s1 ~index_bars ~ad_macro:macro in
+  let s3, a3 = Cb.step ~config:cfg ~state:s2 ~index_bars ~ad_macro:macro in
+  assert_that [ a1; a2; a3 ]
+    (elements_are
+       [ equal_to Cb.Hold; equal_to Cb.Hold; equal_to (Cb.Exit Cb.Slow_grind) ]);
+  assert_that s3 (out_reason Cb.Slow_grind)
+
+(* T3: a slow drift whose last 4 weeks barely move (no fast-V, no confirmed
+   grind) but whose close sits below 80% of the trailing-window high fires the
+   absolute-floor backstop. *)
+let test_floor_exit_on_trailing_window_breach _ =
+  let index_bars =
+    weekly_bars
+      (List.init 40 ~f:(fun _ -> 100.0)
+      @ [ 95.0; 90.0; 85.0; 80.0; 78.0; 77.0; 76.0; 75.5; 75.2; 75.0 ])
+  in
+  let macro =
+    macro_result ~ma_value:60.0 ~ma_direction:Weinstein_types.Rising
+      ~ad_signal:`Neutral
+  in
+  assert_that
+    (Cb.step ~config:cfg ~state:Cb.in_market ~index_bars ~ad_macro:macro)
+    (all_of
+       [
+         field snd (equal_to (Cb.Exit Cb.Absolute_floor));
+         field fst (all_of [ out_reason Cb.Absolute_floor; out_low 75.0 ]);
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Re-entry (asymmetric by exit reason)                                *)
+(* ------------------------------------------------------------------ *)
+
+(* Fast re-entry: after a fast-crash exit, a deeper dip lowers post_exit_low and
+   re-entry is measured as a 5% recovery OFF THAT LOW — so a close of 87 (below
+   the original 88 low) still re-enters once the low has decayed to 82. *)
+let test_fast_reentry_off_post_exit_low _ =
+  let s0 =
+    Cb.Out_of_market
+      {
+        exited_on = Cb.Fast_crash;
+        exit_date = Date.of_string "2020-06-01";
+        post_exit_low = 88.0;
+      }
+  in
+  let r1 =
+    Cb.step ~config:cfg ~state:s0
+      ~index_bars:[ make_bar "2020-06-08" 82.0 ]
+      ~ad_macro:quiet_macro
+  in
+  assert_that r1
+    (all_of [ field snd (equal_to Cb.Hold); field fst (out_low 82.0) ]);
+  let r2 =
+    Cb.step ~config:cfg ~state:(fst r1)
+      ~index_bars:[ make_bar "2020-06-15" 87.0 ]
+      ~ad_macro:quiet_macro
+  in
+  assert_that r2
+    (all_of
+       [ field snd (equal_to Cb.Re_enter); field fst (equal_to Cb.in_market) ])
+
+(* Slow re-entry: after a grind exit, re-entry needs price above a turning
+   30-week MA. A recovered V (declining then rising past the MA) re-enters; a
+   still-declining tape holds. *)
+let test_slow_reentry_above_turning_ma _ =
+  let out_state reason =
+    Cb.Out_of_market
+      {
+        exited_on = reason;
+        exit_date = Date.of_string "2020-06-01";
+        post_exit_low = 80.0;
+      }
+  in
+  let recover_bars =
+    weekly_bars
+      (List.init 20 ~f:(fun i -> 100.0 -. Float.of_int i)
+      @ List.init 20 ~f:(fun i -> 82.0 +. Float.of_int i))
+  in
+  let declining_bars =
+    weekly_bars (List.init 40 ~f:(fun i -> 100.0 -. Float.of_int i))
+  in
+  assert_that
+    (Cb.step ~config:cfg ~state:(out_state Cb.Slow_grind)
+       ~index_bars:recover_bars ~ad_macro:quiet_macro)
+    (all_of
+       [ field snd (equal_to Cb.Re_enter); field fst (equal_to Cb.in_market) ]);
+  assert_that
+    (Cb.step ~config:cfg ~state:(out_state Cb.Slow_grind)
+       ~index_bars:declining_bars ~ad_macro:quiet_macro)
+    (field snd (equal_to Cb.Hold))
+
+(* ------------------------------------------------------------------ *)
+(* GME-lesson regressions                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* Windowed peak decays: a parabolic spike to 300 then collapse to 100 fires the
+   floor while the spike is still inside the trailing window, but once the spike
+   scrolls out (60+ weeks later, all at 100) the floor reference decays to 100
+   and the machine HOLDS instead of firing forever. A monotonic high-water mark
+   would keep 0.8*300=240 as the floor and re-fire indefinitely (the GME
+   pathology). *)
+let test_windowed_peak_decays_no_permanent_disable _ =
+  let macro =
+    macro_result ~ma_value:50.0 ~ma_direction:Weinstein_types.Rising
+      ~ad_signal:`Neutral
+  in
+  let soon_after_collapse =
+    weekly_bars
+      (List.init 40 ~f:(fun _ -> 100.0) @ [ 150.0; 220.0; 300.0; 100.0 ])
+  in
+  let long_after_collapse =
+    weekly_bars
+      (List.init 40 ~f:(fun _ -> 100.0)
+      @ [ 150.0; 220.0; 300.0; 100.0 ]
+      @ List.init 60 ~f:(fun _ -> 100.0))
+  in
+  let action bars =
+    snd
+      (Cb.step ~config:cfg ~state:Cb.in_market ~index_bars:bars ~ad_macro:macro)
+  in
+  assert_that
+    [ action soon_after_collapse; action long_after_collapse ]
+    (elements_are [ equal_to (Cb.Exit Cb.Absolute_floor); equal_to Cb.Hold ])
+
+(* Whipsaw: drop -> recover -> drop must exit, re-enter, then be able to re-exit
+   (the state machine is not permanently locked in either state). *)
+let test_whipsaw_exit_reenter_reexit _ =
+  let crash_bars =
+    weekly_bars (List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 96.0; 92.0; 88.0 ])
+  in
+  let crash_macro =
+    macro_result ~ma_value:70.0 ~ma_direction:Weinstein_types.Rising
+      ~ad_signal:`Neutral
+  in
+  let s1, a1 =
+    Cb.step ~config:cfg ~state:Cb.in_market ~index_bars:crash_bars
+      ~ad_macro:crash_macro
+  in
+  let s2, a2 =
+    Cb.step ~config:cfg ~state:s1
+      ~index_bars:[ make_bar "2020-07-01" 93.0 ]
+      ~ad_macro:quiet_macro
+  in
+  let _s3, a3 =
+    Cb.step ~config:cfg ~state:s2 ~index_bars:crash_bars ~ad_macro:crash_macro
+  in
+  assert_that [ a1; a2; a3 ]
+    (elements_are
+       [
+         equal_to (Cb.Exit Cb.Fast_crash);
+         equal_to Cb.Re_enter;
+         equal_to (Cb.Exit Cb.Fast_crash);
+       ])
+
+(* Edge: empty bars are a safe no-op — the state is returned unchanged, Hold. *)
+let test_empty_bars_is_noop _ =
+  assert_that
+    (Cb.step ~config:cfg ~state:Cb.in_market ~index_bars:[]
+       ~ad_macro:quiet_macro)
+    (all_of [ field fst (equal_to Cb.in_market); field snd (equal_to Cb.Hold) ])
+
+let suite =
+  "index_circuit_breaker"
+  >::: [
+         "fast_crash_exit" >:: test_fast_crash_exit;
+         "slow_grind_exit_after_confirm" >:: test_slow_grind_exit_after_confirm;
+         "floor_exit_on_trailing_window_breach"
+         >:: test_floor_exit_on_trailing_window_breach;
+         "fast_reentry_off_post_exit_low"
+         >:: test_fast_reentry_off_post_exit_low;
+         "slow_reentry_above_turning_ma" >:: test_slow_reentry_above_turning_ma;
+         "windowed_peak_decays_no_permanent_disable"
+         >:: test_windowed_peak_decays_no_permanent_disable;
+         "whipsaw_exit_reenter_reexit" >:: test_whipsaw_exit_reenter_reexit;
+         "empty_bars_is_noop" >:: test_empty_bars_is_noop;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What this does

P1b **step 1** of the floor-quality program: the **pure index circuit-breaker lib** only. No consumer wiring — this PR changes no behaviour anywhere. Design authority: `dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md`; user mandate 2026-07-09.

New module `analysis/weinstein/macro/lib/index_circuit_breaker.{ml,mli}` (alongside `decline_character.ml`, same lib/style): a pure, lookahead-free two-state machine that decides when a long-only SPY floor sleeve sells to cash and when it re-enters.

- **States**: `In_market { grind_streak }` / `Out_of_market { exited_on; exit_date; post_exit_low }`; `action = Hold | Exit of reason | Re_enter`.
- **Exit triggers** (checked in precedence order while In_market):
  - **T1 fast-crash** — `Decline_character.classify` returns `Fast_v` AND trailing drawdown over `fast_exit_lookback_bars` ≥ `fast_exit_rate_pct`.
  - **T3 absolute floor** — close below `(1 − floor_drop_pct) ×` the **trailing-window** high over `floor_peak_lookback_bars`.
  - **T2 slow-grind** — `Slow_grind` sustained `grind_confirm_weeks` consecutive steps.
- **Asymmetric, self-contained re-entry**: after fast/floor → recover `fast_reentry_recover_pct` off the post-exit low; after grind → Weinstein-style price above a turning `slow_reentry_ma_weeks` MA.
- Reuses `Decline_character.classify` for the fast-V / slow-grind character read (adds `show`/`eq` to `Decline_character.config` so it nests in the breaker config).
- Every threshold is a config field with `[@sexp.default …]` → axis-ready per `experiment-flag-discipline.md` R2; nothing hardcoded. `default_config` holds design-doc reference **priors** (to be searched via WF-CV + a deep bear-regime promotion grid before any default).

## The two load-bearing GME-lesson semantics (documented in the `.mli`, per `dev/notes/warmup-364-repin-2026-07-08.md` §Findings)

1. **T3 peak is a decaying trailing-window high of INDEX PRICE**, never a monotonic NAV high-water mark — a parabolic MTM spike cannot poison it once it scrolls out of the window (the GME Jan-2021 sterilization: a monotonic peak locked the floor and force-liquidated 32×).
2. **Re-entry is self-contained** in the state machine — no halt-until-external-macro-reset.

## Test plan

`analysis/weinstein/macro/test/test_index_circuit_breaker.ml` (OUnit2 + Matchers, one `assert_that` per value):
- Each transition: fast-crash exit fires; slow-grind exit fires only after the confirm-week streak; floor exit on trailing-window breach; fast re-entry off the (decayed) post-exit low; slow re-entry above a turning MA (and holds while still declining).
- Two GME regressions: (a) a parabolic spike→collapse does NOT permanently disable re-entry (windowed peak decays → Hold once the spike scrolls out, vs a monotonic peak that would re-fire forever); (b) whipsaw drop→recover→drop exercises exit → re-enter → re-exit.
- Empty-bars no-op edge.

## Verification

- `dune build @fmt`, `dune build`, `dune build analysis/weinstein/macro`, `dune runtest analysis/weinstein/macro` all pass (8 new tests + siblings green).
- Nesting linter clean on the new module (functions extracted to stay within limits).
- Full-repo `dune runtest` has pre-existing environmental failures unrelated to this change (data fixtures like `data/backtest_scenarios/smoke/*.sexp` are untracked/absent in a fresh worktree).

Do not modify `dev/status/_index.md` beyond the new `floor-quality` row (brand-new tracked item; the reconcile happens after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
