### PR TITLE
feat(strategy): breaker SPY sleeve — Index_circuit_breaker consumer (P1b step 2)

### DIFF
--- a/dev/status/floor-quality.md
+++ b/dev/status/floor-quality.md
@@ -1,6 +1,6 @@
 # Status: floor-quality
 
-## Last updated: 2026-07-09
+## Last updated: 2026-07-10
 
 ## Status
 IN_PROGRESS
@@ -43,15 +43,35 @@ while cutting the deep-crash left tail. Design authority:
   wiring; changes no behaviour anywhere. Encodes the two GME-pathology lessons
   (decaying windowed peak, no halt-until-external-reset) per
   `dev/notes/warmup-364-repin-2026-07-08.md` §Findings.
+- **P1b step 2 — thin breaker sleeve strategy** (branch
+  `feat/breaker-spy-sleeve`, PR pending): new
+  `trading/trading/weinstein/strategy/lib/breaker_spy_strategy.{ml,mli}` +
+  OUnit2 tests, alongside `Spy_only_weinstein_strategy`. Consumes the merged
+  `Index_circuit_breaker` (#1904): long-only, default-in-market (deploys cash
+  into SPY whenever flat + `In_market`, so it buys on the first tradable bar),
+  weekly (Friday) breaker `step` over the symbol's own weekly bars — Exit sells
+  to flat, Re_enter buys all-cash, Hold falls through to deploy. No per-position
+  trailing stop; the only exit is a breaker exit. Macro read for the character
+  classifier is `Macro.analyze` with empty A-D/global inputs (the documented
+  single-instrument degradation → A-D `Neutral`, no breadth lead) +
+  `Macro.default_config` (no new tunable; the breaker's thresholds all route
+  through `config.breaker`). Cadence note: the lib is weekly-bars-only, so
+  daily-cadence fast exits are parked as a future dial (documented in the .mli).
+  **Framing (user steer 2026-07-09, `feedback_no_reversal_timing`): not a
+  reversal timer** — slow-grind exit is doctrine-faithful step-aside; fast
+  exit + fast re-entry are tail-RISK insurance whose whipsaw cost is accepted
+  and measured (that measurement is step 3). Runner wired: additive
+  `Breaker_spy_sleeve of { symbol }` variant in `Strategy_choice.t`
+  (`warmup_days_for` = 364), constructed in `panel_strategy_builder`. Zero
+  behaviour change to existing strategies (new variant, default-off per
+  experiment-flag-discipline — no scenario selects it yet).
 
 ## In Progress
-- (none — awaiting review/merge of P1b step 1)
+- (none — awaiting review/merge of P1b step 2)
 
 ## Next Steps
-1. **P1b step 2 — thin sleeve strategy** consuming the breaker (buy-and-hold SPY
-   + breaker), alongside `Spy_only_weinstein_strategy`, adjusted-close bars for
-   both sleeve and comparator. Follow-up dispatch.
-2. **P1b step 3 — lens screen** vs TR-SPY 2000-2026 (per-episode drawdown
+1. **P1b step 3 — lens screen** vs TR-SPY 2000-2026 (per-episode drawdown
    captured/avoided, days out, intervention count, whipsaw cost distribution).
-3. **P1b step 4 — WF-CV surface** over the breaker thresholds, then a deep
+   Consumes the `Breaker_spy_sleeve` runner variant from step 2.
+2. **P1b step 4 — WF-CV surface** over the breaker thresholds, then a deep
    bear-regime promotion grid (`promotion-confirmation.md`) before any default.

--- a/trading/trading/backtest/lib/panel_strategy_builder.ml
+++ b/trading/trading/backtest/lib/panel_strategy_builder.ml
@@ -4,6 +4,7 @@
 open Core
 module Spy_only = Weinstein_strategy.Spy_only_weinstein_strategy
 module Sector_rotation = Weinstein_strategy.Sector_rotation_weinstein_strategy
+module Breaker_spy = Weinstein_strategy.Breaker_spy_strategy
 
 (* The tradable universe for the sector-rotation strategy when it opts into the
    scenario universe: every symbol with a snapshot (the keys of [ticker_sectors])
@@ -59,3 +60,6 @@ let build ~ad_bars ~ticker_sectors ~config ~strategy_choice ~bar_reader
       } ->
       _build_sector_rotation ~ticker_sectors ~bar_reader ~k ~ma_period_weeks
         ~enable_macro_gate ~use_scenario_universe ~sector_cap
+  | Breaker_spy_sleeve { symbol } ->
+      let config = { Breaker_spy.default_config with symbol } in
+      Breaker_spy.make ~config ~bar_reader ()

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -25,10 +25,10 @@ let commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
     semantics the BAH baseline is pinned against. Strategy-dispatched (#882)
     rather than a single constant. *)
 let warmup_days_for : Strategy_choice.t -> int = function
-  | Weinstein -> 364
   | Bah_benchmark _ -> 0
-  | Spy_only_weinstein _ -> 364
-  | Sector_rotation_weinstein _ -> 364
+  | Weinstein | Spy_only_weinstein _ | Sector_rotation_weinstein _
+  | Breaker_spy_sleeve _ ->
+      364
 
 (* Backwards-compatible internal alias kept so the rest of this module reads as
    before; [warmup_days_for] is the exported name (see [runner.mli]). *)

--- a/trading/trading/backtest/lib/runner.ml
+++ b/trading/trading/backtest/lib/runner.ml
@@ -22,17 +22,15 @@ let commission = { Trading_engine.Types.per_share = 0.01; minimum = 1.0 }
     every window; see dev/notes/rs-warmup-gap-2026-07-07.md.) The Buy-and-Hold
     benchmark is stateless and would otherwise enter its single position at
     [warmup_start] instead of [start_date], which corrupts the day-1-entry
-    semantics the BAH baseline is pinned against. Strategy-dispatched (#882)
-    rather than a single constant. *)
+    semantics the BAH baseline is pinned against. Strategy-dispatched (#882):
+    the shared non-BAH value is named [_weekly_strategy_warmup_days]. *)
+let _weekly_strategy_warmup_days = 364
+
 let warmup_days_for : Strategy_choice.t -> int = function
   | Bah_benchmark _ -> 0
   | Weinstein | Spy_only_weinstein _ | Sector_rotation_weinstein _
   | Breaker_spy_sleeve _ ->
-      364
-
-(* Backwards-compatible internal alias kept so the rest of this module reads as
-   before; [warmup_days_for] is the exported name (see [runner.mli]). *)
-let _warmup_days_for = warmup_days_for
+      _weekly_strategy_warmup_days
 
 (* Public types *)
 
@@ -480,7 +478,7 @@ let run_backtest ~start_date ~end_date ?(overrides = []) ?sector_map_override
     ?bar_data_source ?shared_panels ?progress_emitter ?slippage_bps ?cost_model
     () =
   let deps = _load_deps ?trace ?gc_trace ~overrides ~sector_map_override () in
