### PR TITLE
feat(extension-stop): default-off tail-insurance extension stop

### DIFF
--- a/dev/notes/deployment-readiness-2026-07-12.md
+++ b/dev/notes/deployment-readiness-2026-07-12.md
@@ -1,0 +1,82 @@
+# Deployment-readiness assessment — Weinstein strategy (2026-07-12)
+
+Written for the user's deployment-confidence question (2026-07-11 PM session):
+what do we trust, what are the known weak spots, and what must be checked
+before real money. Companion artifacts: the fresh-picks sanity report (same
+session, task 2) and the trade-review agenda (task 3).
+
+## 1. What the record supports (confidence basis)
+
+**Basis of record**: honest-tradeable deep run, top-3000 PIT 2000-2026 (end
+2026-06-26), realism dials armed; realized-basis ≈ **$17.7M / +1670% /
+~11.5%/yr vs SPY TR +700% / 8.17%/yr** — realized beats the index over 26y
+including two bear markets. MaxDD 41.3 (AXTI-peak-relative; capital-relative
+lower), Ulcer 15. The armed/un-armed advantage is gradual and sign-stable
+across every sub-period (quality-filter shape, not one lucky trade).
+
+Robustness that has survived scrutiny:
+- **Bear-regime defense is the strategy's strongest, most repeated result**:
+  wins EVERY SPY-down year (2001/2002/2008/2011/2018/2022); 2008 −11.7% vs
+  −36.8%. Rolling-start matrices: left tail chopped (worst −4.9 vs −28pp).
+- **Verdict discipline**: every mechanism default was earned through
+  WF-CV/grid gates or an explicit user-mandated faithfulness basis change
+  (ledger-tracked); the fold-horizon LAW now guards tail-dependent verdicts.
+- **Realism floor**: entry gate $1M ADV + stale-exit 5d are DEFAULTS
+  (#1926); fake fills/ghost positions cannot inflate the number of record.
+  Liquidity study: 91% of realized trades <0.1 days-ADV; winners are liquid.
+
+## 2. Known weak spots (each documented, none hidden)
+
+| # | Weak spot | Severity | Live-relevant? | Mitigation state |
+|---|---|---|---|---|
+| W1 | **Melt-up lag** — trails SPY badly in narrow mega-cap tapes (2024 −21.8pp, 2019 −21.6, 2023 −20.9) | HIGH (opportunity cost, psychology) | YES — structural | Documented law (melt-up-lag-anatomy note). Answer = P1b SPY-sleeve barbell (in progress), NOT screener changes. Deployment must set expectations: this strategy WILL trail in melt-ups. |
+| W2 | **Constant whipsaw premium** — ~30-39 short stop-outs/yr, −6 to −16% NAV/yr, every year | MEDIUM (baked into record) | YES | Structural insurance cost (stop-tuning closed after repeated WF-CV rejects). Live: expect ~60% of trades to lose small. Psychology risk > math risk. |
+| W3 | **Return is episodic** — a year's sign vs SPY = whether a fat-tail monster pays that year; top-5 trades ≈ 85% of PnL | HIGH (variance of patience) | YES | Cannot diversify away without taxing the edge (9 confirmations). Deployment needs multi-year commitment framing; single-year evaluation will mislead. |
+| W4 | **Mega-cap non-participation** — 9 Mag7 trades in 26y, all scratches; cash-at-signal blocks the rest | MEDIUM | YES | Faithful behavior (volume/freshness criteria). P2b (decision_audit Phase-2) will quantify the cost of cash-rejection ordering. |
+| W5 | **Parabola give-back** — trailing stop sits far below a parabolic peak (AXTI $122→$70 held) | MEDIUM | YES | Extension-stop INSURANCE dial built default-off (#1934). Deployment decision needed: arm trigger 2.0/trail 0.25 or accept give-back. Screen says tight trails are worse than the disease. |
+| W6 | **MTM-vs-realized gap** — deep-run toplines are MTM-top-heavy (AXTI $45M unrealized of $62M OPV) | LOW for live (live sizes are smaller) | PARTIAL | Realized-basis is the number of record. Live at $1-10M NAV: single-position concentration cap 0.30 still allows big terminal weights — position-size review in pre-deploy checklist. |
+| W7 | **Static $1M ADV gate** calibrated for $1-10M capital | LOW now | YES at scale | Documented follow-up: position-vs-ADV scaling above ~$10M NAV. |
+| W8 | **Universe staleness (backtest)** — static PIT membership can't see later IPOs (GME-class) | — | **NO — backtest-only** | Live trading screens the CURRENT universe weekly; this weakness UNDERSTATES live capture vs backtest. P4 fixes the backtest side. |
+| W9 | **Floor/peak pathology** — monotonic MTM peak + floor sterilized a run (GME squeeze) | — | Mitigated | Portfolio_floor default-off (#1910 + ablation); P1b windowed-peak redesign pending. Do NOT re-arm the floor live until P1b lands. |
+| W10 | **Live-pipeline defects found & fixed this cycle** — prior_stage bug (#1821 fix), missing sectors manifest (all-70 alphabetical picks), macro gate on broken breadth data (false Bearish seed) | — | YES — pipeline risk | All three fixed/documented, but they were found by INSPECTION, not by tests failing. Pre-deploy checklist requires a fresh-picks sanity pass every week until a validation harness exists. |
+| W11 | **Screener tie-break skew** — score ties resolve alphabetically at the cap-20 boundary | LOW-MED | YES | Known (#1782): live-UX fix planned; sector-spread restoration (fetch_finviz_sectors) reduces tie mass. Check tie composition in each week's picks. |
+
+## 3. Confidence statement
+
+- **The EDGE (bear defense + fat-tail capture on breadth) is real and
+  multiply-derived** — highest confidence. It survived realism arming,
+  fold-horizon sensitivity, rolling starts, and PIT survivorship correction.
+- **The COST structure (whipsaw premium, melt-up lag, episodic payoff) is
+  equally real and structural** — deploying means accepting years like 2019
+  (+9.6 vs +31.2) without losing conviction. The strategy is a different
+  asset class than SPY, strongest as a sleeve beside an index leg (P1b).
+- **The live PIPELINE is the least-proven layer** (W10): generation works
+  and the 26-week refreshed series is coherent (72% 6-week confirmation),
+  but defects to date were caught by hand. Weekly sanity discipline is
+  load-bearing until automated validation exists.
+
+## 4. Pre-deployment checklist (proposed)
+
+1. [ ] Fresh-picks generation for the current week + per-pick sanity
+   (stage chained, volume ratio, ADV gate, freshness, sector spread,
+   tie-break composition) — this session produces the first instance.
+2. [ ] Macro-gate inputs verified non-degenerate (breadth files present,
+   GSPC stage sane) before trusting the week's long/short posture.
+3. [ ] Decide the insurance dials for live config and RECORD the decision:
+   extension_stop (arm 2.0/0.25?), catastrophic_stop (armed in record
+   basis), portfolio floor stays OFF until P1b.
+4. [ ] Position-sizing sanity at intended capital (concentration 0.30,
+   min_cash 0.30, gate $1M vs intended NAV).
+5. [ ] Paper-trade N weeks with the weekly workflow (generate → review →
+   would-have-ordered), comparing against the backtest's same-week behavior.
+6. [ ] Weekly ops runbook: fetch STALE set → verify data_end ≥ as-of →
+   generate → render report → sanity pass (the caveats playbook).
+7. [ ] Sleeve decision (P1b): deploy strategy-only, or strategy+SPY sleeve
+   from day one. The melt-up-lag law argues for the sleeve.
+
+## 5. Open items feeding this assessment
+
+- Fresh-picks sanity report (this session) — validates the pipeline NOW.
+- Trade-review agenda (this session) — the interactive audit's entry point.
+- P1b sleeve lens (queued) — the melt-up answer.
+- P2b decision_audit Phase-2 (queued) — the cash-at-signal cost.

--- a/dev/notes/trade-review-agenda-2026-07-12.md
+++ b/dev/notes/trade-review-agenda-2026-07-12.md
@@ -1,0 +1,54 @@
+# Trade-by-trade review agenda (interactive session prep, 2026-07-12)
+
+Prepared for the user's deployment-readiness ask #3: an interactive
+trade-by-trade audit of the record run (honest-tradeable ext, top-3000 PIT
+2000-2026, end 2026-06-26; `scenarios-2026-07-11-195158`).
+
+**Browsing tool**: Claude artifact "Trade Audit" —
+https://claude.ai/code/artifact/64d859d6-920a-448e-a870-11a47098fe41
+All 1,140 closed trades + 2 open positions, sortable, with the agenda
+cohorts below as one-click preset filters (counts shown per chip).
+
+## Cohorts + the question each must answer
+
+1. **Monsters ≥$500k** — the edge itself (top-5 ≈ 85% of PnL). Per monster:
+   liquid at entry AND exit? split/dividend-clean bars? fundable at signal
+   (cash)? Would the live pipeline have surfaced it that week?
+2. **Big losses ≤−$150k** — which exit channel let each run? gap_down fill
+   realism; slow-grind holds that weekly-close stops held to Friday.
+3. **Whipsaws (≤21d loss)** — the ~30-39/yr insurance premium. Confirm they
+   cluster in chop; spot-check initial stop distances vs normal weekly noise.
+4. **Blank exit-trigger (41 rows)** — believed = ordinary Stage-transition
+   sells (unlabeled channel). CONFIRM none is an engine edge case. If
+   confirmed, follow-up: label the channel in trades.csv.
+5. **NLS/BFX rename dup** — one company double-held via ticker rename.
+   Question: are there other rename twins in the run? (universe dedupe
+   follow-up.)
+6. **Liquidity exits (6)** — genuine ADV death vs data gap, each.
+7. **Stage-3 force exits (only 10 in 26y)** — channel nearly inert at
+   hysteresis 1; expected or mis-wired?
+8. **Gap-down stop fills** — sample against raw bars: fills should be at the
+   gap price, not the stop level.
+9. **Open positions** — AXTI ($45.8M mark, the give-back exposure #1934's
+   insurance dial exists for) + VSAT.
+10. **Melt-up lag years (2019/2023/2024)** — the no-monster + churn
+    signature (`dev/notes/melt-up-lag-anatomy-2026-07-11.md`).
+
+## Known answers going in (don't re-derive live)
+
+- Whipsaw premium is structural (stop-tuning closed; multiple WF-CV rejects).
+- Melt-up lag is structural (mega-caps: cash-blocked when they signal
+  cleanly — NVDA ×6; no volume-expansion signature when they grind —
+  NVDA-2023). Answer = P1b sleeve, not screener edits.
+- MTM-vs-realized: realized ≈ $17.7M is the honest bank; terminal OPV is
+  AXTI-dominated.
+- Give-back: extension-stop insurance dial built default-off (#1934);
+  arming decision is a deployment-config question.
+
+## Session flow suggestion
+
+Tiles → cohort chips in the order above → per finding: classify
+(data issue / engine issue / strategy-structural / accepted-cost) → new
+issues become follow-ups; structural items get linked to the
+deployment-readiness doc's weak-spot table
+(`dev/notes/deployment-readiness-2026-07-12.md`).

--- a/dev/status/extension-stop.md
+++ b/dev/status/extension-stop.md
@@ -1,0 +1,65 @@
+# Status: extension-stop
+
+## Last updated: 2026-07-12
+
+## Status
+IN_PROGRESS
+
+## Interface stable
+NO
+
+A default-off **extension stop** — a wide tail-INSURANCE trail for a held long
+that has run far above its 30-week WMA (a blow-off / parabolic advance). Once the
+weekly close reaches `trigger_ratio ×` the WMA30 it arms a wide trail; thereafter
+it exits on the first weekly close that is `trail_pct` below the post-trigger
+running peak weekly close. Weekly-close semantics (L3), tighten-only (L2).
+
+Catastrophic-stop-class tail-INSURANCE dial (same class as
+`stops_config.catastrophic_stop_pct`, #1695) — NOT a performance axis. Extension
+events are rare (~0.6-1% of episodes reach 2.0× WMA30 over a quarter-century), so
+a WF-CV is structurally powerless; acceptance basis is the left-tail / event-level
+audit, never fold Sharpe. User-directed insurance build (2026-07-11 PM): "no way
+we actually sit through 140→70, even if that would take a manual intervention" —
+an encoded, tested rule beats an untested panic exit.
+
+W2 authority: a faithful trader exit-aggressiveness dial (book §5.3 "Trailing
+Stop — Trader Method"; §Stage 3 detail Ch. 2 "Traders: exit with profits"). Spine
+untouched.
+
+Design / evidence: `dev/notes/next-session-priorities-2026-07-12.md` §P0a;
+`dev/backtest/extension-screen-2026-07-11/FINDINGS.md` §"What survives".
+
+## Completed
+- **Build (PR `feat/extension-stop`, 2026-07-12)** — default-off mechanism:
+  - `trading/trading/weinstein/stops/lib/extension_stop.{ml,mli}` — pure trigger
+    + trail logic (`config { trigger_ratio; trail_pct }`, both default `0.0` =
+    disabled; `fired config ~closes ~wmas`). Mirrors the merged extension screen's
+    trigger/peak/fire logic exactly. Registered as `Weinstein_stops.Extension_stop`.
+  - `trading/trading/weinstein/strategy/lib/extension_stop_runner.{ml,mli}` —
+    Friday-gated, LONG-only special-exit runner: replays each held long's holding
+    window on the WMA30 basis (`Sma.calculate_weighted_ma`), emits a `TriggerExit`
+    (`StrategySignal "extension_stop"`) at the current weekly close when the trail
+    fires; skips positions already exiting (tighten-only).
+  - Wired into `special_exits.ml` after the liquidity exit, sharing the full
+    same-tick skip-set union (stop / force-liq / Stage-3 / laggard / liquidity).
+  - Config: `extension_stop_config : Weinstein_stops.Extension_stop.config`
+    (default no-op) in `Weinstein_strategy.config` — a nested `Variant_matrix`
+    axis resolvable through `Overlay_validator.apply_overrides`.
+  - Tests: `test_extension_stop.ml` (pure mechanism), `test_extension_stop_runner.ml`
+    (wiring/gating/fire/shakeout/skip-set/side/cadence), + Overlay_validator
+    round-trip cases in `test_runner_hypothesis_overrides.ml`.
+
+## In Progress
+- PR `feat/extension-stop` open, awaiting QC + CI.
+
+## Next Steps
+- **Acceptance audit (post-merge, insurance basis).** Run armed-vs-off record
+  runs on the current-basis deep runs + re-run the `analysis/scripts/extension_screen`
+  counterfactual; judge on left-tail / dispersion / event-level (NOT fold Sharpe).
+  Screen pins the width: `trail_pct 0.25` survives on-ramp shakeouts; `0.10-0.20`
+  are on-ramp killers. `[non-blocking]`.
+- Only after an insurance-basis ACCEPT would a default flip be considered
+  (experiment-flag-discipline R3) — default stays off until then.
+
+## Follow-ups
+- None.

--- a/trading/trading/backtest/test/dune
+++ b/trading/trading/backtest/test/dune
@@ -59,6 +59,7 @@
   trading.strategy
   weinstein_trading.strategy
   weinstein_trading.portfolio_risk
+  weinstein_trading.stops
   weinstein.screener
   types
   status

--- a/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
+++ b/trading/trading/backtest/test/test_runner_hypothesis_overrides.ml
@@ -497,6 +497,59 @@ let test_cash_reserve_pct_axis_resolves_via_overlay_validator _ =
   in
   assert_that merged.cash_reserve_pct (float_equal 0.30)
 
+(* -------------------------------------------------------------------- *)
+(* extension_stop_config — tail-insurance trail (default-off nested axis) *)
+(* -------------------------------------------------------------------- *)
+
+(** [extension_stop_config] defaults to the no-op ([trigger_ratio = 0.0] /
+    [trail_pct = 0.0]) — the mechanism is disabled, so every existing
+    golden/baseline decodes unchanged
+    ([.claude/rules/experiment-flag-discipline.md] R1). *)
+let test_default_extension_stop_config_is_no_op _ =
+  let cfg = _default_config () in
+  assert_that cfg.extension_stop_config
+    (all_of
+       [
+         field
+           (fun (c : Weinstein_stops.Extension_stop.config) -> c.trigger_ratio)
+           (float_equal 0.0);
+         field
+           (fun (c : Weinstein_stops.Extension_stop.config) -> c.trail_pct)
+           (float_equal 0.0);
+       ])
+
+(** Deep-merge path for the nested [extension_stop_config]: a partial-config
+    overlay lands both sub-fields via the sexp merge. *)
+let test_override_extension_stop_config _ =
+  let merged =
+    _apply_one_override (_default_config ())
+      (Sexp.of_string
+         "((extension_stop_config ((trigger_ratio 2.0) (trail_pct 0.25))))")
+  in
+  assert_that merged.extension_stop_config
+    (all_of
+       [
+         field
+           (fun (c : Weinstein_stops.Extension_stop.config) -> c.trigger_ratio)
+           (float_equal 2.0);
+         field
+           (fun (c : Weinstein_stops.Extension_stop.config) -> c.trail_pct)
+           (float_equal 0.25);
+       ])
+
+(** Axis reachability (experiment-flag-discipline R2): the nested
+    [extension_stop_config] override resolves through the {b real}
+    [Overlay_validator.apply_overrides] (the sweep / WF-CV path) with no
+    unknown-key error, landing a single sub-field — this is what makes
+    [((key (extension_stop_config trigger_ratio)) (values (2.0 2.25)))] a valid
+    [Variant_matrix] axis. *)
+let test_extension_stop_config_axis_resolves_via_overlay_validator _ =
+  let merged =
+    Backtest.Overlay_validator.apply_overrides (_default_config ())
+      [ Sexp.of_string "((extension_stop_config ((trigger_ratio 2.0))))" ]
+  in
+  assert_that merged.extension_stop_config.trigger_ratio (float_equal 2.0)
+
 let suite =
   "Runner_hypothesis_overrides"
   >::: [
@@ -554,6 +607,12 @@ let suite =
          >:: test_override_cash_reserve_pct;
          "cash_reserve_pct axis resolves via Overlay_validator"
          >:: test_cash_reserve_pct_axis_resolves_via_overlay_validator;
+         "default extension_stop_config is no-op"
+         >:: test_default_extension_stop_config_is_no_op;
+         "override extension_stop_config through sexp"
+         >:: test_override_extension_stop_config;
+         "extension_stop_config axis resolves via Overlay_validator"
+         >:: test_extension_stop_config_axis_resolves_via_overlay_validator;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/weinstein/stops/lib/extension_stop.ml
+++ b/trading/trading/weinstein/stops/lib/extension_stop.ml
@@ -1,0 +1,51 @@
+open Core
+
+type config = {
+  trigger_ratio : float; [@sexp.default 0.0]
+  trail_pct : float; [@sexp.default 0.0]
+}
+[@@deriving show, eq, sexp]
+
+let default_config = { trigger_ratio = 0.0; trail_pct = 0.0 }
+
+let is_enabled { trigger_ratio; trail_pct } =
+  Float.( > ) trigger_ratio 0.0 && Float.( > ) trail_pct 0.0
+
+(* First week whose close/wma reaches the trigger ratio; the WMA must be filled
+   (finite and > 0). Mirrors the extension screen's [_first_trigger]. *)
+let _first_trigger ~closes ~wmas ~trigger_ratio =
+  let n = Array.length closes in
+  let rec go i =
+    if i >= n then None
+    else if
+      Float.is_finite wmas.(i)
+      && Float.( > ) wmas.(i) 0.0
+      && Float.( >= ) (closes.(i) /. wmas.(i)) trigger_ratio
+    then Some i
+    else go (i + 1)
+  in
+  go 0
+
+(* Walk forward from the trigger week; fire at the first weekly close that is
+   [trail_pct] below the running peak close (peak seeded at the trigger week).
+   The fire-check precedes the peak update so a new high can never fire. Mirrors
+   the extension screen's [_trail_fire]. *)
+let _trail_fires ~closes ~trigger ~trail_pct =
+  let n = Array.length closes in
+  let peak = ref closes.(trigger) in
+  let rec go i =
+    if i >= n then false
+    else if Float.( <= ) closes.(i) (!peak *. (1.0 -. trail_pct)) then true
+    else (
+      peak := Float.max !peak closes.(i);
+      go (i + 1))
+  in
+  go (trigger + 1)
+
+let fired config ~closes ~wmas =
+  if (not (is_enabled config)) || Array.length closes <> Array.length wmas then
+    false
+  else
+    match _first_trigger ~closes ~wmas ~trigger_ratio:config.trigger_ratio with
+    | None -> false
+    | Some trigger -> _trail_fires ~closes ~trigger ~trail_pct:config.trail_pct

--- a/trading/trading/weinstein/stops/lib/extension_stop.mli
+++ b/trading/trading/weinstein/stops/lib/extension_stop.mli
@@ -1,0 +1,93 @@
+(** Extension stop — a wide tail-INSURANCE trail for a held long that has run
+    far above its weekly moving average (a blow-off / parabolic advance).
+
+    {1 What it is}
+
+    Once a held long's weekly close reaches [trigger_ratio ×] its 30-week WMA
+    (the stage classifier's MA basis — {!Stage.default_config}: [ma_period = 30],
+    [ma_type = Wma]) the position {e arms} a wide trail; thereafter it exits on
+    the first weekly close that is [trail_pct] below the running peak weekly
+    close observed since the trigger. Weekly-close semantics throughout (book
+    §Stop-Loss Rules: weekly re-evaluation).
+
+    This module is {b pure} and {b date-agnostic}: it operates on the
+    holding-window [(close, wma)] arrays that the strategy-side runner
+    ({!Extension_stop_runner}) prepares. The peak / trigger / fire logic mirrors
+    the merged extension screen
+    ([analysis/scripts/extension_screen/bin/extension_screen.ml]) exactly.
+
+    {1 It is TAIL-INSURANCE, not an alpha axis}
+
+    This is a catastrophic-stop-class dial (same class as
+    {!Catastrophic_stop} / [stops_config.catastrophic_stop_pct], PR #1695), NOT
+    a performance knob. Extension events are {e rare} — the screen measured
+    ~0.6-1% of episodes reach [2.0×] WMA30 over a quarter-century — so a
+    walk-forward CV on this axis is structurally powerless (most folds contain
+    zero events). Its acceptance basis is therefore the left-tail / dispersion /
+    event-level audit (armed-vs-off record runs + the extension_screen
+    counterfactual), {b never} fold Sharpe. See
+    [dev/backtest/extension-screen-2026-07-11/FINDINGS.md] §"What survives".
+
+    {1 Faithfulness (W2)}
+
+    A faithful {b trader exit-aggressiveness} dial: on a parabolic advance far
+    above the MA a trader takes profits / swing-sells rather than waiting for the
+    MA violation ([docs/design/weinstein-book-reference.md] §5.3 "Trailing Stop —
+    Trader Method": "Don't wait for MA violation — exit when pattern deviates
+    from plan"; §Stage 3 detail Ch. 2: "Traders: exit with profits"). The
+    strategy spine is untouched: stage classification, the Stage-2-only buy rule,
+    breakout+volume entry, the macro/sector gate, and relative strength are all
+    unaffected — only a held long gains one extra, discretionary weekly-close
+    exit trigger.
+
+    {1 Width}
+
+    The screen pins the width: a [0.25] (25%) trail survives the on-ramp
+    shakeouts of the very monsters it is meant to protect (the AXTI April 2025
+    ~−18% mid-parabola dip, the January chop) and still banks the collapse;
+    tighter [0.10-0.20] trails are on-ramp killers — they exit during the advance
+    as often as at the top, taxing the fat tail (the 9th confirmation of the
+    winner-touching tax, [[project_edge_is_the_fat_tail]]). Do NOT build tight. *)
+
+type config = {
+  trigger_ratio : float; [@sexp.default 0.0]
+      (** Weekly close / 30-week WMA ratio at which the wide trail arms.
+          [<= 0.0] (the default) DISABLES the mechanism — an exact no-op. A value
+          such as [2.0] arms when the close reaches twice the WMA30. *)
+  trail_pct : float; [@sexp.default 0.0]
+      (** Fraction below the post-trigger running peak weekly close at which the
+          armed trail fires. [<= 0.0] (the default) DISABLES the mechanism.
+          Screen-pinned width: [0.25] survives on-ramp shakeouts; [0.10-0.20] are
+          on-ramp killers. *)
+}
+[@@deriving show, eq, sexp]
+
+val default_config : config
+(** The no-op default ([trigger_ratio = 0.0], [trail_pct = 0.0]) — the mechanism
+    is disabled, so merging it changes no backtest result
+    ([.claude/rules/experiment-flag-discipline.md] R1). *)
+
+val is_enabled : config -> bool
+(** [true] iff both [trigger_ratio > 0.0] and [trail_pct > 0.0]. When [false] the
+    mechanism is a no-op regardless of the price series. *)
+
+val fired : config -> closes:float array -> wmas:float array -> bool
+(** [fired config ~closes ~wmas] is [true] iff the armed extension trail has
+    fired by the last element of the holding-window series.
+
+    [closes] and [wmas] are the weekly adjusted-close and 30-week WMA of the
+    position's {e holding window} (entry → as-of), same length, chronological
+    (oldest first). [wmas.(i)] is [Float.nan] where the WMA window had not yet
+    filled at week [i].
+
+    Semantics (mirroring the merged extension screen):
+    - Returns [false] when [is_enabled config] is [false], the arrays differ in
+      length, or no week ever reaches the trigger.
+    - {b Trigger}: the first week [i] with [wmas.(i)] finite and [> 0] and
+      [closes.(i) /. wmas.(i) >= trigger_ratio].
+    - {b Peak}: seeded at the trigger week's close; the running maximum of weekly
+      closes after it. The fire-check at each later week is evaluated {e before}
+      the peak is updated with that week's close, so a new high can never fire.
+    - {b Fire}: the first later week whose [close <= peak *. (1. -. trail_pct)].
+
+    Pure: same inputs always produce the same result. *)

--- a/trading/trading/weinstein/stops/lib/extension_stop.mli
+++ b/trading/trading/weinstein/stops/lib/extension_stop.mli
@@ -4,11 +4,11 @@
     {1 What it is}
 
     Once a held long's weekly close reaches [trigger_ratio ×] its 30-week WMA
-    (the stage classifier's MA basis — {!Stage.default_config}: [ma_period = 30],
-    [ma_type = Wma]) the position {e arms} a wide trail; thereafter it exits on
-    the first weekly close that is [trail_pct] below the running peak weekly
-    close observed since the trigger. Weekly-close semantics throughout (book
-    §Stop-Loss Rules: weekly re-evaluation).
+    (the stage classifier's MA basis — {!Stage.default_config}:
+    [ma_period = 30], [ma_type = Wma]) the position {e arms} a wide trail;
+    thereafter it exits on the first weekly close that is [trail_pct] below the
+    running peak weekly close observed since the trigger. Weekly-close semantics
+    throughout (book §Stop-Loss Rules: weekly re-evaluation).
 
     This module is {b pure} and {b date-agnostic}: it operates on the
     holding-window [(close, wma)] arrays that the strategy-side runner
@@ -18,47 +18,48 @@
 
     {1 It is TAIL-INSURANCE, not an alpha axis}
 
-    This is a catastrophic-stop-class dial (same class as
-    {!Catastrophic_stop} / [stops_config.catastrophic_stop_pct], PR #1695), NOT
-    a performance knob. Extension events are {e rare} — the screen measured
-    ~0.6-1% of episodes reach [2.0×] WMA30 over a quarter-century — so a
-    walk-forward CV on this axis is structurally powerless (most folds contain
-    zero events). Its acceptance basis is therefore the left-tail / dispersion /
-    event-level audit (armed-vs-off record runs + the extension_screen
-    counterfactual), {b never} fold Sharpe. See
-    [dev/backtest/extension-screen-2026-07-11/FINDINGS.md] §"What survives".
+    This is a catastrophic-stop-class dial (same class as {!Catastrophic_stop} /
+    [stops_config.catastrophic_stop_pct], PR #1695), NOT a performance knob.
+    Extension events are {e rare} — the screen measured ~0.6-1% of episodes
+    reach [2.0×] WMA30 over a quarter-century — so a walk-forward CV on this
+    axis is structurally powerless (most folds contain zero events). Its
+    acceptance basis is therefore the left-tail / dispersion / event-level audit
+    (armed-vs-off record runs + the extension_screen counterfactual), {b never}
+    fold Sharpe. See [dev/backtest/extension-screen-2026-07-11/FINDINGS.md]
+    §"What survives".
 
     {1 Faithfulness (W2)}
 
     A faithful {b trader exit-aggressiveness} dial: on a parabolic advance far
-    above the MA a trader takes profits / swing-sells rather than waiting for the
-    MA violation ([docs/design/weinstein-book-reference.md] §5.3 "Trailing Stop —
-    Trader Method": "Don't wait for MA violation — exit when pattern deviates
-    from plan"; §Stage 3 detail Ch. 2: "Traders: exit with profits"). The
-    strategy spine is untouched: stage classification, the Stage-2-only buy rule,
-    breakout+volume entry, the macro/sector gate, and relative strength are all
-    unaffected — only a held long gains one extra, discretionary weekly-close
-    exit trigger.
+    above the MA a trader takes profits / swing-sells rather than waiting for
+    the MA violation ([docs/design/weinstein-book-reference.md] §5.3 "Trailing
+    Stop — Trader Method": "Don't wait for MA violation — exit when pattern
+    deviates from plan"; §Stage 3 detail Ch. 2: "Traders: exit with profits").
+    The strategy spine is untouched: stage classification, the Stage-2-only buy
+    rule, breakout+volume entry, the macro/sector gate, and relative strength
+    are all unaffected — only a held long gains one extra, discretionary
+    weekly-close exit trigger.
 
     {1 Width}
 
     The screen pins the width: a [0.25] (25%) trail survives the on-ramp
     shakeouts of the very monsters it is meant to protect (the AXTI April 2025
     ~−18% mid-parabola dip, the January chop) and still banks the collapse;
-    tighter [0.10-0.20] trails are on-ramp killers — they exit during the advance
-    as often as at the top, taxing the fat tail (the 9th confirmation of the
-    winner-touching tax, [[project_edge_is_the_fat_tail]]). Do NOT build tight. *)
+    tighter [0.10-0.20] trails are on-ramp killers — they exit during the
+    advance as often as at the top, taxing the fat tail (the 9th confirmation of
+    the winner-touching tax, [[project_edge_is_the_fat_tail]]). Do NOT build
+    tight. *)
 
 type config = {
   trigger_ratio : float; [@sexp.default 0.0]
       (** Weekly close / 30-week WMA ratio at which the wide trail arms.
-          [<= 0.0] (the default) DISABLES the mechanism — an exact no-op. A value
-          such as [2.0] arms when the close reaches twice the WMA30. *)
+          [<= 0.0] (the default) DISABLES the mechanism — an exact no-op. A
+          value such as [2.0] arms when the close reaches twice the WMA30. *)
   trail_pct : float; [@sexp.default 0.0]
       (** Fraction below the post-trigger running peak weekly close at which the
           armed trail fires. [<= 0.0] (the default) DISABLES the mechanism.
-          Screen-pinned width: [0.25] survives on-ramp shakeouts; [0.10-0.20] are
-          on-ramp killers. *)
+          Screen-pinned width: [0.25] survives on-ramp shakeouts; [0.10-0.20]
+          are on-ramp killers. *)
 }
 [@@deriving show, eq, sexp]
 
@@ -68,8 +69,8 @@ val default_config : config
     ([.claude/rules/experiment-flag-discipline.md] R1). *)
 
 val is_enabled : config -> bool
-(** [true] iff both [trigger_ratio > 0.0] and [trail_pct > 0.0]. When [false] the
-    mechanism is a no-op regardless of the price series. *)
+(** [true] iff both [trigger_ratio > 0.0] and [trail_pct > 0.0]. When [false]
+    the mechanism is a no-op regardless of the price series. *)
 
 val fired : config -> closes:float array -> wmas:float array -> bool
 (** [fired config ~closes ~wmas] is [true] iff the armed extension trail has
@@ -85,9 +86,10 @@ val fired : config -> closes:float array -> wmas:float array -> bool
       length, or no week ever reaches the trigger.
     - {b Trigger}: the first week [i] with [wmas.(i)] finite and [> 0] and
       [closes.(i) /. wmas.(i) >= trigger_ratio].
-    - {b Peak}: seeded at the trigger week's close; the running maximum of weekly
-      closes after it. The fire-check at each later week is evaluated {e before}
-      the peak is updated with that week's close, so a new high can never fire.
+    - {b Peak}: seeded at the trigger week's close; the running maximum of
+      weekly closes after it. The fire-check at each later week is evaluated
+      {e before} the peak is updated with that week's close, so a new high can
+      never fire.
     - {b Fire}: the first later week whose [close <= peak *. (1. -. trail_pct)].
 
     Pure: same inputs always produce the same result. *)

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.ml
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.ml
@@ -8,6 +8,7 @@ module Stop_split_adjust = Stop_split_adjust
 module Stop_widen = Stop_widen
 module Vol_scaled_stop = Vol_scaled_stop
 module Catastrophic_stop = Catastrophic_stop
+module Extension_stop = Extension_stop
 
 (* Round-number nudging lives in {!Stop_nudge} (extracted to keep this
    coordinator under the file-length cap). This adapts it to the stops config's

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.mli
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.mli
@@ -44,8 +44,8 @@ module Extension_stop = Extension_stop
 (** Extension stop (default-off, [Extension_stop.config]). A wide tail-INSURANCE
     trail for a held long that has run far above its 30-week WMA (blow-off).
     Pure trigger + trail logic; the strategy-side runner
-    ({!Extension_stop_runner}) feeds it the holding-window series. See the module
-    doc for the contract. *)
+    ({!Extension_stop_runner}) feeds it the holding-window series. See the
+    module doc for the contract. *)
 
 (** {1 Core Functions} *)
 

--- a/trading/trading/weinstein/stops/lib/weinstein_stops.mli
+++ b/trading/trading/weinstein/stops/lib/weinstein_stops.mli
@@ -40,6 +40,13 @@ module Catastrophic_stop = Catastrophic_stop
     Macro-agnostic trigger armed only in a fast-V decline. See the module doc
     for the contract. *)
 
+module Extension_stop = Extension_stop
+(** Extension stop (default-off, [Extension_stop.config]). A wide tail-INSURANCE
+    trail for a held long that has run far above its 30-week WMA (blow-off).
+    Pure trigger + trail logic; the strategy-side runner
+    ({!Extension_stop_runner}) feeds it the holding-window series. See the module
+    doc for the contract. *)
+
 (** {1 Core Functions} *)
 
 val compute_initial_stop :

--- a/trading/trading/weinstein/stops/test/dune
+++ b/trading/trading/weinstein/stops/test/dune
@@ -5,6 +5,7 @@
   test_support_floor
   test_stop_split_adjust
   test_vol_scaled_stop
+  test_extension_stop
   test_weinstein_stops_callbacks_parity)
  (libraries
   weinstein_trading.stops

--- a/trading/trading/weinstein/stops/test/test_extension_stop.ml
+++ b/trading/trading/weinstein/stops/test/test_extension_stop.ml
@@ -1,0 +1,144 @@
+(** Unit tests for {!Weinstein_stops.Extension_stop} — the pure trigger + trail
+    logic of the extension tail-insurance stop.
+
+    Pins:
+    - Default-off: the no-op config never fires regardless of the series.
+    - No trigger below the ratio → never fires.
+    - Trigger then only new highs → never fires (a new high can never fire).
+    - Trigger, peak, then a close [trail_pct] below the peak → fires.
+    - Width sensitivity (the AXTI April-shakeout shape): a ~-18% post-trigger
+      dip SURVIVES a 0.25 trail but EXITS a 0.15 trail — the screen-pinned
+      reason the build is wide (0.25), not tight.
+    - WMA-warmup weeks (NaN wma) cannot trigger.
+    - Degenerate inputs (empty / mismatched-length arrays) return false. *)
+
+open OUnit2
+open Core
+open Matchers
+module Extension_stop = Weinstein_stops.Extension_stop
+
+let _armed = { Extension_stop.trigger_ratio = 2.0; trail_pct = 0.25 }
+
+(* A constant WMA of 50.0 per week, so [close = 100.0] is exactly 2.0x the WMA
+   (the trigger). *)
+let _flat_wma n = Array.create ~len:n 50.0
+
+(* ------------------------------------------------------------------ *)
+(* Default-off: the no-op config never fires                           *)
+(* ------------------------------------------------------------------ *)
+
+(* A series that WOULD fire under an armed config: trigger at 100, peak 120,
+   collapse to 60 (60 <= 120 * 0.75). *)
+let _would_fire_closes = [| 60.0; 100.0; 120.0; 60.0 |]
+
+let test_default_off_never_fires _ =
+  let wmas = _flat_wma (Array.length _would_fire_closes) in
+  assert_that
+    (Extension_stop.fired Extension_stop.default_config
+       ~closes:_would_fire_closes ~wmas)
+    (equal_to false)
+
+(* ------------------------------------------------------------------ *)
+(* No trigger below the ratio → never fires                             *)
+(* ------------------------------------------------------------------ *)
+
+let test_no_trigger_below_ratio _ =
+  (* Max close 90 vs WMA 50 => 1.8x, below the 2.0 trigger even though it later
+     collapses hard. *)
+  let closes = [| 60.0; 80.0; 90.0; 40.0 |] in
+  let wmas = _flat_wma (Array.length closes) in
+  assert_that (Extension_stop.fired _armed ~closes ~wmas) (equal_to false)
+
+(* ------------------------------------------------------------------ *)
+(* Trigger then only new highs → never fires                            *)
+(* ------------------------------------------------------------------ *)
+
+let test_new_highs_never_fire _ =
+  (* Trigger at 100 (2.0x), then a monotone climb — a new high can never fire
+     (fire-check precedes the peak update). *)
+  let closes = [| 70.0; 100.0; 110.0; 130.0; 160.0 |] in
+  let wmas = _flat_wma (Array.length closes) in
+  assert_that (Extension_stop.fired _armed ~closes ~wmas) (equal_to false)
+
+(* ------------------------------------------------------------------ *)
+(* Trigger, peak, then collapse ≤ peak*(1-trail) → fires                *)
+(* ------------------------------------------------------------------ *)
+
+let test_collapse_below_trail_fires _ =
+  (* Trigger at 100, peak 120, then 84 <= 120*0.75 (=90) => fires at 0.25. *)
+  let closes = [| 70.0; 100.0; 120.0; 84.0 |] in
+  let wmas = _flat_wma (Array.length closes) in
+  assert_that (Extension_stop.fired _armed ~closes ~wmas) (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* Width sensitivity — the AXTI April-shakeout shape                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Trigger at 100 (2.0x WMA 50), peak 120, then a ~-18% shakeout dip to 98.4
+   (120 * 0.82), then the parabola resumes to a new high. *)
+let _shakeout_closes = [| 70.0; 100.0; 120.0; 98.4; 140.0 |]
+
+let test_shakeout_survives_wide_trail _ =
+  (* 98.4 > 120 * 0.75 (=90) => the 0.25 trail HOLDS through the shakeout. *)
+  let wmas = _flat_wma (Array.length _shakeout_closes) in
+  assert_that
+    (Extension_stop.fired
+       { Extension_stop.trigger_ratio = 2.0; trail_pct = 0.25 }
+       ~closes:_shakeout_closes ~wmas)
+    (equal_to false)
+
+let test_shakeout_exits_tight_trail _ =
+  (* 98.4 <= 120 * 0.85 (=102) => the 0.15 trail is an on-ramp KILLER: it exits
+     during the shakeout, before the parabola resumes. *)
+  let wmas = _flat_wma (Array.length _shakeout_closes) in
+  assert_that
+    (Extension_stop.fired
+       { Extension_stop.trigger_ratio = 2.0; trail_pct = 0.15 }
+       ~closes:_shakeout_closes ~wmas)
+    (equal_to true)
+
+(* ------------------------------------------------------------------ *)
+(* WMA-warmup weeks (NaN wma) cannot trigger                            *)
+(* ------------------------------------------------------------------ *)
+
+let test_nan_wma_warmup_cannot_trigger _ =
+  (* Week 0 has a huge close but a NaN WMA (window not yet filled) — it must not
+     trigger; the finite-WMA weeks that follow stay below the ratio, so no fire.
+  *)
+  let closes = [| 500.0; 60.0; 80.0; 90.0 |] in
+  let wmas = [| Float.nan; 50.0; 50.0; 50.0 |] in
+  assert_that (Extension_stop.fired _armed ~closes ~wmas) (equal_to false)
+
+(* ------------------------------------------------------------------ *)
+(* Degenerate inputs                                                    *)
+(* ------------------------------------------------------------------ *)
+
+let test_empty_series_returns_false _ =
+  assert_that
+    (Extension_stop.fired _armed ~closes:[||] ~wmas:[||])
+    (equal_to false)
+
+let test_mismatched_lengths_returns_false _ =
+  assert_that
+    (Extension_stop.fired _armed ~closes:[| 100.0; 120.0; 60.0 |]
+       ~wmas:[| 50.0; 50.0 |])
+    (equal_to false)
+
+let () =
+  run_test_tt_main
+    ("extension_stop"
+    >::: [
+           "default-off never fires" >:: test_default_off_never_fires;
+           "no trigger below ratio never fires" >:: test_no_trigger_below_ratio;
+           "new highs never fire" >:: test_new_highs_never_fire;
+           "collapse below trail fires" >:: test_collapse_below_trail_fires;
+           "shakeout survives wide (0.25) trail"
+           >:: test_shakeout_survives_wide_trail;
+           "shakeout exits tight (0.15) trail"
+           >:: test_shakeout_exits_tight_trail;
+           "NaN-wma warmup cannot trigger"
+           >:: test_nan_wma_warmup_cannot_trigger;
+           "empty series returns false" >:: test_empty_series_returns_false;
+           "mismatched lengths return false"
+           >:: test_mismatched_lengths_returns_false;
+         ])

--- a/trading/trading/weinstein/strategy/lib/extension_stop_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/extension_stop_runner.ml
@@ -47,43 +47,51 @@ let _holding_window_series ~bar_reader ~ma_period ~symbol ~entry_date
   in
   (closes, wmas)
 
+(* [StrategySignal "extension_stop"] with the trigger/trail config in the
+   detail, for the [exit_trigger] forensic column. *)
+let _exit_reason ~config =
+  let detail =
+    Printf.sprintf "trigger=%.2f,trail=%.2f"
+      config.Weinstein_stops.Extension_stop.trigger_ratio
+      config.Weinstein_stops.Extension_stop.trail_pct
+  in
+  Position.StrategySignal { label = "extension_stop"; detail = Some detail }
+
 (* The [TriggerExit] for a fired extension stop: exit at the current bar's close
-   (weekly-close semantics), tagged [StrategySignal "extension_stop"] with the
-   trigger/trail config for the [exit_trigger] forensic column. *)
+   (weekly-close semantics). *)
 let _make_exit_transition ~(pos : Position.t) ~current_date ~bar ~config =
   let exit_price = bar.Types.Daily_price.close_price in
-  let exit_reason =
-    Position.StrategySignal
-      {
-        label = "extension_stop";
-        detail =
-          Some
-            (Printf.sprintf "trigger=%.2f,trail=%.2f"
-               config.Weinstein_stops.Extension_stop.trigger_ratio
-               config.Weinstein_stops.Extension_stop.trail_pct);
-      }
-  in
   {
     Position.position_id = pos.id;
     date = current_date;
-    kind = Position.TriggerExit { exit_reason; exit_price };
+    kind =
+      Position.TriggerExit { exit_reason = _exit_reason ~config; exit_price };
   }
+
+(* Whether the held long's extension trail has fired on its holding-window
+   weekly series. *)
+let _trail_fired ~config ~ma_period ~bar_reader ~current_date ~entry_date
+    (pos : Position.t) =
+  let closes, wmas =
+    _holding_window_series ~bar_reader ~ma_period ~symbol:pos.symbol ~entry_date
+      ~current_date
+  in
+  Weinstein_stops.Extension_stop.fired config ~closes ~wmas
 
 (* Decide whether a held long's extension trail has fired and, if so, emit its
    exit. Skips the position when it is already exiting this tick or has no
    current bar. *)
 let _exit_for_holding ~config ~ma_period ~bar_reader ~skip_position_ids
     ~get_price ~current_date ~entry_date (pos : Position.t) =
-  if Set.mem skip_position_ids pos.Position.id then None
+  let skipped = Set.mem skip_position_ids pos.Position.id in
+  let fired =
+    (not skipped)
+    && _trail_fired ~config ~ma_period ~bar_reader ~current_date ~entry_date pos
+  in
+  if not fired then None
   else
-    let closes, wmas =
-      _holding_window_series ~bar_reader ~ma_period ~symbol:pos.symbol
-        ~entry_date ~current_date
-    in
-    if Weinstein_stops.Extension_stop.fired config ~closes ~wmas then
-      Option.map (get_price pos.symbol) ~f:(fun bar ->
-          _make_exit_transition ~pos ~current_date ~bar ~config)
-    else None
+    Option.map (get_price pos.symbol) ~f:(fun bar ->
+        _make_exit_transition ~pos ~current_date ~bar ~config)
 
 (* Only held LONG positions are eligible — the extension blow-off is a
    long-side phenomenon. *)

--- a/trading/trading/weinstein/strategy/lib/extension_stop_runner.ml
+++ b/trading/trading/weinstein/strategy/lib/extension_stop_runner.ml
@@ -1,0 +1,116 @@
+open Core
+open Trading_strategy
+
+(* Extra weekly bars read beyond the hold length so the trailing WMA window is
+   already filled at the first holding week (the WMA needs [ma_period] prior
+   weeks). *)
+let _wma_window_margin = 4
+
+(* Weekly WMA input on the adjusted-close basis — the same basis as the merged
+   extension screen and Stage's default Wma. *)
+let _ma_input (b : Types.Daily_price.t) =
+  Indicator_types.{ date = b.date; value = b.adjusted_close }
+
+(* WMA value per weekly date; missing until the trailing window fills. *)
+let _wma_by_date ~ma_period weekly =
+  let tbl = Date.Table.create () in
+  Sma.calculate_weighted_ma (List.map weekly ~f:_ma_input) ma_period
+  |> List.iter ~f:(fun iv ->
+      Hashtbl.set tbl ~key:iv.Indicator_types.date
+        ~data:iv.Indicator_types.value);
+  tbl
+
+(* Weekly (adjusted_close, wma30) arrays over the holding window
+   [entry_date, current_date]. Enough weekly bars are read to also fill the
+   trailing WMA window before entry, so early holding weeks carry a real
+   (non-NaN) WMA; [wmas.(i)] is NaN where the window had not yet filled. *)
+let _holding_window_series ~bar_reader ~ma_period ~symbol ~entry_date
+    ~current_date =
+  let weeks_held = (Date.diff current_date entry_date / 7) + 1 in
+  let n = weeks_held + ma_period + _wma_window_margin in
+  let weekly =
+    Bar_reader.weekly_bars_for bar_reader ~symbol ~n ~as_of:current_date
+  in
+  let wma_by_date = _wma_by_date ~ma_period weekly in
+  let in_window =
+    List.filter weekly ~f:(fun b ->
+        Date.( >= ) b.Types.Daily_price.date entry_date)
+  in
+  let closes =
+    Array.of_list_map in_window ~f:(fun b -> b.Types.Daily_price.adjusted_close)
+  in
+  let wmas =
+    Array.of_list_map in_window ~f:(fun b ->
+        Option.value
+          (Hashtbl.find wma_by_date b.Types.Daily_price.date)
+          ~default:Float.nan)
+  in
+  (closes, wmas)
+
+(* The [TriggerExit] for a fired extension stop: exit at the current bar's close
+   (weekly-close semantics), tagged [StrategySignal "extension_stop"] with the
+   trigger/trail config for the [exit_trigger] forensic column. *)
+let _make_exit_transition ~(pos : Position.t) ~current_date ~bar ~config =
+  let exit_price = bar.Types.Daily_price.close_price in
+  let exit_reason =
+    Position.StrategySignal
+      {
+        label = "extension_stop";
+        detail =
+          Some
+            (Printf.sprintf "trigger=%.2f,trail=%.2f"
+               config.Weinstein_stops.Extension_stop.trigger_ratio
+               config.Weinstein_stops.Extension_stop.trail_pct);
+      }
+  in
+  {
+    Position.position_id = pos.id;
+    date = current_date;
+    kind = Position.TriggerExit { exit_reason; exit_price };
+  }
+
+(* Decide whether a held long's extension trail has fired and, if so, emit its
+   exit. Skips the position when it is already exiting this tick or has no
+   current bar. *)
+let _exit_for_holding ~config ~ma_period ~bar_reader ~skip_position_ids
+    ~get_price ~current_date ~entry_date (pos : Position.t) =
+  if Set.mem skip_position_ids pos.Position.id then None
+  else
+    let closes, wmas =
+      _holding_window_series ~bar_reader ~ma_period ~symbol:pos.symbol
+        ~entry_date ~current_date
+    in
+    if Weinstein_stops.Extension_stop.fired config ~closes ~wmas then
+      Option.map (get_price pos.symbol) ~f:(fun bar ->
+          _make_exit_transition ~pos ~current_date ~bar ~config)
+    else None
+
+(* Only held LONG positions are eligible — the extension blow-off is a
+   long-side phenomenon. *)
+let _process_position ~config ~ma_period ~bar_reader ~skip_position_ids
+    ~get_price ~current_date (pos : Position.t) =
+  match (pos.Position.side, Position.get_state pos) with
+  | Trading_base.Types.Long, Position.Holding h ->
+      _exit_for_holding ~config ~ma_period ~bar_reader ~skip_position_ids
+        ~get_price ~current_date ~entry_date:h.entry_date pos
+  | _ -> None
+
+let _fold_position ~config ~ma_period ~bar_reader ~skip_position_ids ~get_price
+    ~current_date acc pos =
+  match
+    _process_position ~config ~ma_period ~bar_reader ~skip_position_ids
+      ~get_price ~current_date pos
+  with
+  | Some t -> t :: acc
+  | None -> acc
+
+let update ~config ~ma_period ~is_screening_day ~positions ~bar_reader
+    ~get_price ~skip_position_ids ~current_date =
+  if
+    (not (Weinstein_stops.Extension_stop.is_enabled config))
+    || (not is_screening_day) || Map.is_empty positions
+  then []
+  else
+    Map.fold positions ~init:[] ~f:(fun ~key:_ ~data:pos acc ->
+        _fold_position ~config ~ma_period ~bar_reader ~skip_position_ids
+          ~get_price ~current_date acc pos)

--- a/trading/trading/weinstein/strategy/lib/extension_stop_runner.mli
+++ b/trading/trading/weinstein/strategy/lib/extension_stop_runner.mli
@@ -1,0 +1,76 @@
+(** Extension-stop exit runner — the strategy-side arm of the extension stop
+    ({!Weinstein_stops.Extension_stop}).
+
+    Each screening cycle, for every held LONG {!Position.t}, replays the weekly
+    bars of its holding window (entry → [current_date]) on the 30-week WMA basis
+    ([ma_period]) and emits a [TriggerExit] when the wide extension trail has
+    fired — i.e. once the weekly close reached [config.trigger_ratio ×] the
+    WMA30 and has since fallen [config.trail_pct] below the post-trigger running
+    peak weekly close. The exit fires at the current bar's close (weekly-close
+    semantics, L3).
+
+    {1 Tail-insurance, not alpha}
+
+    A catastrophic-stop-class dial (#1695 precedent). Extension events are rare
+    (~0.6-1% of episodes), so this is a left-tail insurance mechanism, not a
+    fold-metric lever — see {!Weinstein_stops.Extension_stop} for the acceptance
+    basis and the width evidence.
+
+    {1 Tighten-only (L2)}
+
+    The runner only ever ADDS an exit trigger; it never lowers or replaces the
+    structural trailing stop. A position already exiting this tick via any other
+    channel (stop / force-liq / Stage-3 / laggard / liquidity) is skipped via
+    [skip_position_ids], so an earlier structural exit always wins.
+
+    {1 Default-off}
+
+    No-op when [not (Extension_stop.is_enabled config)] (the default
+    [trigger_ratio = 0.0] / [trail_pct = 0.0]): returns [[]] so every existing
+    golden/baseline replays bit-identically
+    ([.claude/rules/experiment-flag-discipline.md] R1).
+
+    {1 Cadence & side}
+
+    Fires only on a screening day ([is_screening_day], i.e. Friday weekly
+    cadence). LONG positions only — the extension blow-off is a long-side
+    phenomenon. *)
+
+open Core
+open Trading_strategy
+
+val update :
+  config:Weinstein_stops.Extension_stop.config ->
+  ma_period:int ->
+  is_screening_day:bool ->
+  positions:Position.t Map.M(String).t ->
+  bar_reader:Bar_reader.t ->
+  get_price:Strategy_interface.get_price_fn ->
+  skip_position_ids:String.Set.t ->
+  current_date:Core.Date.t ->
+  Position.transition list
+(** [update] iterates over every held LONG {!Position.t} and emits a
+    [TriggerExit] for each whose extension trail has fired.
+
+    {2 Behaviour}
+
+    - Returns [[]] when [not (Extension_stop.is_enabled config)] (the no-op
+      default), when [is_screening_day = false] (weekly cadence only), or when
+      [positions] is empty.
+    - For each held LONG position (in a {!Position.Holding} state): 1. Reads its
+      weekly bars entry → [current_date] via {!Bar_reader.weekly_bars_for}
+      (enough weeks to also fill the trailing WMA window), computes the 30-week
+      WMA ([ma_period]) with {!Sma.calculate_weighted_ma} — the same basis as
+      the merged extension screen — and slices to the holding window. 2. When
+      {!Weinstein_stops.Extension_stop.fired} is [true] on that series, emits a
+      [TriggerExit] with
+      [exit_reason = StrategySignal { label = "extension_stop"; detail = Some
+       "trigger=<r>,trail=<t>" }] and [exit_price = bar.close_price] from
+      [get_price]. 3. Skips the position (no emit) when its [position_id] is in
+      [skip_position_ids] or [get_price] returns [None].
+    - SHORT positions and non-[Holding] states are skipped without emitting.
+
+    Pure aside from the bar reads; holds no per-symbol state (the trail decision
+    is recomputed from the holding window each cycle, which is self-healing —
+    each Friday's replay ends at that Friday, so a fire is detected on its own
+    week). *)

--- a/trading/trading/weinstein/strategy/lib/special_exits.ml
+++ b/trading/trading/weinstein/strategy/lib/special_exits.ml
@@ -111,6 +111,44 @@ let _liquidity_skip_ids ~force_exit_ts ~stop_exited_ids ~stage3_exited_ids
     (Transition_assembly.trigger_exit_ids_of force_exit_ts)
     (Set.union stop_exited_ids (Set.union stage3_exited_ids laggard_exited_ids))
 
+(* Extension-stop special exit: emitted last (after the liquidity exit) and
+   merged into the force-exit channel — same close-fill convention + audit path.
+   Skips every position already exiting this tick via ANY prior channel (stop,
+   force-liq, Stage-3, laggard, liquidity): [skip_ids] is the pre-liquidity union
+   and [force_exit_ts] now carries the prepended liquidity exits, so their union
+   is the full skip set. Tighten-only (L2): the extension stop only ADDS a
+   trigger, so an earlier structural exit always wins. No-op at the default
+   config (extension_stop disabled). Returns the force-exit channel with the
+   extension exits prepended. *)
+let _run_extension_stop_exit ~config ~record_force_exit ~positions
+    ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~skip_ids
+    ~current_date =
+  let extension_ts =
+    Extension_stop_runner.update ~config:config.extension_stop_config
+      ~ma_period:config.stage_config.Stage.ma_period ~is_screening_day:is_friday
+      ~positions ~bar_reader ~get_price ~skip_position_ids:skip_ids
+      ~current_date
+  in
+  List.iter extension_ts
+    ~f:
+      (record_force_exit ~last_stop_out_dates ~positions ~current_date
+         ~cooldown_weeks:0 ~label:"extension_stop");
+  extension_ts
+
+let _run_extension_special_exit ~config ~record_force_exit ~positions
+    ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit ~skip_ids
+    ~force_exit_ts ~current_date =
+  let extension_skip_ids =
+    Set.union skip_ids (Transition_assembly.trigger_exit_ids_of force_exit_ts)
+  in
+  let extension_ts =
+    _run_extension_stop_exit ~config ~record_force_exit ~positions
+      ~last_stop_out_dates ~bar_reader ~get_price ~is_friday
+      ~skip_ids:extension_skip_ids ~current_date
+  in
+  emit_audit extension_ts;
+  extension_ts @ force_exit_ts
+
 (* Build the base force-liquidation channel: run the force-liq runner, then drop
    positions already exiting via a stop this tick. Returns the trimmed channel
    plus the stop-exited id set used to seed the running skip set. *)
@@ -167,6 +205,11 @@ let run ~config ~record_force_exit ~positions ~last_stop_out_dates
   in
   let force_exit_ts =
     _run_liquidity_special_exit ~config ~record_force_exit ~positions
+      ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit
+      ~skip_ids ~force_exit_ts ~current_date
+  in
+  let force_exit_ts =
+    _run_extension_special_exit ~config ~record_force_exit ~positions
       ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit
       ~skip_ids ~force_exit_ts ~current_date
   in

--- a/trading/trading/weinstein/strategy/lib/special_exits.ml
+++ b/trading/trading/weinstein/strategy/lib/special_exits.ml
@@ -165,6 +165,20 @@ let _build_force_exit_channel ~config ~positions ~get_price ~cash ~peak_tracker
   ( Transition_assembly.filter_out_exited_ids stop_exited_ids raw_force_exit_ts,
     stop_exited_ids )
 
+(* The two trailing special exits (liquidity, then extension) share the same
+   emit/merge shape; threading them here keeps [run] under the length cap. *)
+let _run_trailing_special_exits ~config ~record_force_exit ~positions
+    ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit ~skip_ids
+    ~force_exit_ts ~current_date =
+  let force_exit_ts =
+    _run_liquidity_special_exit ~config ~record_force_exit ~positions
+      ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit
+      ~skip_ids ~force_exit_ts ~current_date
+  in
+  _run_extension_special_exit ~config ~record_force_exit ~positions
+    ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit ~skip_ids
+    ~force_exit_ts ~current_date
+
 let run ~config ~record_force_exit ~positions ~last_stop_out_dates
     ~(portfolio : Portfolio_view.t) ~get_price ~peak_tracker ~audit_recorder
     ~prior_macro_result ~prior_stages ~prior_stage_ma_values ~stage3_streaks
@@ -204,12 +218,7 @@ let run ~config ~record_force_exit ~positions ~last_stop_out_dates
       ~laggard_exited_ids
   in
   let force_exit_ts =
-    _run_liquidity_special_exit ~config ~record_force_exit ~positions
-      ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit
-      ~skip_ids ~force_exit_ts ~current_date
-  in
-  let force_exit_ts =
-    _run_extension_special_exit ~config ~record_force_exit ~positions
+    _run_trailing_special_exits ~config ~record_force_exit ~positions
       ~last_stop_out_dates ~bar_reader ~get_price ~is_friday ~emit_audit
       ~skip_ids ~force_exit_ts ~current_date
   in

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.ml
@@ -24,6 +24,7 @@ module Scale_in_detector = Scale_in_detector
 module Scale_in_runner = Scale_in_runner
 module Liquidity_metric = Liquidity_metric
 module Liquidity_exit_runner = Liquidity_exit_runner
+module Extension_stop_runner = Extension_stop_runner
 module Stage3_force_exit = Stage3_force_exit
 module Laggard_rotation = Laggard_rotation
 module Ad_bars = Ad_bars

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy.mli
@@ -154,6 +154,12 @@ module Liquidity_exit_runner = Liquidity_exit_runner
     on Friday ticks when [config.liquidity_config.min_hold_dollar_adv > 0.0].
     See {!Liquidity_exit_runner}. *)
 
+module Extension_stop_runner = Extension_stop_runner
+(** Extension-stop exit runner — the strategy-side arm of the extension
+    tail-insurance stop. Invoked among the special exits on Friday ticks when
+    [config.extension_stop_config] is enabled; LONG-only, weekly-close,
+    tighten-only. See {!Extension_stop_runner}. *)
+
 module Macro_inputs = Macro_inputs
 (** Sector map + global index assembly from accumulated bar history. Exposes the
     canonical {!Macro_inputs.spdr_sector_etfs} and
@@ -548,6 +554,14 @@ type config = {
           (bit-identical single combined walk). Reserves capital for shorts so
           they are not crowded out by longs at the entry walk. See
           [Weinstein_strategy_config]. *)
+  extension_stop_config : Weinstein_stops.Extension_stop.config;
+      [@sexp.default Weinstein_stops.Extension_stop.default_config]
+      (** Extension-stop tail-INSURANCE trail for a held long far above its
+          WMA30; default {!Weinstein_stops.Extension_stop.default_config}
+          ([trigger_ratio = 0.0] / [trail_pct = 0.0]) DISABLES it (bit-identical
+          to baseline). Wired via [Extension_stop_runner] as a special-exit
+          channel (weekly-close, tighten-only). See [Weinstein_strategy_config].
+      *)
   liquidity_config : Liquidity_config.t;
       [@sexp.default Liquidity_config.default_config]
       (** Liquidity-realism overlay parameters (held-position degradation exit +

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.ml
@@ -150,6 +150,12 @@ type config = {
       (** Fraction of portfolio value reserved as a dedicated short-only cash
           budget in the per-Friday entry walk; default [0.0] is a no-op
           (bit-identical single combined walk). See [.mli]. *)
+  extension_stop_config : Weinstein_stops.Extension_stop.config;
+      [@sexp.default Weinstein_stops.Extension_stop.default_config]
+      (** Extension-stop tail-INSURANCE trail for a held long far above its
+          WMA30; default {!Weinstein_stops.Extension_stop.default_config}
+          ([trigger_ratio = 0.0] / [trail_pct = 0.0]) DISABLES it (bit-identical
+          to baseline). Wired via {!Extension_stop_runner}. See [.mli]. *)
   liquidity_config : Liquidity_config.t;
       [@sexp.default Liquidity_config.default_config]
       (** See [.mli]. *)
@@ -221,6 +227,7 @@ let default_config ~universe ~index_symbol =
     enable_harvest_rotate = false;
     harvest_fraction = 0.5;
     short_sleeve_fraction = 0.0;
+    extension_stop_config = Weinstein_stops.Extension_stop.default_config;
     liquidity_config = Liquidity_config.default_config;
     enable_scale_in = false;
     scale_in_config = Scale_in_detector.default_config;

--- a/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
+++ b/trading/trading/weinstein/strategy/lib/weinstein_strategy_config.mli
@@ -451,6 +451,55 @@ type config = {
           Default-off until an experiment-ledger ACCEPT (per
           [.claude/rules/experiment-flag-discipline.md] +
           [.claude/rules/promotion-confirmation.md]). *)
+  extension_stop_config : Weinstein_stops.Extension_stop.config;
+      [@sexp.default Weinstein_stops.Extension_stop.default_config]
+      (** Extension-stop parameters — a wide tail-INSURANCE trail for a held
+          long that has run far above its 30-week WMA (a blow-off / parabolic
+          advance). Wired through {!Extension_stop_runner} as a special-exit
+          channel that emits a [TriggerExit] once the weekly close reached
+          [trigger_ratio ×] the WMA30 and has since fallen [trail_pct] below the
+          post-trigger running peak weekly close (weekly-close semantics, L3).
+
+          {b Tail-insurance, not an alpha axis.} A catastrophic-stop-class dial
+          (same class as [stops_config.catastrophic_stop_pct], #1695), NOT a
+          performance knob. Extension events are rare (~0.6-1% of episodes reach
+          [2.0×] WMA30 over a quarter-century), so a walk-forward CV on this
+          axis is structurally powerless; its acceptance basis is the left-tail
+          / dispersion / event-level audit (armed-vs-off record runs + the
+          [analysis/scripts/extension_screen] counterfactual), {b never} fold
+          Sharpe. User-directed insurance build (2026-07-11): "no way we
+          actually sit through 140→70, even if that would take a manual
+          intervention" — an encoded, tested rule beats an untested panic exit
+          ([dev/backtest/extension-screen-2026-07-11/FINDINGS.md] §"What
+          survives").
+
+          {b Default-off.} Default
+          {!Weinstein_stops.Extension_stop.default_config}
+          ([trigger_ratio = 0.0], [trail_pct = 0.0]) DISABLES the mechanism:
+          {!Extension_stop_runner.update} returns [[]], so every existing
+          golden/baseline replays bit-identically
+          ([.claude/rules/experiment-flag-discipline.md] R1). Set e.g.
+          [((trigger_ratio 2.0) (trail_pct 0.25))] to arm it.
+
+          {b Tighten-only (L2).} The runner only ever ADDS an exit trigger and
+          never lowers or replaces the structural trailing stop; a position
+          already exiting this tick via any other channel is skipped, so an
+          earlier structural exit always wins.
+
+          {b Faithfulness (W2).} A faithful {b trader exit-aggressiveness} dial
+          — on a parabolic advance far above the MA a trader takes profits /
+          swing-sells rather than waiting for the MA violation
+          ([docs/design/weinstein-book-reference.md] §5.3 "Trailing Stop —
+          Trader Method"; §Stage 3 detail Ch. 2 "Traders: exit with profits").
+          The spine is untouched. Screen evidence pins the width:
+          [trail_pct 0.25] survives the on-ramp shakeouts (the AXTI April 2025
+          dip, the January chop) and still banks the collapse; tighter
+          [0.10-0.20] trails are on-ramp killers.
+
+          Searchable as a nested {!Walk_forward.Variant_matrix} axis, e.g.
+          [((key (extension_stop_config trigger_ratio)) (values (2.0 2.25)))].
+          Default-off until an experiment-ledger ACCEPT (per
+          [.claude/rules/experiment-flag-discipline.md]). *)
   liquidity_config : Liquidity_config.t;
       [@sexp.default Liquidity_config.default_config]
       (** Liquidity-realism overlay parameters — the held-position liquidity

--- a/trading/trading/weinstein/strategy/test/dune
+++ b/trading/trading/weinstein/strategy/test/dune
@@ -20,6 +20,7 @@
   test_liquidity_metric
   test_liquidity_gate
   test_liquidity_exit_runner
+  test_extension_stop_runner
   test_spy_only_weinstein_strategy
   test_breaker_spy_strategy
   test_stage3_force_exit_runner

--- a/trading/trading/weinstein/strategy/test/test_extension_stop_runner.ml
+++ b/trading/trading/weinstein/strategy/test/test_extension_stop_runner.ml
@@ -1,0 +1,217 @@
+(** Unit tests for {!Extension_stop_runner} — the strategy-side arm of the
+    extension tail-insurance stop.
+
+    Pins:
+    - Default-off bit-identity: the no-op config leaves a held long untouched.
+    - Fire: a long that ran to [2.0×] its WMA30 and then collapsed [25%] below
+      the post-trigger peak weekly close emits an [extension_stop] TriggerExit
+      at the current close.
+    - Shakeout survival (width): the same run-up with only a ~-17% post-trigger
+      dip is HELD under the [0.25] trail — the screen-pinned reason the build is
+      wide.
+    - Tighten-only (L2) / skip-set: a position already exiting this tick is
+      skipped (an earlier structural exit always wins).
+    - LONG-only: a short is never touched.
+    - Off-cadence (non-screening-day) is a no-op. *)
+
+open OUnit2
+open Core
+open Matchers
+open Weinstein_strategy
+module Extension_stop = Weinstein_stops.Extension_stop
+
+(* ------------------------------------------------------------------ *)
+(* Helpers                                                              *)
+(* ------------------------------------------------------------------ *)
+
+let make_bar date ~close =
+  {
+    Types.Daily_price.date;
+    open_price = close;
+    high_price = close *. 1.01;
+    low_price = close *. 0.99;
+    close_price = close;
+    adjusted_close = close;
+    volume = 1_000_000;
+    active_through = None;
+  }
+
+(* One weekly bar per consecutive Friday, starting 2020-01-03 (a Friday). Each
+   Friday is a distinct ISO week, so [Bar_reader.weekly_bars_for] aggregates one
+   bar per week. *)
+let _friday0 = Date.of_string "2020-01-03"
+let _week_date i = Date.add_days _friday0 (7 * i)
+
+let _weekly_bars closes =
+  List.mapi closes ~f:(fun i c -> make_bar (_week_date i) ~close:c)
+
+(* A 34-week flat base at 20, then a spike to 2.0×+ its WMA, a higher peak, then
+   a collapse 50% below the peak — an extension event that FIRES. Trigger week
+   index 34, peak 35, collapse 36. *)
+let _fire_closes = List.init 34 ~f:(fun _ -> 20.0) @ [ 100.0; 120.0; 60.0 ]
+
+(* Same base + spike + peak, then only a ~-17% post-trigger dip (100 vs peak
+   120), then the parabola resumes — HELD under a 0.25 trail. *)
+let _shakeout_closes =
+  List.init 34 ~f:(fun _ -> 20.0) @ [ 100.0; 120.0; 100.0; 140.0 ]
+
+let _entry_idx = 30
+let _entry_date = _week_date _entry_idx
+let _armed_config = { Extension_stop.trigger_ratio = 2.0; trail_pct = 0.25 }
+let _symbol = "EXT"
+
+(** Build a Holding position for [_symbol] entered on [_entry_date]. Mirrors the
+    helper in [test_liquidity_exit_runner.ml]. *)
+let make_holding_pos ?(side = Trading_base.Types.Long) () =
+  let make_trans kind =
+    {
+      Trading_strategy.Position.position_id = _symbol;
+      date = _entry_date;
+      kind;
+    }
+  in
+  let unwrap = function
+    | Ok p -> p
+    | Error _ -> OUnit2.assert_failure "position setup failed"
+  in
+  let open Trading_strategy.Position in
+  let p =
+    create_entering
+      (make_trans
+         (CreateEntering
+            {
+              symbol = _symbol;
+              side;
+              target_quantity = 10.0;
+              entry_price = 20.0;
+              reasoning = ManualDecision { description = "test" };
+            }))
+    |> unwrap
+  in
+  let p =
+    apply_transition p
+      (make_trans (EntryFill { filled_quantity = 10.0; fill_price = 20.0 }))
+    |> unwrap
+  in
+  apply_transition p
+    (make_trans
+       (EntryComplete
+          {
+            risk_params =
+              {
+                stop_loss_price = None;
+                take_profit_price = None;
+                max_hold_days = None;
+              };
+          }))
+  |> unwrap
+
+let run ?(config = _armed_config) ?(is_screening_day = true)
+    ?(skip_position_ids = String.Set.empty) ?(side = Trading_base.Types.Long)
+    ~closes () =
+  let bars = _weekly_bars closes in
+  let last_bar = List.last_exn bars in
+  let current_date = last_bar.Types.Daily_price.date in
+  let pos = make_holding_pos ~side () in
+  let positions = String.Map.singleton _symbol pos in
+  let bar_reader = Bar_reader.of_in_memory_bars [ (_symbol, bars) ] in
+  let get_price s = if String.equal s _symbol then Some last_bar else None in
+  Extension_stop_runner.update ~config ~ma_period:30 ~is_screening_day
+    ~positions ~bar_reader ~get_price ~skip_position_ids ~current_date
+
+(* ------------------------------------------------------------------ *)
+(* Default-off: no exit at the no-op default                           *)
+(* ------------------------------------------------------------------ *)
+
+let test_default_off_no_exit _ =
+  let result =
+    run ~config:Extension_stop.default_config ~closes:_fire_closes ()
+  in
+  assert_that (List.length result) (equal_to 0)
+
+(* ------------------------------------------------------------------ *)
+(* Fire: collapse 25% below the post-trigger peak emits extension_stop  *)
+(* ------------------------------------------------------------------ *)
+
+let test_collapse_fires_extension_stop _ =
+  let result = run ~closes:_fire_closes () in
+  (* Exit at the current (collapse) weekly close 60.0, tagged extension_stop. *)
+  assert_that result
+    (elements_are
+       [
+         all_of
+           [
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.position_id)
+               (equal_to _symbol);
+             field
+               (fun (t : Trading_strategy.Position.transition) -> t.kind)
+               (matching
+                  ~msg:"Expected TriggerExit StrategySignal extension_stop"
+                  (function
+                    | Trading_strategy.Position.TriggerExit
+                        {
+                          exit_reason =
+                            Trading_strategy.Position.StrategySignal
+                              { label; detail = _ };
+                          exit_price;
+                        } ->
+                        Some (label, exit_price)
+                    | _ -> None)
+                  (all_of
+                     [
+                       field (fun (l, _) -> l) (equal_to "extension_stop");
+                       field (fun (_, p) -> p) (float_equal 60.0);
+                     ]));
+           ];
+       ])
+
+(* ------------------------------------------------------------------ *)
+(* Shakeout survival: a shallow post-trigger dip is HELD (wide trail)   *)
+(* ------------------------------------------------------------------ *)
+
+let test_shakeout_survives_wide_trail _ =
+  let result = run ~closes:_shakeout_closes () in
+  assert_that (List.length result) (equal_to 0)
+
+(* ------------------------------------------------------------------ *)
+(* Tighten-only / skip-set: a position already exiting is skipped       *)
+(* ------------------------------------------------------------------ *)
+
+let test_skip_set_collision_no_op _ =
+  let result =
+    run
+      ~skip_position_ids:(String.Set.singleton _symbol)
+      ~closes:_fire_closes ()
+  in
+  assert_that (List.length result) (equal_to 0)
+
+(* ------------------------------------------------------------------ *)
+(* LONG-only: a short is never touched                                  *)
+(* ------------------------------------------------------------------ *)
+
+let test_short_not_eligible _ =
+  let result = run ~side:Trading_base.Types.Short ~closes:_fire_closes () in
+  assert_that (List.length result) (equal_to 0)
+
+(* ------------------------------------------------------------------ *)
+(* Off-cadence: a non-screening-day call is a no-op                     *)
+(* ------------------------------------------------------------------ *)
+
+let test_off_cadence_no_op _ =
+  let result = run ~is_screening_day:false ~closes:_fire_closes () in
+  assert_that (List.length result) (equal_to 0)
+
+let () =
+  run_test_tt_main
+    ("extension_stop_runner"
+    >::: [
+           "default-off: no exit" >:: test_default_off_no_exit;
+           "collapse fires extension_stop"
+           >:: test_collapse_fires_extension_stop;
+           "shakeout survives wide (0.25) trail"
+           >:: test_shakeout_survives_wide_trail;
+           "skip-set collision is a no-op" >:: test_skip_set_collision_no_op;
+           "short not eligible" >:: test_short_not_eligible;
+           "off-cadence is a no-op" >:: test_off_cadence_no_op;
+         ])


### PR DESCRIPTION
## What

A default-off **extension stop** (P0a, user-directed 2026-07-11): a wide
tail-INSURANCE trail for a held LONG that has run far above its 30-week WMA (a
blow-off / parabolic advance). Once the weekly close reaches `trigger_ratio ×`
the WMA30 the position arms a wide trail; thereafter it exits on the first
weekly close that is `trail_pct` below the post-trigger running peak weekly
close. Weekly-close semantics (L3), tighten-only (L2).

- **`weinstein/stops/lib/extension_stop.{ml,mli}`** — pure `config { trigger_ratio; trail_pct }` (both default `0.0` = disabled) + `fired config ~closes ~wmas`. Trigger / peak / fire logic mirrors the merged extension screen (`analysis/scripts/extension_screen`) exactly. Registered as `Weinstein_stops.Extension_stop`.
- **`weinstein/strategy/lib/extension_stop_runner.{ml,mli}`** — Friday-gated, LONG-only special-exit runner. Replays each held long's holding window on the WMA30 basis (`Sma.calculate_weighted_ma`), emits a `TriggerExit` (`StrategySignal "extension_stop"`) at the current weekly close when the trail fires; skips positions already exiting this tick.
- Wired into `special_exits.ml` after the liquidity exit, sharing the full same-tick skip-set union (stop / force-liq / Stage-3 / laggard / liquidity) — so an earlier structural exit always wins (tighten-only).
- Config field `extension_stop_config : Weinstein_stops.Extension_stop.config` (default no-op) in `Weinstein_strategy.config`; a nested `Variant_matrix` axis resolvable through `Overlay_validator.apply_overrides`.

## Why

User-directed insurance build (2026-07-11 PM): "no way we actually sit through
140→70, even if that would take a manual intervention" — an encoded, tested
rule beats an untested panic exit. The event-level screen
(`dev/backtest/extension-screen-2026-07-11/FINDINGS.md`) found extension events
are rare (~0.6-1% of episodes reach 2.0× WMA30 over a quarter-century), so a
WF-CV is structurally powerless — this is a **catastrophic-stop-class
tail-INSURANCE dial** (#1695 precedent), NOT an alpha axis. Acceptance basis is
the left-tail / event-level audit, never fold Sharpe. Screen pins the width:
`trail_pct 0.25` survives the on-ramp shakeouts (AXTI April dip, January chop);
`0.10-0.20` are on-ramp killers — do NOT build tight.

## Default-off (experiment-flag-discipline R1)

Default `Extension_stop.default_config` (`trigger_ratio = 0.0` / `trail_pct = 0.0`)
DISABLES the mechanism — the runner returns `[]`, so **merging this PR changes
no backtest result** and every existing golden/baseline replays bit-identically.
Searchable as a `Variant_matrix` axis the day it lands (R2). No default flip
until an insurance-basis ACCEPT (R3).

## Faithfulness (W2)

A faithful **trader exit-aggressiveness** dial — on a parabolic advance far
above the MA a trader takes profits / swing-sells rather than waiting for the MA
violation (`docs/design/weinstein-book-reference.md` §5.3 "Trailing Stop —
Trader Method"; §Stage 3 detail Ch. 2 "Traders: exit with profits"). The
strategy spine is untouched — stage classification, Stage-2-only entry,
breakout+volume, macro/sector gate, and RS are all unaffected; a held long
simply gains one extra discretionary weekly-close exit trigger.

## Test plan

- `test_extension_stop.ml` (9 tests, PASS): default-off never fires; no trigger below ratio; new highs never fire; collapse below trail fires; **shakeout width** (a ~-18% post-trigger dip survives 0.25 but exits 0.15); NaN-wma warmup cannot trigger; empty / mismatched arrays return false.
- `test_extension_stop_runner.ml` (6 tests, PASS): default-off no exit; collapse fires `extension_stop` at the current close; shakeout survives the wide trail; skip-set collision is a no-op (tighten-only); LONG-only (short not touched); off-cadence no-op.
- `test_runner_hypothesis_overrides.ml` (+3, PASS): `extension_stop_config` default is no-op; nested override round-trips through sexp; nested axis resolves through the real `Overlay_validator.apply_overrides`.

Note: 8 pre-existing `test_runner_hypothesis_overrides` runner-integration tests
error locally on a missing `data/backtest_scenarios/` fixture (absent in this
environment); they are untouched by this PR and pass on CI where the fixtures
exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)