### PR TITLE
fix(test): orphan-sweep count assertion races concurrent sweeps (#1884)

### DIFF
--- a/trading/trading/backtest/test/test_csv_snapshot_builder_cleanup.ml
+++ b/trading/trading/backtest/test/test_csv_snapshot_builder_cleanup.ml
@@ -114,10 +114,14 @@ let test_orphan_sweep_removes_old_panel_runner_dirs _ =
   (* Backdate mtime to 1 hour ago. *)
   let one_hour_ago = Core_unix.gettimeofday () -. 3600.0 in
   Core_unix.utimes dir ~access:one_hour_ago ~modif:one_hour_ago;
-  let removed = Builder.startup_orphan_sweep ~max_age_hours:0.001 () in
-  assert_that (Stdlib.Sys.file_exists dir) (equal_to false);
-  (* At least our test dir was removed; other CI residue could push count higher. *)
-  assert_that removed (ge (module Int_ord) 1)
+  let (_ : int) = Builder.startup_orphan_sweep ~max_age_hours:0.001 () in
+  (* The load-bearing postcondition is that OUR backdated dir is gone. We do
+     NOT assert the returned count is >= 1: under parallel dune a concurrent
+     test's sweep can legitimately remove our dir first, so this sweep sees it
+     already gone and returns 0 while [file_exists dir = false] still holds
+     (issue #1884). The count is unassertable across concurrent sweeps sharing
+     [Filename.temp_dir_name]; the dir-absence is the contract. *)
+  assert_that (Stdlib.Sys.file_exists dir) (equal_to false)
 
 let test_orphan_sweep_spares_fresh_panel_runner_dirs _ =
   (* A freshly-created dir (mtime ~now) should be spared by a 1-hour


### PR DESCRIPTION
## What

Fixes the flaky `test_orphan_sweep_removes_old_panel_runner_dirs` in
`trading/trading/backtest/test/test_csv_snapshot_builder_cleanup.ml` (issue #1884).

The test backdated a `panel_runner_csv_snapshot_*` dir and asserted its own
`startup_orphan_sweep ~max_age_hours:0.001` returned `removed >= 1`. Under
parallel `dune runtest`, a **concurrent** test's sweep can legitimately remove
the same backdated dir first (all sweeps share `Filename.temp_dir_name` and the
`panel_runner_csv_snapshot_` prefix). This test's sweep then sees the dir already
gone and returns `0`, tripping `removed >= 1` — while the actual postcondition
(`file_exists dir = false`) still holds.

## Fix (issue's option 1)

Option 2 (make the sweep return removed paths) would change
`startup_orphan_sweep`'s return type from `int` and every caller — not a tiny
`.mli` tweak — so per the task instructions this uses **option 1**: drop the
racy count assertion, keep `file_exists dir = false` as the load-bearing
contract, with an explanatory comment citing #1884 and why the count is
unassertable across concurrent sweeps. The sweep result is bound as
`let (_ : int) = ...` so the return value is still exercised. No production code
or sweep behavior changes.

## Test plan

- `dune build @fmt` — exit 0.
- `dune build` — exit 0.
- `dune runtest trading/backtest/test/` — the `Csv_snapshot_builder cleanup`
  suite passes. (The only remaining errors in a fresh isolated worktree are
  pre-existing `Sys_error(".../data/backtest_scenarios/...: No such file or
  directory")` scenario/golden loads with no populated `data/` dir — unrelated
  to this change.)
- Ran `test_csv_snapshot_builder_cleanup.exe` 5× serially (all OK) and 6× in
  parallel (all OK). The parallel run reproduces the exact concurrent-sweep
  race from #1884; the fixed test is stable under it.

Closes #1884

🤖 Generated with [Claude Code](https://claude.com/claude-code)
