### PR TITLE
ops(budget): land 5 orphaned budget records (2026-06-29..07-09)

### DIFF
--- a/dev/budget/2026-06-29-28389918507.json
+++ b/dev/budget/2026-06-29-28389918507.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-06-29-28389918507",
+  "timestamp": "2026-06-29T17:47:59Z",
+  "commit_sha": "a395d77b261d7e85eb09f28f3f653610e3a08e4f",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 11.632018100000002,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-08-28927156762.json
+++ b/dev/budget/2026-07-08-28927156762.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-08-28927156762",
+  "timestamp": "2026-07-08T08:14:34Z",
+  "commit_sha": "31e2a909a8f436b7ee1f61a412a3218912b0e836",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 4.2057675,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-08-28980554116.json
+++ b/dev/budget/2026-07-08-28980554116.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-08-28980554116",
+  "timestamp": "2026-07-08T22:46:52Z",
+  "commit_sha": "d82f1b35a5a5de342811e19e8beb875a2daf67de",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 6.178377999999999,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-09-28988697682.json
+++ b/dev/budget/2026-07-09-28988697682.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-09-28988697682",
+  "timestamp": "2026-07-09T02:10:57Z",
+  "commit_sha": "a564ea3c63baf3ac1464add1f7e669f86e03407a",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 5.3124835,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-09-29055406084.json
+++ b/dev/budget/2026-07-09-29055406084.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-09-29055406084",
+  "timestamp": "2026-07-09T22:54:52Z",
+  "commit_sha": "c8a40346faea9feec21959710df20b3adf354cc1",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 5.800937000000001,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}


### PR DESCRIPTION
Branch-cleanup follow-through (user request 2026-07-10): 5 `ops/budget-*` branches on origin each carried one auto-generated budget-audit JSON whose orchestrator PR step never ran (the known Step-4.5 failure mode). This PR batches all 5 `dev/budget/*.json` records onto main so the source branches can be deleted; content byte-identical to the branch heads.

Pure ops-data (auto-generated JSON audit records); CI is the gate — QC agents add no value here (same treatment as ops/daily summaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)