-  let warmup_days = _warmup_days_for strategy_choice in
+  let warmup_days = warmup_days_for strategy_choice in
   let warmup_start = Date.add_days start_date (-warmup_days) in
   _log_backtest_window ~start_date ~end_date ~warmup_start
     ~all_symbols:deps.all_symbols;

--- a/trading/trading/backtest/lib/strategy_choice.ml
+++ b/trading/trading/backtest/lib/strategy_choice.ml
@@ -30,6 +30,9 @@ let default_sector_rotation_use_scenario_universe = false
    uncapped top-k selection, bit-identical to the pre-cap behaviour. *)
 let default_sector_rotation_sector_cap = None
 
+(* Breaker SPY sleeve default instrument (the P1b floor sleeve trades SPY). *)
+let default_breaker_spy_symbol = "SPY"
+
 type t =
   | Weinstein
   | Bah_benchmark of { symbol : string }
@@ -47,6 +50,9 @@ type t =
       use_scenario_universe : bool;
           [@sexp.default default_sector_rotation_use_scenario_universe]
       sector_cap : int option; [@sexp.default default_sector_rotation_sector_cap]
+    }
+  | Breaker_spy_sleeve of {
+      symbol : string; [@sexp.default default_breaker_spy_symbol]
     }
 [@@deriving sexp, eq, show]
 
@@ -81,3 +87,4 @@ let name = function
       } ->
       _sector_rotation_label ~k ~ma_period_weeks ~enable_macro_gate
         ~use_scenario_universe ~sector_cap
+  | Breaker_spy_sleeve { symbol } -> sprintf "Breaker_spy_sleeve(%s)" symbol

--- a/trading/trading/backtest/lib/strategy_choice.mli
+++ b/trading/trading/backtest/lib/strategy_choice.mli
@@ -120,6 +120,27 @@ type t =
 
           The strategy spine (Stage-2-only entry, Stage 3/4 exit, stop below
           base, RS for selection) is untouched by all dials. *)
+  | Breaker_spy_sleeve of { symbol : string [@sexp.default "SPY"] }
+      (** Breaker SPY sleeve — a long-only, default-in-market index floor
+          strategy on [symbol] (default [SPY], the [@sexp.default] so a scenario
+          may omit it). Constructs
+          {!Weinstein_strategy.Breaker_spy_strategy.make} with the runner's
+          [bar_reader] (it reads the symbol's own weekly bars for the breaker
+          step). Like {!Bah_benchmark} and {!Spy_only_weinstein}, the runner's
+          universe / sector-map / AD-bars machinery is loaded but unused;
+          [symbol] must be present in the scenario's universe.
+
+          Unlike {!Spy_only_weinstein} (full stage timing on SPY), this sleeve
+          holds SPY buy-and-hold by default and defers every sell/re-buy to the
+          pure {!Index_circuit_breaker} state machine (P1b of the floor-quality
+          program). It is {b not} a reversal timer: the slow-grind exit is the
+          doctrine-faithful step-aside from a distribution top, while the fast
+          exit + fast re-entry are explicit tail-RISK insurance whose whipsaw
+          cost is accepted and measured (lens screen vs total-return SPY, a
+          separate step). Every breaker threshold routes through the strategy's
+          own default {!Index_circuit_breaker.config}, default-off relative to a
+          promoted default per [.claude/rules/experiment-flag-discipline.md].
+          See {!Weinstein_strategy.Breaker_spy_strategy.config}. *)
 [@@deriving sexp, eq, show]
 
 val default : t

