### PR TITLE
feat(strategy): neutral_blocks_shorts default true — faithfulness flip

### DIFF
--- a/dev/status/short-side-strategy.md
+++ b/dev/status/short-side-strategy.md
@@ -5,6 +5,32 @@
 ## Status
 IN_PROGRESS
 
+## 2026-07-09 — `neutral_blocks_shorts` default flipped false→true (branch `feat/neutral-blocks-shorts-default`)
+
+User-mandated **faithfulness** flip (not an alpha claim): shorting only a
+confirmed `Bearish` tape is strictly more Weinstein-faithful than also shorting a
+`Neutral` tape (weinstein-book-reference.md §Short-Selling Rules). Flipped the
+`Weinstein_strategy.config.neutral_blocks_shorts` default (`[@sexp.default false]`
+→ `true`) in `weinstein_strategy_config.ml{,i}` + the mirror docstring in
+`weinstein_strategy.mli`.
+
+- **Ledger:** ACCEPT `2026-06-22-neutral-blocks-shorts-wfcv` (helpful-or-inert on
+  the WF-CV cell); companion grid `2026-06-22-neutral-blocks-shorts-grid` showed
+  no edge flip — honestly a faithfulness flip.
+- **Deep re-attribution** (`dev/notes/p1a-deep-short-screens-364-2026-07-09.md`
+  §Attribution): the neutral gate blocked exactly ONE Neutral-tape short in 11
+  deep years (CF Jun-2006, a loser — blocking helped); true edge cost ≈ 0.
+- **Golden impact:** `goldens-sp500-historical/sp500-2010-2026-longshort`
+  re-ran **BIT-IDENTICAL** under the flip (ret 362.11 / 782 tr / 35.81 win /
+  0.75 Sharpe / 21.35 MaxDD) — no Neutral-tape short taken in that window; bands
+  unchanged, pin comment updated. `sp500-2000-2026-longshort` (research-tier,
+  sanity-wide bands, reads the gitignored deep data store — not re-runnable in
+  this env) documented as provably in-band (near-inert flip); no re-pin.
+  All `goldens-broad/*` + `sp500-2019-2023*` are `enable_short_side=false` →
+  unaffected. `experiments/*` frozen — untouched.
+- Strategy + screener unit suites green under the flip (the Screener module keeps
+  its own independent `neutral_blocks_shorts` default — out of scope, untouched).
+
 ## 2026-07-09 — SHORT-leak in `enable_short_side=false` backtest FIXED (branch `feat/fix-short-leak`)
 
 A SHORT trade appeared in the long-only reference arm of the faithful-short deep

--- a/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2000-2026-longshort.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2000-2026-longshort.sexp
@@ -7,6 +7,15 @@
 ;; period here is a default. Reads the gitignored repo-root data/ store (deep
 ;; 1998-2026 bars fetched 2026-06-22). NOT a pinned golden — research-tier,
 ;; sentinel bands only.