--- a/trading/trading/weinstein/strategy/lib/breaker_spy_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/breaker_spy_strategy.ml
@@ -1,0 +1,233 @@
+(** Breaker SPY sleeve — see [breaker_spy_strategy.mli]. *)
+
+open Core
+open Trading_strategy
+
+type config = { symbol : string; breaker : Index_circuit_breaker.config }
+
+let name = "BreakerSpySleeve"
+let default_symbol = "SPY"
+
+let default_config =
+  { symbol = default_symbol; breaker = Index_circuit_breaker.default_config }
+
+(* Overnight gap buffer for all-cash sizing, identical in spirit to
+   [Bah_benchmark_strategy._entry_gap_buffer_pct]: size against
+   [close * (1 + buffer)] so a small gap-up between today's sizing close and
+   tomorrow's fill open does not bust the cash budget and stall the entry. *)
+let _entry_gap_buffer_pct = 0.01
+
+(* Weekly bars fed to the breaker step. Comfortably covers the breaker's widest
+   window (52-week floor peak / trailing high) plus the ~60 weeks the 30-week
+   stage MA in [Macro.analyze] wants to warm up, with margin. The breaker windows
+   its own lookbacks internally, so surplus history is harmless. *)
+let _breaker_lookback_weeks = 130
+
+let _position_id_of_symbol (symbol : string) : string =
+  Printf.sprintf "%s-breaker-spy-sleeve" symbol
+
+let _is_weekly_close ~(date : Date.t) : bool =
+  Date.day_of_week date |> Day_of_week.equal Day_of_week.Fri
+
+(* All-cash sizing: whole shares affordable at [close_price] with the gap buffer
+   applied. [None] when the cash cannot buy a single share or inputs are
+   non-positive. *)
+let _shares_from_cash ~(cash : float) ~(close_price : float) : float option =
+  if Float.(cash <= 0.0) || Float.(close_price <= 0.0) then None
+  else
+    let sizing_price = close_price *. (1.0 +. _entry_gap_buffer_pct) in
+    let shares = Float.round_down (cash /. sizing_price) in
+    Option.some_if Float.(shares > 0.0) shares
+
+(* Where the portfolio stands for our symbol, collapsed to the three cases the
+   sleeve acts on. [In_transition] (an [Entering] awaiting fill or an [Exiting]
+   awaiting close) means "do nothing this tick" so we neither double-enter nor
+   double-exit. *)
+type _pos_status = Holding of Position.t | In_transition | Flat
+
+(* The strategy's single live (non-[Closed]) position for [symbol], if any. *)
+let _live_position ~(symbol : string) ~(positions : Position.t String.Map.t) :
+    Position.t option =
+  Map.data positions
+  |> List.find ~f:(fun (p : Position.t) ->
+      String.equal p.symbol symbol
+      &&
+      match p.state with
+      | Position.Entering _ | Position.Holding _ | Position.Exiting _ -> true
+      | Position.Closed _ -> false)
+
+let _classify_position ~(symbol : string) ~(positions : Position.t String.Map.t)
+    : _pos_status =
+  match _live_position ~symbol ~positions with
+  | None -> Flat
+  | Some pos -> (
+      match pos.state with
+      | Position.Holding _ -> Holding pos
+      | Position.Entering _ | Position.Exiting _ -> In_transition
+      | Position.Closed _ -> Flat)
+
+(* --- transition builders (long-only; correct breaker reasoning) ------------ *)
+
+let _entry_reasoning : Position.entry_reasoning =
+  ManualDecision
+    {
+      description = "Breaker SPY sleeve: default-in-market buy-and-hold deploy";
+    }
+
+let _build_entry ~(position_id : string) ~(symbol : string)
+    ~(bar : Types.Daily_price.t) ~(target_quantity : float) :
+    Position.transition =
+  let kind : Position.transition_kind =
+    CreateEntering
+      {
+        symbol;
+        side = Long;
+        target_quantity;
+        entry_price = bar.close_price;
+        reasoning = _entry_reasoning;
+      }
+  in
+  { Position.position_id; date = bar.date; kind }
+
+(* Label the exit by which breaker trigger fired, so the trade audit distinguishes
+   the slow structural exit from the fast tail-insurance exits. *)
+let _exit_label_of_reason (reason : Index_circuit_breaker.exit_reason) : string
+    =
+  match reason with
+  | Index_circuit_breaker.Fast_crash -> "breaker_fast_crash"
+  | Index_circuit_breaker.Slow_grind -> "breaker_slow_grind"
+  | Index_circuit_breaker.Absolute_floor -> "breaker_absolute_floor"
+
+let _build_exit ~(pos : Position.t) ~(bar : Types.Daily_price.t)
+    ~(reason : Index_circuit_breaker.exit_reason) : Position.transition =
+  let exit_reason : Position.exit_reason =
+    StrategySignal
+      { label = _exit_label_of_reason reason; detail = Some "breaker" }
+  in
+  let kind : Position.transition_kind =
+    TriggerExit { exit_reason; exit_price = bar.close_price }
+  in
+  { Position.position_id = pos.id; date = bar.date; kind }
+
+(* At most one all-cash entry for [bar], or none when the cash cannot afford a
+   whole share. *)
+let _entry_transitions ~(config : config) ~(cash : float)
+    ~(bar : Types.Daily_price.t) : Position.transition list =
+  match _shares_from_cash ~cash ~close_price:bar.close_price with
+  | None -> []
+  | Some target_quantity ->
+      [
+        _build_entry
+          ~position_id:(_position_id_of_symbol config.symbol)
+          ~symbol:config.symbol ~bar ~target_quantity;
+      ]
+
+(* Deploy cash into the symbol when flat and the breaker wants to be in market —
+   the default-in-market property (runs every day, independent of the step). *)
+let _deploy_if_flat ~(config : config) ~(state : Index_circuit_breaker.state)
+    ~(pos_status : _pos_status) ~(cash : float) ~(bar : Types.Daily_price.t) :
+    Position.transition list =
+  match (pos_status, state) with
+  | Flat, Index_circuit_breaker.In_market _ ->
+      _entry_transitions ~config ~cash ~bar
+  | Flat, Index_circuit_breaker.Out_of_market _ | (Holding _ | In_transition), _
+    ->
+      []
+
+(* --- breaker step wiring --------------------------------------------------- *)
+
+(* Weekly index view for the breaker: the symbol's own weekly-aggregated bars up
+   to [as_of], oldest-first. *)
+let _weekly_index_bars ~(config : config) ~(bar_reader : Bar_reader.t)
+    ~(as_of : Date.t) : Types.Daily_price.t list =
+  Bar_reader.weekly_bars_for bar_reader ~symbol:config.symbol
+    ~n:_breaker_lookback_weeks ~as_of
+
+(* The macro read the breaker's decline-character consumes. Single-instrument
+   degradation: empty A-D / global inputs leave the A-D indicator [`Neutral]
+   ("no breadth lead", per [Decline_character.classify]). [Macro.default_config]
+   is reused verbatim — it adds no tunable of ours; the breaker's own thresholds
+   live in [config.breaker]. [prior_macro] threads last week's result for
+   [Macro.analyze]'s prior / prior_stage arguments and is advanced here. *)
+let _macro ~(prior_macro : Macro.result option ref)
+    ~(index_bars : Types.Daily_price.t list) : Macro.result =
+  let prior_stage =
+    Option.map !prior_macro ~f:(fun (m : Macro.result) -> m.index_stage.stage)
+  in
+  let result =
+    Macro.analyze ~config:Macro.default_config ~index_bars ~ad_bars:[]
+      ~global_index_bars:[] ~prior_stage ~prior:!prior_macro
+  in
+  prior_macro := Some result;
+  result
+
+(* Turn the (new state, action) the breaker returned into at most one transition,
+   given where the portfolio stands. Exit sells a held position; Re_enter buys
+   when flat; otherwise fall through to the default-in-market deploy (which is
+   also what realizes the very first buy on a Hold-into-In_market Friday). *)
+let _act_on ~(config : config) ~(state : Index_circuit_breaker.state)
+    ~(action : Index_circuit_breaker.action) ~(pos_status : _pos_status)
+    ~(cash : float) ~(bar : Types.Daily_price.t) : Position.transition list =
+  match (action, pos_status) with
+  | Index_circuit_breaker.Exit reason, Holding pos ->
+      [ _build_exit ~pos ~bar ~reason ]
+  | Index_circuit_breaker.Re_enter, Flat ->
+      _entry_transitions ~config ~cash ~bar
+  | (Index_circuit_breaker.Exit _ | Re_enter | Hold), _ ->
+      _deploy_if_flat ~config ~state ~pos_status ~cash ~bar
+
+(* Friday: advance the breaker one step against this week's index view + macro,
+   persist the new state, and act on the returned action. *)
+let _friday_transitions ~(config : config) ~(bar_reader : Bar_reader.t)
+    ~(breaker_state : Index_circuit_breaker.state ref)
+    ~(prior_macro : Macro.result option ref) ~(pos_status : _pos_status)
+    ~(cash : float) ~(bar : Types.Daily_price.t) : Position.transition list =
+  let index_bars = _weekly_index_bars ~config ~bar_reader ~as_of:bar.date in
+  let ad_macro = _macro ~prior_macro ~index_bars in
+  let new_state, action =
+    Index_circuit_breaker.step ~config:config.breaker ~state:!breaker_state
+      ~index_bars ~ad_macro
+  in
+  breaker_state := new_state;
+  _act_on ~config ~state:new_state ~action ~pos_status ~cash ~bar
+
+let _transitions_for_bar ~(config : config) ~(bar_reader : Bar_reader.t)
+    ~(breaker_state : Index_circuit_breaker.state ref)
+    ~(prior_macro : Macro.result option ref) ~(portfolio : Portfolio_view.t)
+    ~(bar : Types.Daily_price.t) : Position.transition list =
+  let pos_status =
+    _classify_position ~symbol:config.symbol ~positions:portfolio.positions
+  in
+  if _is_weekly_close ~date:bar.date then
+    _friday_transitions ~config ~bar_reader ~breaker_state ~prior_macro
+      ~pos_status ~cash:portfolio.cash ~bar
+  else
+    (* Mid-week: no breaker evaluation; only the default-in-market deploy runs,
+       carrying the last Friday's state. *)
+    _deploy_if_flat ~config ~state:!breaker_state ~pos_status
+      ~cash:portfolio.cash ~bar
+
+let _on_market_close config ~bar_reader ~breaker_state ~prior_macro ~get_price
+    ~get_indicator:_ ~(portfolio : Portfolio_view.t) =
+  let transitions =
+    match get_price config.symbol with
+    | None -> []
+    | Some bar ->
+        _transitions_for_bar ~config ~bar_reader ~breaker_state ~prior_macro
+          ~portfolio ~bar
+  in
+  Result.return { Strategy_interface.transitions }
+
+let make ?(config = default_config) ~bar_reader () :
+    (module Strategy_interface.STRATEGY) =
+  let breaker_state : Index_circuit_breaker.state ref =
+    ref Index_circuit_breaker.in_market
+  in
+  let prior_macro : Macro.result option ref = ref None in
+  let module M = struct
+    let on_market_close =
+      _on_market_close config ~bar_reader ~breaker_state ~prior_macro
+
+    let name = name
+  end in
+  (module M : Strategy_interface.STRATEGY)

--- a/trading/trading/weinstein/strategy/lib/breaker_spy_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/breaker_spy_strategy.mli
@@ -1,0 +1,110 @@
+(** Breaker SPY sleeve — a long-only, default-in-market index floor strategy
+    that consumes the pure {!Index_circuit_breaker} state machine (P1b step 2 of
+    the floor-quality program; design authority
+    [dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md], lib in
+    [analysis/weinstein/macro/lib/index_circuit_breaker.mli], merged #1904).
+
+    This is the {b consumer} of the breaker lib. It trades exactly one symbol
+    (default SPY), holds it buy-and-hold by default, and defers every
+    sell/re-buy decision to {!Index_circuit_breaker.step}. It is deliberately
+    minimal and {b separate} from both the production {!Weinstein_strategy} and
+    the {!Spy_only_weinstein_strategy} stage-timing testbed — it reuses their
+    sizing shape but carries {e no} per-position trailing stop and runs {e no}
+    stage-entry rule. The only exit is a breaker exit; the only entry is a
+    breaker re-entry or the default-in-market deploy.
+
+    {1 Framing — we are not timing reversals}
+
+    Per the user steer (2026-07-09, [memory/feedback_no_reversal_timing]):
+    {b the sleeve is not trying to time market reversals}. The slow structural
+    exit (breadth-led distribution / slow grind,
+    {!Index_circuit_breaker.Slow_grind}) is the doctrine-faithful part —
+    Weinstein sanctions stepping aside from a genuine distribution top. The fast
+    exit ({!Index_circuit_breaker.Fast_crash} /
+    {!Index_circuit_breaker.Absolute_floor}) and its fast re-entry are explicit
+    {b tail-RISK insurance}: their whipsaw cost is {e accepted and measured},
+    not assumed to be free. The lens screen vs total-return SPY (P1b step 3) is
+    where that whipsaw cost is quantified — this module only wires the
+    machinery.
+
+    {1 Cadence — weekly}
+
+    {!Index_circuit_breaker.step}'s config priors are weekly-bar semantics (a
+    4-week fast window, a 3-week grind confirm, a 52-week floor peak, a 30-week
+    re-entry MA), so the breaker is evaluated on {b weekly closes (Friday)} over
+    the symbol's own weekly-aggregated bars — the symbol {e is} the index, so
+    there is no separate index instrument. Between Fridays the breaker is
+    {b not} re-evaluated: the lib exposes no daily semantics, so a daily-cadence
+    fast exit (the design doc's "days cadence" ambition) is a {e future dial},
+    not invented here. The one thing that {e does} run every day is the
+    default-in-market deploy: whenever the portfolio is flat and the breaker
+    state is {!Index_circuit_breaker.In_market}, available cash is deployed into
+    the symbol — this is how "in-market by default, buy on the first tradable
+    bar" is realized without a daily breaker evaluation.
+
+    {1 Macro / A-D input}
+
+    {!Index_circuit_breaker.step} needs a {!Macro.result} for its
+    {!Decline_character} character read. This sleeve computes it each Friday via
+    {!Macro.analyze} over the symbol's weekly bars with {b empty} A-D and global
+    breadth inputs ([ad_bars:[] ~global_index_bars:[]]) and
+    {!Macro.default_config}. Empty A-D is the documented single-instrument
+    degradation (see {!Decline_character.classify}: a missing / [`Neutral] A-D
+    reading means "no breadth lead"): the slow-grind path then rests on the
+    weeks-below-falling-MA leg alone, and the fast-V path on the rate-of-decline
+    leg — both of which read only index price. {!Macro.default_config}
+    contributes {b no new tunable threshold} of this module's own — its 30-week
+    stage MA merely supplies the [ma_value] / [ma_direction] the character read
+    consumes, consistent with the breaker's own 30-week re-entry MA prior. Every
+    {e tunable} threshold routes through {!config.breaker} so the whole sleeve
+    is a {!Index_circuit_breaker} nesting axis (experiment-flag-discipline R2).
+*)
+
+type config = {
+  symbol : string;
+      (** Instrument to trade. Default {!default_symbol} ([SPY]). Bare ticker,
+          no exchange suffix — matches the on-disk CSV layout under
+          [data/S/Y/SPY/]. *)
+  breaker : Index_circuit_breaker.config;
+      (** The circuit-breaker configuration, threaded verbatim into
+          {!Index_circuit_breaker.step}. Default
+          {!Index_circuit_breaker.default_config}. Every breaker trigger
+          threshold lives here (nothing hardcoded in this module), so the sleeve
+          is expressible as a nested [Variant_matrix] axis the day it lands. *)
+}
+
+val name : string
+(** Human-readable strategy name, [BreakerSpySleeve]. *)
+
+val default_symbol : string
+(** [SPY]. *)
+
+val default_config : config
+(** [default_config] uses {!default_symbol} and
+    {!Index_circuit_breaker.default_config}. The breaker defaults are
+    {e priors to search}, not a validated configuration (see the lib's
+    [default_config] doc): a WF-CV surface + deep bear-regime promotion grid
+    gate them before any is trusted as a default. *)
+
+val make :
+  ?config:config ->
+  bar_reader:Bar_reader.t ->
+  unit ->
+  (module Trading_strategy.Strategy_interface.STRATEGY)
+(** [make ?config ~bar_reader ()] constructor. Returns a first-class
+    {!Trading_strategy.Strategy_interface.STRATEGY} module whose
+    [on_market_close] implements the weekly-breaker cadence above.
+
+    The instance carries closure-scoped mutable state across [on_market_close]
+    calls — the current {!Index_circuit_breaker.state} (seeded fresh at
+    {!Index_circuit_breaker.in_market} per {!make}) and the prior week's
+    {!Macro.result} (for {!Macro.analyze}'s [prior] / [prior_stage] threading).
+    No wall clock is read; given the same bar stream the sequence of decisions
+    is deterministic.
+
+    @param config Strategy parameters. Defaults to {!default_config}.
+    @param bar_reader
+      The snapshot-backed bar source the runner constructs; used to read the
+      symbol's weekly aggregates for the breaker step. The simulator's per-tick
+      [get_price] supplies today's bar for sizing and the default-in-market
+      deploy. *)

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -7,6 +7,7 @@ open Trading_strategy
 module Bar_reader = Bar_reader
 module Spy_only_weinstein_strategy = Spy_only_weinstein_strategy
 module Sector_rotation_weinstein_strategy = Sector_rotation_weinstein_strategy
+module Breaker_spy_strategy = Breaker_spy_strategy
 module Stops_runner = Stops_runner
 module Stops_split_runner = Stops_split_runner
 module Force_liquidation_runner = Force_liquidation_runner

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -52,6 +52,11 @@ module Sector_rotation_weinstein_strategy = Sector_rotation_weinstein_strategy
     the top-[k] strongest Stage-2 sector ETFs by RS vs SPY. See
     {!Sector_rotation_weinstein_strategy}. *)
 
+module Breaker_spy_strategy = Breaker_spy_strategy
+(** Long-only, default-in-market SPY floor sleeve that defers sell/re-buy to the
+    pure {!Index_circuit_breaker} state machine (P1b floor-quality program). See
+    {!Breaker_spy_strategy}. *)
+
 module Stops_runner = Stops_runner
 (** Trailing-stop state machine loop over held positions. See {!Stops_runner}.
 *)

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -21,6 +21,7 @@
   test_liquidity_gate
   test_liquidity_exit_runner
   test_spy_only_weinstein_strategy
+  test_breaker_spy_strategy
   test_stage3_force_exit_runner
   test_late_stage2_stop_runner
   test_harvest_rotate_runner

--- a/trading/trading/weinstein/strategy/test/test_breaker_spy_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_breaker_spy_strategy.ml
@@ -85,6 +85,46 @@ let make_holding ~entry_price ~entry_date ~quantity () : Position.t =
           }))
   |> unwrap
 
+let unwrap_pos = function
+  | Ok p -> p
+  | Error e -> OUnit2.assert_failure ("position setup failed: " ^ Status.show e)
+
+(* An [Entering] SPY position (created, not yet filled). *)
+let make_entering ~entry_price ~entry_date ~quantity () : Position.t =
+  let pos_id = symbol ^ "-breaker-spy-sleeve" in
+  Position.create_entering
+    {
+      Position.position_id = pos_id;
+      date = entry_date;
+      kind =
+        Position.CreateEntering
+          {
+            symbol;
+            side = Long;
+            target_quantity = quantity;
+            entry_price;
+            reasoning = Position.ManualDecision { description = "test" };
+          };
+    }
+  |> unwrap_pos
+
+(* An [Exiting] SPY position: a Holding position with a TriggerExit applied. *)
+let make_exiting ~entry_price ~entry_date ~quantity ~exit_date () : Position.t =
+  let pos = make_holding ~entry_price ~entry_date ~quantity () in
+  Position.apply_transition pos
+    {
+      Position.position_id = pos.id;
+      date = exit_date;
+      kind =
+        Position.TriggerExit
+          {
+            exit_reason =
+              Position.StrategySignal { label = "test"; detail = None };
+            exit_price = entry_price;
+          };
+    }
+  |> unwrap_pos
+
 let no_indicator : Strategy_interface.get_indicator_fn = fun _ _ _ _ -> None
 
 let run_once (module M : Strategy_interface.STRATEGY) ~today_bar ~portfolio =