+;;
+;; 2026-07-09 neutral_blocks_shorts default flip (false→true, user-mandated
+;; faithfulness flip): not re-run here (the deep data/ store is absent in this
+;; environment). No re-pin needed — the flip is near-inert (the 2010-2026
+;; longshort twin re-ran BIT-IDENTICAL; the 2000-2010 deep screen blocked
+;; exactly one Neutral-tape short over 11y, ≈0 cost — see
+;; dev/notes/p1a-deep-short-screens-364-2026-07-09.md §Attribution) and the
+;; 368% VERIFIED baseline sits deep inside the sanity-wide bands below, which
+;; a near-inert change cannot escape.
 ((name "sp500-2000-2026-longshort-deep")
  (description
    "Deep long-short base (sp500-as-of-2000 PIT, 2000-2026, enable_short_side=true) for the neutral_blocks_shorts WF-CV. Same overlay as sp500-2010-2026-longshort.")

--- a/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026-longshort.sexp
+++ b/trading/test_data/backtest_scenarios/goldens-sp500-historical/sp500-2010-2026-longshort.sexp
@@ -97,6 +97,13 @@
   ;;   OPV 3,760,365  sortino 1.11  calmar 0.46  ulcer 8.26
   ;; Unlike the long-only twin (floor-halted by the GME squeeze — see its pin
   ;; comment), this hedged variant rides the same window healthily.
+  ;; Re-verified 2026-07-09 under the neutral_blocks_shorts default flip
+  ;; (false→true, user-mandated faithfulness flip): actuals are BIT-IDENTICAL
+  ;; to the 364 pin above (ret 362.11 / 782 / 35.81 / 0.75 / 21.35 / 45.40 /
+  ;; OPV 3,760,365 / 1.11 / 0.46 / 8.26). This 2010-2026 window took no
+  ;; Neutral-tape short the gate would block, so the flip is inert here —
+  ;; bands unchanged. Confirms the ≈0-cost deep-cell attribution
+  ;; (dev/notes/p1a-deep-short-screens-364-2026-07-09.md §Attribution).
   ((total_return_pct   ((min 307.8)         (max 416.4)))
    (total_trades       ((min 665)           (max  899)))
    (win_rate           ((min  30.4)         (max  41.2)))

--- a/trading/trading/simulation/test/test_weinstein_backtest.ml
+++ b/trading/trading/simulation/test/test_weinstein_backtest.ml
@@ -171,9 +171,21 @@ let test_six_year_full_lifecycle _ =
      makes the macro gate live for 2020-2023, admitting one fewer entry in this
      2018-2023 window (29/26, 26 round-trips, 4W/22L vs 30/27, 27, 5W/22L).
      Same 7-symbol set; final value and max-DD still inside their bands. *)
+  (* neutral_blocks_shorts default flip (2026-07-09, false->true; faithfulness
+     flip, user mandate — see weinstein_strategy_config.mli): the flip blocks
+     ONE Neutral-tape short in this window — HD, opened 2018-11-17, covered
+     2019-01-08 during the Q4-2018 correction (a Neutral tape, not a confirmed
+     Bearish one), a -$353 loser. Removing that short round-trip drops one
+     Sell-open + its cover Buy: buys 29->28, sells 26->25, round-trips 26->25,
+     losses 22->21 (wins unchanged at 4). Same 7-symbol set (HD still trades
+     long). Final value 484,438.68 -> 484,753.99 (still in band); realized
+     max drawdown ~5.6% -> ~5.5% (the old "54.25%" pin-comment below is stale
+     from the G15 era; the loose < 0.60 assertion masked it). Delta is small,
+     consistent with the ~0-cost deep-cell attribution
+     (dev/notes/p1a-deep-short-screens-364-2026-07-09.md §Attribution). *)
   assert_that (List.length result.steps) (equal_to 2187);
-  assert_that n_buys (equal_to 29);
-  assert_that n_sells (equal_to 26);
+  assert_that n_buys (equal_to 28);
+  assert_that n_sells (equal_to 25);
   assert_that symbols
     (elements_are
        [
@@ -185,18 +197,20 @@ let test_six_year_full_lifecycle _ =
          equal_to "KO";
          equal_to "MSFT";
        ]);
-  assert_that (List.length round_trips) (equal_to 26);
+  assert_that (List.length round_trips) (equal_to 25);
   assert_that stats
     (is_some_and
        (all_of
           [
             field (fun s -> s.Metrics.win_count) (equal_to 4);
-            field (fun s -> s.Metrics.loss_count) (equal_to 22);
+            field (fun s -> s.Metrics.loss_count) (equal_to 21);
           ]));
-  (* G15 step 3 (2026-05-01): final value $485,285.88; pin ±$3K. *)
+  (* Final value $484,753.99 under the 2026-07-09 flip (was $485,285.88 at the
+     G15 step-3 pin); band kept at ±$3K around the G15 centre, which still
+     contains the new value. *)
   assert_that final_value
     (is_between (module Float_ord) ~low:482_285.88 ~high:488_285.88);
-  (* G15 step 3 (2026-05-01): max drawdown 54.25%; pin loose at < 0.60. *)
+  (* Realized max drawdown ~5.5% under the flip; pin loose at < 0.60. *)
   assert_that max_drawdown_pct (lt (module Float_ord) 0.60)
 
 (* ------------------------------------------------------------------ *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -436,13 +436,15 @@ type config = {
           [screening_config.neutral_blocks_longs] at screen time so it is a
           [Variant_matrix] flag axis. See [Weinstein_strategy_config] for full
           semantics. *)
-  neutral_blocks_shorts : bool; [@sexp.default false]
-      (** Short-side mirror of {!neutral_blocks_longs} (default-off): when
-          [true], a macro-[Neutral] tape blocks new short entries (only
-          [Bearish] admits shorts). Default [false] preserves the historical
-          gate where both [Bearish] and [Neutral] admit shorts. Tightens the
-          short side to Weinstein's confirmed-bear rule; the Stage-4 breakdown
-          criteria and the macro gate are unaffected. Threaded into
+  neutral_blocks_shorts : bool; [@sexp.default true]
+      (** Short-side mirror of {!neutral_blocks_longs}: when [true] (the
+          default), a macro-[Neutral] tape blocks new short entries (only
+          [Bearish] admits shorts). Setting [false] restores the historical gate
+          where both [Bearish] and [Neutral] admit shorts. Tightens the short
+          side to Weinstein's confirmed-bear rule; the Stage-4 breakdown
+          criteria and the macro gate are unaffected. Default flipped [false] ->
+          [true] on 2026-07-09 (user mandate) as a faithfulness flip; ledger
+          ACCEPT [2026-06-22-neutral-blocks-shorts-wfcv]. Threaded into
           [screening_config.neutral_blocks_shorts] at screen time so it is a
           [Variant_matrix] flag axis. See [Weinstein_strategy_config] for full
           semantics. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -99,10 +99,8 @@ type config = {
           [screening_config.neutral_blocks_longs] at screen time. See [.mli]. *)
   neutral_blocks_shorts : bool; [@sexp.default true]
       (** Short-side mirror of [neutral_blocks_longs]; default [true] admits
-          shorts only under a confirmed [Bearish] tape (a [Neutral] tape is
-          blocked). Faithfulness flip (user mandate 2026-07-09): shorting only a
-          confirmed bear is strictly more Weinstein-faithful. Ledger ACCEPT:
-          [2026-06-22-neutral-blocks-shorts-wfcv]. See [.mli]. *)
+          shorts only under a confirmed [Bearish] tape (2026-07-09 faithfulness
+          flip). See [.mli]. *)
   enable_slow_grind_short_gate : bool; [@sexp.default false]
       (** Admit shorts only in a slow-grind decline; default [false] = no-op.
           See [.mli]. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -97,9 +97,12 @@ type config = {
           [Bullish] admits longs); default [false] preserves the historical gate
           where both [Bullish] and [Neutral] admit longs. Threaded into
           [screening_config.neutral_blocks_longs] at screen time. See [.mli]. *)
-  neutral_blocks_shorts : bool; [@sexp.default false]
-      (** Short-side mirror of [neutral_blocks_longs]; default [false] = prior
-          gate (both [Bearish] and [Neutral] admit shorts). See [.mli]. *)
+  neutral_blocks_shorts : bool; [@sexp.default true]
+      (** Short-side mirror of [neutral_blocks_longs]; default [true] admits
+          shorts only under a confirmed [Bearish] tape (a [Neutral] tape is
+          blocked). Faithfulness flip (user mandate 2026-07-09): shorting only a
+          confirmed bear is strictly more Weinstein-faithful. Ledger ACCEPT:
+          [2026-06-22-neutral-blocks-shorts-wfcv]. See [.mli]. *)
   enable_slow_grind_short_gate : bool; [@sexp.default false]
       (** Admit shorts only in a slow-grind decline; default [false] = no-op.
           See [.mli]. *)
@@ -197,7 +200,7 @@ let default_config ~universe ~index_symbol =
     enable_pi_filter = false;
     margin_config = Trading_portfolio.Margin_config.default_config;
     neutral_blocks_longs = false;
-    neutral_blocks_shorts = false;
+    neutral_blocks_shorts = true;
     enable_slow_grind_short_gate = false;
     fast_v_arm_on_rate_alone = false;
     fast_v_min_rate_pct = fast_v_min_rate_no_op;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -156,13 +156,12 @@ type config = {
           through the [Neutral]/[Bullish] bear-rally blips, contributing to the
           false-breakout stop-out churn. Default-off until an experiment-ledger
           ACCEPT (per [.claude/rules/experiment-flag-discipline.md]). *)
-  neutral_blocks_shorts : bool; [@sexp.default false]
-      (** Short-side mirror of {!neutral_blocks_longs} (default-off). When
-          [true], a macro-[Neutral] tape blocks new short entries exactly as a
-          [Bullish] tape does — only a [Bearish] tape admits shorts. Default
-          [false] preserves the historical macro gate bit-equally (shorts
-          admitted under both [Bearish] and [Neutral], blocked only under
-          [Bullish]).
+  neutral_blocks_shorts : bool; [@sexp.default true]
+      (** Short-side mirror of {!neutral_blocks_longs}. When [true] (the
+          default), a macro-[Neutral] tape blocks new short entries exactly as a
+          [Bullish] tape does — only a [Bearish] tape admits shorts. Setting
+          [false] restores the historical macro gate (shorts admitted under both
+          [Bearish] and [Neutral], blocked only under [Bullish]).
 
           This *tightens* the short side to Weinstein's confirmed-bear rule
           (weinstein-book-reference.md §Short-Selling Rules — short only in a
@@ -172,11 +171,21 @@ type config = {
           removes the [Neutral] chop tape (the 2020 V) where shorts are most
           likely squeezed.
 
+          Default flipped [false] -> [true] on 2026-07-09 (user mandate) as a
+          {b faithfulness} flip, not an alpha claim: shorting only a confirmed
+          [Bearish] tape is strictly more Weinstein-faithful than also shorting
+          a [Neutral] tape. Ledger ACCEPT:
+          [2026-06-22-neutral-blocks-shorts-wfcv] (helpful-or-inert on the WF-CV
+          cell; the companion grid [2026-06-22-neutral-blocks-shorts-grid]
+          showed no edge flip). The deep-cell re-attribution (2026-07-09,
+          [dev/notes/p1a-deep-short-screens-364-2026-07-09.md]) found the gate
+          blocked exactly one [Neutral]-tape short in 11 deep years (a loser) so
+          the true edge cost is ~0; blocked [Neutral]-tape shorts are the
+          squeeze-trap class.
+
           Wired by threading into [screening_config.neutral_blocks_shorts] at
           screen time, so the flag is a single-component [Variant_matrix] flag
-          axis ([((flag neutral_blocks_shorts) (values (true false)))]).
-          Default-off until an experiment-ledger ACCEPT (per
-          [.claude/rules/experiment-flag-discipline.md]). *)
+          axis ([((flag neutral_blocks_shorts) (values (true false)))]). *)
   enable_slow_grind_short_gate : bool; [@sexp.default false]
       (** Faithful-short decline-character gate (default-off). When [true],
           shorts are admitted only when the current primary-index decline is a


### PR DESCRIPTION
## What

Flip `Weinstein_strategy.config.neutral_blocks_shorts` default `false` → `true`
(user mandate, 2026-07-09). When `true`, shorts are admitted only under a
confirmed macro-`Bearish` tape — a `Neutral` tape now blocks new short entries
(mirroring how `Bullish` already did). The field's `[@sexp.default …]` in
`weinstein_strategy_config.ml{,i}` and the mirror docstring in
`weinstein_strategy.mli` are updated, plus the `default_config` record literal.

## Why (this is a FAITHFULNESS flip, not an alpha claim)

- **Faithfulness.** Shorting only a confirmed Bearish tape is strictly more
  Weinstein-faithful (book: short into confirmed Stage-4 bear markets; a Neutral
  tape is not that). W2: `docs/design/weinstein-book-reference.md` §Short-Selling
  Rules. Spine untouched — Stage-4 breakdown / negative-RS / weak-sector / volume
  short criteria and the macro gate itself are unchanged.
- **Ledger evidence** (`experiment-flag-discipline` R3): ACCEPT
  `2026-06-22-neutral-blocks-shorts-wfcv` (cell-1, helpful-or-inert; 2019 cell
  −0.96pp MaxDD at thin opportunity cost). The companion grid
  `2026-06-22-neutral-blocks-shorts-grid` showed **no edge flip** — honestly
  cited: this is a faithfulness flip, not an alpha claim.
- **Deep-cell re-attribution** (2026-07-09,
  `dev/notes/p1a-deep-short-screens-364-2026-07-09.md` §Attribution correction):
  the gate blocked exactly **ONE** Neutral-tape short in 11 deep years
  (CF 2006, a loser — blocking helped); measured arm deltas are post-divergence
  path noise; true edge cost ≈ 0.
- **Asymmetry.** Blocked Neutral-tape shorts are the squeeze-trap class; the cost
  of forgoing them is thin.

## Golden re-measurement (before / after)

Re-ran the affected `enable_short_side=true` goldens that do NOT explicitly set
`neutral_blocks_shorts`, via `scenario_runner` (CSV mode,
`TRADING_DATA_DIR=test_data`, warmup-364 basis):

| golden | lane | before (ret / tr / win / Sharpe / MaxDD) | after | Δ | action |
|---|---|---|---|---|---|
| `goldens-sp500-historical/sp500-2010-2026-longshort` | 15y cron (TIGHT ±15%) | 362.11% / 782 / 35.81 / 0.75 / 21.35 | 362.11% / 782 / 35.81 / 0.75 / 21.35 | **BIT-IDENTICAL** | bands unchanged; pin comment added |
| `goldens-sp500-historical/sp500-2000-2026-longshort` | research (sanity-wide) | 368.0% (VERIFIED) | not re-run (deep `data/` store absent in env) | provably in-band | no re-pin; flip note added |

The 2010-2026 window took **no** Neutral-tape short the gate would block, so the
flip is inert there — full actuals bit-identical to the current 364 pin
(`362.111 / 782 / 35.806 / 0.747 / 21.347 / hold 45.402 / OPV 3,760,364.79 /
sortino 1.114 / calmar 0.460 / ulcer 8.260`). This confirms the ≈0-cost
attribution. The 2000-2026 deep golden reads the gitignored repo-root `data/`
deep store (not present in this environment); its bands are sanity-wide
(`return -90..5000`, `MaxDD 0..90`) and the near-inert flip cannot push the 368%
baseline out of band — documented, no re-pin.

## Not affected / not touched

- All `goldens-broad/*` and `goldens-sp500/sp500-2019-2023*` are
  `enable_short_side=false` → unaffected.
- `experiments/*` are frozen records → untouched.
- The `Screener` module keeps its own independent `neutral_blocks_shorts`
  default (`false`) — out of the mandate's named files; its unit test pins the
  screener-level default, so it stays as-is (the strategy always threads its own
  value in at screen time).

## Tests

- `dune build @fmt` + `dune build` green (container).
- Weinstein strategy + screener unit suites green under the flip (the
  `test_short_min_price_gate` `Screener.Neutral` usage is an inert sector-rating
  placeholder, unrelated to macro-tape short admission).
- Remaining local `dune runtest trading/backtest/` errors are pre-existing
  environment failures (`Sys_error(.../data/backtest_scenarios/smoke/*.sexp:
  No such file or directory)` — hardcoded parent `data/` path absent in the
  worktree), the same class documented in `dev/notes/warmup-364-repin-2026-07-08.md`;
  not related to this bool-default change (a config value cannot produce a
  file-not-found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Rework 1 (QC NEEDS_REWORK — behavioral CP2 + structural nesting)

**Correction to the impact enumeration above.** The flip is **inert on the
2010-2026 longshort golden** (bit-identical, as stated) but is **NOT globally
inert** — QC correctly caught that it changes the 2018-2023 unit-lifecycle
backtest. Honest per-window statement:

- **2010-2026 longshort golden:** inert (no Neutral-tape short in-window) — bit-identical.
- **2018-2023 lifecycle (`test_six_year_full_lifecycle`, simulation unit test, short-side via `default_config`):** the flip blocks **one** Neutral-tape short — **HD**, opened 2018-11-17, covered 2019-01-08 during the **Q4-2018 correction** (a Neutral tape, not a confirmed-Bearish one), a **−$353 loser**. Metric deltas (false→true):

  | metric | before | after |
  |---|---|---|
  | n_buys | 29 | 28 |
  | n_sells | 26 | 25 |
  | round_trips | 26 | 25 |
  | win / loss | 4 / 22 | 4 / 21 |
  | final value | $484,438.68 | $484,753.99 (in band) |
  | realized max-DD | ~5.6% | ~5.5% (loose < 0.60 pin) |

  Small, one-losing-short delta — consistent with the ≈0-cost deep-cell attribution. Re-pinned the test with an attributing pin-comment (mirrors the 2026-04 / 2026-06-23 pin comments in the same file). No other `default_config` short-side test is affected: the full `simulation/test` suite passes with only this one re-pin; `engine/test` passes; `backtest/` failures are all pre-existing env `Sys_error(.../data/...)` + intentional negative-test stubs (zero assertion failures).

**Structural (nesting linter).** `weinstein_strategy_config.ml` file-avg nesting hit 2.51 > 2.5 (dune-cache had masked it) — driven by the verbose `.ml` field docstring I added (deeply-indented continuation lines counted by `measure_file_avg`). Fixed by restoring the **terse `.ml` docstring** (the file's convention keeps detail in the `.mli` and points there); file-avg back under 2.5, **no limit bump / no exception added**. `dune runtest devtools/checks` now exit 0 ("nesting linter — all functions within limits").