@@ -137,7 +177,18 @@ let flat_then_crash =
   List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 96.0; 92.0; 88.0 ]
 
 let crash_then_recover = flat_then_crash @ [ 95.0 ]
+
+(* Crash, then two Fridays that stay well below the fast-reentry threshold (5%
+   off the post-exit low of 88 = 92.4) — the sleeve must remain in cash. *)
+let crash_then_stay_down = flat_then_crash @ [ 89.0; 90.0 ]
 let rising = List.init 60 ~f:(fun i -> 50.0 +. (Float.of_int i *. 1.5))
+
+(* A slow drift whose last four weeks barely move (no fast-V) but whose close
+   sits below 80% of the trailing-window high (100) → the T3 absolute-floor
+   backstop, not a fast-crash. Reused from the lib's own floor fixture. *)
+let floor_breach =
+  List.init 40 ~f:(fun _ -> 100.0)
+  @ [ 95.0; 90.0; 85.0; 80.0; 78.0; 77.0; 76.0; 75.5; 75.2; 75.0 ]
 
 (* A gentle sustained decline (grind) then a sharp recovery. The decline is
    shallow (< 4%/4wk) with the index below a falling 30-week MA for many weeks —
@@ -293,6 +344,86 @@ let test_slow_reentry_above_turning_ma _ =
          field (fun (_, r) -> r) is_long_entry;
        ])
 
+let test_stays_out_after_exit_until_reentry _ =
+  (* The DEFINING safety property: after a breaker exit, [_deploy_if_flat] must
+     return [] while Out_of_market — the sleeve stays in cash across every Friday
+     whose bar does NOT satisfy re-entry, rather than re-deploying instantly. *)
+  let bars = bars_of_closes crash_then_stay_down in
+  let crash_bar =
+    List.nth_exn bars (index_of ~closes:crash_then_stay_down ~offset:2)
+  in
+  let down_bar_1 =
+    List.nth_exn bars (index_of ~closes:crash_then_stay_down ~offset:1)
+  in
+  let down_bar_2 = List.last_exn bars in
+  let pos =
+    make_holding ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0 ()
+  in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let exit_result =
+    run_once strat ~today_bar:crash_bar
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  let flat = make_portfolio ~cash:100_000.0 () in
+  let stay_1 = run_once strat ~today_bar:down_bar_1 ~portfolio:flat in
+  let stay_2 = run_once strat ~today_bar:down_bar_2 ~portfolio:flat in
+  assert_that
+    (exit_result, stay_1, stay_2)
+    (all_of
+       [
+         field (fun (e, _, _) -> e) (is_exit_with_label "breaker_fast_crash");
+         field (fun (_, s, _) -> s) is_no_transitions;
+         field (fun (_, _, s) -> s) is_no_transitions;
+       ])
+
+let test_in_transition_position_emits_nothing _ =
+  (* A position mid-transition ([Entering] awaiting fill / [Exiting] awaiting
+     close) must produce NO signal — no double-enter on a rising Friday, no
+     double-exit on a crash Friday. *)
+  let rising_bars = bars_of_closes rising in
+  let crash_bars = bars_of_closes flat_then_crash in
+  let entering =
+    make_entering ~entry_price:110.0 ~entry_date:(friday 0) ~quantity:100.0 ()
+  in
+  let exiting =
+    make_exiting ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0
+      ~exit_date:(friday 1) ()
+  in
+  let strat_a = Breaker.make ~bar_reader:(bar_reader_of rising_bars) () in
+  let strat_b = Breaker.make ~bar_reader:(bar_reader_of crash_bars) () in
+  let entering_result =
+    run_once strat_a
+      ~today_bar:(List.last_exn rising_bars)
+      ~portfolio:(make_portfolio ~cash:100_000.0 ~position:entering ())
+  in
+  let exiting_result =
+    run_once strat_b ~today_bar:(List.last_exn crash_bars)
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:exiting ())
+  in
+  assert_that
+    (entering_result, exiting_result)
+    (all_of
+       [
+         field (fun (e, _) -> e) is_no_transitions;
+         field (fun (_, x) -> x) is_no_transitions;
+       ])
+
+let test_absolute_floor_exit_label _ =
+  (* A slow drift that breaches the trailing-window floor (close < 80% of the
+     52-week high) with no fast-V character → the T3 absolute-floor exit, tagged
+     [breaker_absolute_floor] (the one exit-reason arm the other tests miss). *)
+  let bars = bars_of_closes floor_breach in
+  let today = List.last_exn bars in
+  let pos =
+    make_holding ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0 ()
+  in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  assert_that result (is_exit_with_label "breaker_absolute_floor")
+
 let suite =
   "breaker_spy_strategy"
   >::: [
@@ -309,6 +440,11 @@ let suite =
          "slow grind exits after confirm"
          >:: test_slow_grind_exits_after_confirm;
          "slow re-entry above turning MA" >:: test_slow_reentry_above_turning_ma;
+         "stays out after exit until re-entry"
+         >:: test_stays_out_after_exit_until_reentry;
+         "in-transition position emits nothing"
+         >:: test_in_transition_position_emits_nothing;
+         "absolute-floor exit label" >:: test_absolute_floor_exit_label;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/strategy/test/test_breaker_spy_strategy.ml
+++ b/trading/trading/weinstein/strategy/test/test_breaker_spy_strategy.ml
@@ -1,0 +1,314 @@
+open OUnit2
+open Core
+open Matchers
+module Breaker = Weinstein_strategy.Breaker_spy_strategy
+module Bar_reader = Weinstein_strategy.Bar_reader
+module Strategy_interface = Trading_strategy.Strategy_interface
+module Portfolio_view = Trading_strategy.Portfolio_view
+module Position = Trading_strategy.Position
+
+let symbol = "SPY"
+
+(* One daily bar; open/high/low default around close. *)
+let make_bar date ~close : Types.Daily_price.t =
+  {
+    date;
+    open_price = close;
+    high_price = close *. 1.01;
+    low_price = close *. 0.99;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+    active_through = None;
+  }
+
+(* [base_friday] is a Friday; [friday i] is the i-th consecutive Friday. Dating
+   each bar on a distinct Friday makes ISO-week aggregation in [weekly_bars_for]
+   yield exactly one weekly bar per element, whose close is that Friday's close —
+   the same trick [test_spy_only_weinstein_strategy.ml] uses. *)
+let base_friday = Date.of_string "2020-01-03"
+let friday i = Date.add_days base_friday (7 * i)
+
+(* Daily bars, one per consecutive Friday, from a close trajectory. *)
+let bars_of_closes (closes : float list) : Types.Daily_price.t list =
+  List.mapi closes ~f:(fun i c -> make_bar (friday i) ~close:c)
+
+let bar_reader_of bars = Bar_reader.of_in_memory_bars [ (symbol, bars) ]
+
+let make_portfolio ~cash ?position () : Portfolio_view.t =
+  let positions =
+    match position with
+    | None -> String.Map.empty
+    | Some (p : Position.t) -> String.Map.singleton p.id p
+  in
+  { cash; positions }
+
+(* Build a Holding SPY position at [entry_price] / [entry_date]. *)
+let make_holding ~entry_price ~entry_date ~quantity () : Position.t =
+  let pos_id = symbol ^ "-breaker-spy-sleeve" in
+  let make_trans kind =
+    { Position.position_id = pos_id; date = entry_date; kind }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error e ->
+        OUnit2.assert_failure ("position setup failed: " ^ Status.show e)
+  in
+  let open Position in
+  create_entering
+    (make_trans
+       (CreateEntering
+          {
+            symbol;
+            side = Long;
+            target_quantity = quantity;
+            entry_price;
+            reasoning = ManualDecision { description = "test" };
+          }))
+  |> unwrap
+  |> fun p ->
+  apply_transition p
+    (make_trans
+       (EntryFill { filled_quantity = quantity; fill_price = entry_price }))
+  |> unwrap
+  |> fun p ->
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+let no_indicator : Strategy_interface.get_indicator_fn = fun _ _ _ _ -> None
+
+let run_once (module M : Strategy_interface.STRATEGY) ~today_bar ~portfolio =
+  M.on_market_close
+    ~get_price:(fun s -> if String.equal s symbol then Some today_bar else None)
+    ~get_indicator:no_indicator ~portfolio
+
+(* ---- matchers ---------------------------------------------------------- *)
+
+let is_long_entry =
+  is_ok_and_holds
+    (field
+       (fun (o : Strategy_interface.output) -> o.transitions)
+       (elements_are
+          [
+            field
+              (fun (t : Position.transition) -> t.kind)
+              (matching ~msg:"Expected CreateEntering Long"
+                 (function
+                   | Position.CreateEntering c -> Some (c.symbol, c.side)
+                   | _ -> None)
+                 (equal_to
+                    ((symbol, Position.Long) : string * Position.position_side)));
+          ]))
+
+let is_exit_with_label label =
+  is_ok_and_holds
+    (field
+       (fun (o : Strategy_interface.output) -> o.transitions)
+       (elements_are
+          [
+            field
+              (fun (t : Position.transition) -> t.kind)
+              (matching ~msg:"Expected TriggerExit StrategySignal"
+                 (function
+                   | Position.TriggerExit e -> (
+                       match e.exit_reason with
+                       | Position.StrategySignal s -> Some s.label
+                       | _ -> None)
+                   | _ -> None)
+                 (equal_to label));
+          ]))
+
+let is_no_transitions =
+  is_ok_and_holds
+    (field (fun (o : Strategy_interface.output) -> o.transitions) is_empty)
+
+(* Close trajectories reused from the lib fixtures' shapes. *)
+let flat_then_crash =
+  List.init 56 ~f:(fun _ -> 100.0) @ [ 100.0; 96.0; 92.0; 88.0 ]
+
+let crash_then_recover = flat_then_crash @ [ 95.0 ]
+let rising = List.init 60 ~f:(fun i -> 50.0 +. (Float.of_int i *. 1.5))
+
+(* A gentle sustained decline (grind) then a sharp recovery. The decline is
+   shallow (< 4%/4wk) with the index below a falling 30-week MA for many weeks —
+   the slow-grind signature — while staying above the 20% absolute floor. The
+   recovery then lifts the index back above a turning 30-week MA. *)
+let grind_then_recover =
+  List.init 40 ~f:(fun i -> 100.0 -. (Float.of_int i *. 0.4))
+  @ List.init 20 ~f:(fun j -> 84.4 +. (Float.of_int j *. 2.0))
+
+let index_of ~closes ~offset = List.length closes - 1 - offset
+
+(* ---- tests ------------------------------------------------------------- *)
+
+let test_first_friday_deploys_when_flat _ =
+  (* Fresh sleeve, flat, first Friday on a rising tape → default-in-market buy. *)
+  let bars = bars_of_closes rising in
+  let today = List.last_exn bars in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result is_long_entry
+
+let test_first_midweek_deploys_when_flat _ =
+  (* Same fresh in-market default, but the first tradable bar is a Wednesday: the
+     deploy still fires (it does not wait for the breaker's weekly step). *)
+  let bars = bars_of_closes rising in
+  let wed_bar = make_bar (Date.of_string "2020-01-01") ~close:50.0 in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:wed_bar
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that result is_long_entry
+
+let test_fast_crash_friday_exits_when_holding _ =
+  (* Holding into a fast-crash Friday (a ~12% 4-week drop, no A-D lead) → the
+     breaker fires a fast-crash exit, sold to flat. *)
+  let bars = bars_of_closes flat_then_crash in
+  let today = List.last_exn bars in
+  let pos =
+    make_holding ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0 ()
+  in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:today
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  assert_that result (is_exit_with_label "breaker_fast_crash")
+
+let test_midweek_crash_does_not_evaluate_breaker _ =
+  (* Holding; a violent DOWN day mid-week (Wednesday) → no breaker evaluation
+     between Fridays, so no exit fires. Proves the weekly cadence / state carry. *)
+  let bars = bars_of_closes flat_then_crash in
+  let wed_crash = make_bar (Date.of_string "2020-01-01") ~close:40.0 in
+  let pos =
+    make_holding ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0 ()
+  in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let result =
+    run_once strat ~today_bar:wed_crash
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  assert_that result is_no_transitions
+
+let test_fast_crash_then_recovery_reenters _ =
+  (* One instance across two Fridays: the crash Friday exits (holding → flat),
+     then a later Friday recovered > 5% off the post-exit low re-enters when
+     flat. Exercises breaker-state persistence across ticks. *)
+  let bars = bars_of_closes crash_then_recover in
+  let crash_bar =
+    List.nth_exn bars (index_of ~closes:crash_then_recover ~offset:1)
+  in
+  let recover_bar = List.last_exn bars in
+  let pos =
+    make_holding ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0 ()
+  in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let exit_result =
+    run_once strat ~today_bar:crash_bar
+      ~portfolio:(make_portfolio ~cash:0.0 ~position:pos ())
+  in
+  let reenter_result =
+    run_once strat ~today_bar:recover_bar
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that
+    (exit_result, reenter_result)
+    (all_of
+       [
+         field (fun (e, _) -> e) (is_exit_with_label "breaker_fast_crash");
+         field (fun (_, r) -> r) is_long_entry;
+       ])
+
+let test_slow_grind_exits_after_confirm _ =
+  (* Three consecutive grind Fridays while holding: the first two hold (streak
+     rising), the third fires the slow-grind exit. *)
+  let bars = bars_of_closes grind_then_recover in
+  let grind_friday k = List.nth_exn bars (37 + k) in
+  let pos =
+    make_holding ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0 ()
+  in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let holding_pf () = make_portfolio ~cash:0.0 ~position:pos () in
+  let a1 =
+    run_once strat ~today_bar:(grind_friday 0) ~portfolio:(holding_pf ())
+  in
+  let a2 =
+    run_once strat ~today_bar:(grind_friday 1) ~portfolio:(holding_pf ())
+  in
+  let a3 =
+    run_once strat ~today_bar:(grind_friday 2) ~portfolio:(holding_pf ())
+  in
+  assert_that (a1, a2, a3)
+    (all_of
+       [
+         field (fun (x, _, _) -> x) is_no_transitions;
+         field (fun (_, x, _) -> x) is_no_transitions;
+         field (fun (_, _, x) -> x) (is_exit_with_label "breaker_slow_grind");
+       ])
+
+let test_slow_reentry_above_turning_ma _ =
+  (* Continuation of the grind sequence on the SAME instance: after the grind
+     exit, a Friday whose index has recovered above a turning 30-week MA
+     re-enters when flat. *)
+  let bars = bars_of_closes grind_then_recover in
+  let grind_friday k = List.nth_exn bars (37 + k) in
+  let recover_bar = List.last_exn bars in
+  let pos =
+    make_holding ~entry_price:100.0 ~entry_date:(friday 0) ~quantity:1000.0 ()
+  in
+  let strat = Breaker.make ~bar_reader:(bar_reader_of bars) () in
+  let holding_pf () = make_portfolio ~cash:0.0 ~position:pos () in
+  let _ =
+    run_once strat ~today_bar:(grind_friday 0) ~portfolio:(holding_pf ())
+  in
+  let _ =
+    run_once strat ~today_bar:(grind_friday 1) ~portfolio:(holding_pf ())
+  in
+  let exit_result =
+    run_once strat ~today_bar:(grind_friday 2) ~portfolio:(holding_pf ())
+  in
+  let reenter_result =
+    run_once strat ~today_bar:recover_bar
+      ~portfolio:(make_portfolio ~cash:100_000.0 ())
+  in
+  assert_that
+    (exit_result, reenter_result)
+    (all_of
+       [
+         field (fun (e, _) -> e) (is_exit_with_label "breaker_slow_grind");
+         field (fun (_, r) -> r) is_long_entry;
+       ])
+
+let suite =
+  "breaker_spy_strategy"
+  >::: [
+         "first Friday deploys when flat"
+         >:: test_first_friday_deploys_when_flat;
+         "first mid-week bar deploys when flat"
+         >:: test_first_midweek_deploys_when_flat;
+         "fast-crash Friday exits when holding"
+         >:: test_fast_crash_friday_exits_when_holding;
+         "mid-week crash does not evaluate breaker"
+         >:: test_midweek_crash_does_not_evaluate_breaker;
+         "fast crash then recovery re-enters"
+         >:: test_fast_crash_then_recovery_reenters;
+         "slow grind exits after confirm"
+         >:: test_slow_grind_exits_after_confirm;
+         "slow re-entry above turning MA" >:: test_slow_reentry_above_turning_ma;
+       ]
+
+let () = run_test_tt_main suite


### PR DESCRIPTION
## What

Adds **`Breaker_spy_strategy`** (`trading/trading/weinstein/strategy/lib/breaker_spy_strategy.{ml,mli}` + OUnit2 tests) — the **consumer** of the merged pure `Index_circuit_breaker` lib (#1904, `analysis/weinstein/macro/lib/index_circuit_breaker.mli`). P1b **step 2** of the floor-quality program (design authority: `dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md`).

A long-only, **default-in-market** sleeve that trades one symbol (default SPY), holds it buy-and-hold, and defers every sell/re-buy to `Index_circuit_breaker.step`. It sits alongside `Spy_only_weinstein_strategy` and the production `Weinstein_strategy` — build-alongside, no change to either. It carries **no per-position trailing stop** and runs **no stage-entry rule**: the only exit is a breaker exit; the only entry is a breaker re-entry or the default-in-market deploy.

- **Default in-market:** whenever flat and the breaker state is `In_market`, deploy all-cash (`floor(cash / (close·1.01))`, mirroring Bah/spy_only). This is what makes the sleeve buy on the first tradable bar (any weekday) without a daily breaker evaluation.
- **Weekly (Friday) cadence:** build the symbol's own weekly bars, compute the macro read, call `Index_circuit_breaker.step`, persist the returned state in the instance closure, and act — `Exit → sell to flat`, `Re_enter → buy all-cash`, `Hold → fall through to the deploy`.
- **A-D / macro input:** `Macro.analyze` with **empty** A-D + global inputs (`ad_bars:[] ~global_index_bars:[]`) — the documented single-instrument degradation (A-D `Neutral`, "no breadth lead"; see `Decline_character.classify`) — with `Macro.default_config`. That config adds **no new tunable** of ours; every breaker threshold routes through `config.breaker`, so the sleeve is a nested `Variant_matrix` axis (experiment-flag-discipline R2).

## Why / framing — we are not timing reversals

Per the user steer (2026-07-09, `feedback_no_reversal_timing`): **the sleeve is not trying to time market reversals.** The slow structural exit (breadth-led distribution / `Slow_grind`) is the doctrine-faithful step-aside from a distribution top; the fast exit (`Fast_crash` / `Absolute_floor`) and fast re-entry are explicit **tail-RISK insurance** whose whipsaw cost is *accepted and measured* — that measurement is the P1b step-3 lens screen vs total-return SPY (a separate dispatch), not this PR. This PR only wires the machinery. Documented in the `.mli`.

**Cadence caveat:** the lib's config priors are weekly-bar semantics (4-week fast window, 3-week grind confirm, 52-week floor peak, 30-week re-entry MA), so the sleeve feeds it **weekly** bars and evaluates on Fridays. The lib exposes no daily semantics, so a daily-cadence fast exit is parked as a **future dial** (noted in the `.mli`) rather than invented here.

## Runner wiring (additive, zero behaviour change)

- New `Breaker_spy_sleeve of { symbol }` variant in `Strategy_choice.t` (+ `name` arm, `warmup_days_for` = 364, construction in `panel_strategy_builder`). Mirrors the `Spy_only_weinstein` threading exactly.
- Default-off per experiment-flag-discipline: no scenario selects it, so every existing strategy is bit-identical. `runner.ml`'s `warmup_days_for` match arms were merged (identical RHS) to keep the file at its 500-line declared-large cap.

## Test plan

`trading/trading/weinstein/strategy/test/test_breaker_spy_strategy.ml` (7 tests, OUnit2 + Matchers), driving the full `on_market_close` loop over synthetic weekly bar sequences (bar-shapes reused from the lib's own fixtures):

- starts in-market invested — first Friday (rising tape, flat) deploys a long entry;
- default-in-market deploy also fires **mid-week** (first tradable Wednesday);
- fast-crash Friday while holding → sells to flat (`breaker_fast_crash`);
- **mid-week crash bar → no breaker evaluation** (no exit — proves the weekly cadence / state carry);
- fast crash → recovery re-enters (state persists across ticks, one instance across two Fridays);
- three consecutive grind Fridays → slow-grind exit on the third (`breaker_slow_grind`);
- slow re-entry above a turning 30-week MA (continuation on the same instance).

## Verification

`dune build @fmt`, `dune build`, `dune runtest trading/weinstein/strategy/test/`, and `dune runtest devtools/checks` (the full linter suite) all exit 0 — verified in-container reading the exit codes. The magic-numbers linter reports "OK: no magic numbers found in lib/ files"; nesting + file-length report OK (runner.ml is 498 lines, within its declared-large cap).

> **Correction (rework 1):** the original body claimed the magic-number linter passed; it did not. CI caught a real violation — the merged `warmup_days_for` match arms left a standalone `364` on an indented line (the linter flags a bare literal not adjacent to an arm arrow / not in a `let x = N` binding). Fixed in commit 2 by extracting `let _weekly_strategy_warmup_days = 364` (the 52-aligned-weekly-bars basis) and referencing it in the arm; the single-use `_warmup_days_for` alias was inlined to keep runner.ml at its 500-line cap.

## Rework 1 (QC iteration 1)

Addresses qc-behavioral NEEDS_REWORK + the CI magic-number failure:

- **A — CI magic-number fix (runner.ml):** named constant `_weekly_strategy_warmup_days = 364` replaces the bare literal; no `linter_exceptions` entry.
- **B — three new safety pins** on the sleeve's defining properties (was 7 tests, now 10):
  1. `test_stays_out_after_exit_until_reentry` — after a fast-crash exit, two subsequent no-reentry Fridays produce **no transitions** while flat (pins `_deploy_if_flat` returning `[]` on `(Flat, Out_of_market)` — a regression that instantly re-deployed after every exit would previously have passed all tests).
  2. `test_in_transition_position_emits_nothing` — an `Entering` position on a rising Friday and an `Exiting` position on a crash Friday both emit nothing (no double-enter / double-exit).
  3. `test_absolute_floor_exit_label` — a trailing-window floor breach with no fast-V character yields the `breaker_absolute_floor` label (the one `_exit_label_of_reason` arm the original tests never exercised).

Cites #1904 (the lib) and `dev/plans/fast-circuit-breaker-spy-sleeve-2026-07-08.md` (design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)