### PR TITLE
feat(universe): asset-type blocklist filter (default-off) — CEF/trust/SPAC leak

### DIFF
--- a/dev/status/data-foundations.md
+++ b/dev/status/data-foundations.md
@@ -1,11 +1,40 @@
 # Status: data-foundations
 
-## Last updated: 2026-07-01
+## Last updated: 2026-07-12
 
 ## Status
 IN_PROGRESS
 
 ## Completed
+- [x] **2026-07-12 — asset-type blocklist filter (CEF/trust/SPAC leak, W14;
+  fix #3 of `dev/notes/visual-trade-audit-2026-07-12.md`).** EODHD's
+  exchange-symbol-list `Type` field mislabels bond/equity CEFs and
+  physical-bullion trusts as "Common Stock", so
+  `Build_eligible_universe`'s equity-like filter admitted them — FTHY
+  (bond CEF) surfaced as a top-7 live pick; PHYS/PSLV (bullion trusts)
+  and ~50 CEFs leaked. Added a new pure module
+  `analysis/data/universe/lib/asset_type_blocklist.{ml,mli}`: a
+  symbol→`category` (`Bond_cef | Equity_cef | Bullion_trust | Spac`)
+  blocklist that drops mislabelled instruments independent of the wrong
+  vendor `Type`. Membership from three interchangeable sources —
+  `curated` (embedded checked-in seed, 22 tickers), `load ~path` (sexp
+  file), or `of_entries` (the feed point for a future `General::Type`
+  fundamentals enrichment; `union` merges). Wired into
+  `Build_eligible_universe.config` as a new
+  `asset_type_blocklist : Asset_type_blocklist.t [@sexp.default empty]`
+  field applied before the composition policy; **default `empty` in both
+  `default_config` and `spec_config` keeps the build bit-identical**
+  (experiment-flag-discipline R1) — arming live with `curated` is a
+  separate decision. SPAC coverage intentionally minimal (ephemeral
+  tickers → follow-up: heuristic/fundamentals gate). Tests: 16 in
+  `test/test_asset_type_blocklist.ml` (find/is_blocked/case-insensitive,
+  dup-last-wins, sorted entries, union precedence, curated blocks
+  FTHY/PHYS/PSLV, load from committed fixture
+  `test/data/asset_type_blocklist_sample.sexp`, missing-file error,
+  sexp round-trip) + 2 wiring tests in `test/test_build_eligible_universe.ml`
+  (armed blocklist drops FTHY; empty blocklist is a no-op). Verify:
+  `dune build && dune runtest analysis/data/universe/`. PR:
+  `feat/universe-asset-type-filter`.
 - [x] **2026-06-29 — eligible-universe staleness guard (issue #1783).**
   `Build_eligible_universe`'s active filter dropped any symbol whose
   last bar was even one trading day stale (`data_end_date < date`),

--- a/trading/analysis/data/universe/lib/asset_type_blocklist.ml
+++ b/trading/analysis/data/universe/lib/asset_type_blocklist.ml
@@ -1,0 +1,76 @@
+open Core
+
+type category = Bond_cef | Equity_cef | Bullion_trust | Spac
+[@@deriving sexp, eq, show]
+
+type entry = { symbol : string; category : category }
+[@@deriving sexp, eq, show]
+
+(* Internal representation: uppercased-symbol -> category. Hashtbl gives O(1)
+   membership; the public sexp form is the deterministic sorted [entry] list
+   (see [sexp_of_t]) so a [t] serialises stably as a config field. *)
+type t = (string, category) Hashtbl.t
+
+let empty : t = Hashtbl.create (module String)
+
+let _add tbl { symbol; category } =
+  Hashtbl.set tbl ~key:(String.uppercase symbol) ~data:category
+
+let of_entries entries : t =
+  let tbl = Hashtbl.create (module String) in
+  List.iter entries ~f:(_add tbl);
+  tbl
+
+let find t ~symbol = Hashtbl.find t (String.uppercase symbol)
+let is_blocked t ~symbol = Option.is_some (find t ~symbol)
+let size t = Hashtbl.length t
+
+let entries t : entry list =
+  Hashtbl.to_alist t
+  |> List.map ~f:(fun (symbol, category) -> { symbol; category })
+  |> List.sort ~compare:(fun a b -> String.compare a.symbol b.symbol)
+
+let union a b : t =
+  let tbl = Hashtbl.copy a in
+  Hashtbl.iteri b ~f:(fun ~key ~data -> Hashtbl.set tbl ~key ~data);
+  tbl
+
+let sexp_of_t t = [%sexp_of: entry list] (entries t)
+let t_of_sexp sexp = of_entries ([%of_sexp: entry list] sexp)
+
+let load ~path : t Status.status_or =
+  try Ok (t_of_sexp (Sexp.load_sexp path)) with
+  | Sys_error msg | Failure msg ->
+      Status.error_internal ("asset_type_blocklist: load: " ^ msg)
+  | Sexp.Of_sexp_error (exn, _) ->
+      Status.error_internal
+        ("asset_type_blocklist: decode: " ^ Exn.to_string exn)
+
+(* ------------------------------------------------------------------ *)
+(* Curated seed — the checked-in source of record.                     *)
+(*                                                                     *)
+(* Every entry is a real instrument EODHD mislabels as "Common Stock". *)
+(* Extend this list (grouped by category) as new leaks are found. SPAC *)
+(* shells are intentionally omitted: their tickers are ephemeral (they *)
+(* de-SPAC or liquidate), so hand-curating them goes stale fast — the  *)
+(* [Spac] category is reserved for a heuristic / fundamentals feed via *)
+(* [of_entries] (see the .mli). *)
+(* ------------------------------------------------------------------ *)
+
+let _bond_cefs =
+  [ "FTHY"; "PDI"; "PTY"; "PCN"; "PML"; "PFN"; "PFL"; "RCS"; "DSL"; "NAD" ]
+
+let _equity_cefs = [ "ADX"; "GAB"; "CET"; "USA"; "STK"; "ETV"; "ETY"; "EOS" ]
+let _bullion_trusts = [ "PHYS"; "PSLV"; "CEF"; "SPPP" ]
+
+let _seed category symbols =
+  List.map symbols ~f:(fun symbol -> { symbol; category })
+
+let curated : t =
+  of_entries
+    (List.concat
+       [
+         _seed Bond_cef _bond_cefs;
+         _seed Equity_cef _equity_cefs;
+         _seed Bullion_trust _bullion_trusts;
+       ])

--- a/trading/analysis/data/universe/lib/asset_type_blocklist.mli
+++ b/trading/analysis/data/universe/lib/asset_type_blocklist.mli
@@ -1,0 +1,108 @@
+(** Curated asset-type exclusion blocklist for universe construction.
+
+    {1 Why this exists}
+
+    EODHD's [/api/exchange-symbol-list] [Type] field mislabels a large class of
+    non-equity instruments as ["Common Stock"] — bond closed-end funds (CEFs),
+    equity CEFs, physical-bullion trusts, and SPAC shells. Because
+    {!Eodhd.Asset_type.of_eodhd_string} therefore parses them as
+    {!Eodhd.Asset_type.Common_stock}, the {!Build_eligible_universe} equity-like
+    filter admits them: FTHY (a bond CEF) has surfaced as a top live pick, and
+    PHYS / PSLV (bullion trusts) and dozens of bond / equity CEFs leak into the
+    tradeable universe. None of these are Weinstein-stage-tradeable operating
+    companies.
+
+    This module is a second, {b symbol-level} exclusion layer that catches those
+    mislabelled instruments by an explicit curated list, independent of the
+    (wrong) vendor [Type]. A blocklisted symbol is dropped from the universe
+    regardless of what EODHD calls it.
+
+    {1 Sources of membership}
+
+    A {!t} is a [symbol -> category] map. Three ways to populate one, all
+    equivalent downstream:
+
+    - {!curated} — the checked-in, hand-maintained seed. This is the source of
+      record today; extend it in [asset_type_blocklist.ml] as new leaks are
+      found.
+    - {!load} — parse a sexp file of {!entry} values, for a larger externally
+      maintained list without a code change.
+    - {!of_entries} — build directly from an {!entry} list. This is the intended
+      feed point for a future fundamentals enrichment: mapping EODHD's
+      [General::Type] (e.g. ["CLOSED-END FUND"]) to a {!category} yields an
+      {!entry} list that becomes a {!t} here, with no change to the exclusion
+      logic. {!union} combines such a derived set with {!curated}.
+
+    {1 Default is a no-op}
+
+    {!empty} blocks nothing, so a universe build wired with {!empty} is
+    bit-identical to one with no blocklist at all — per
+    [.claude/rules/experiment-flag-discipline.md] R1, the filter is inert until
+    a caller supplies a non-empty {!t}. Arming the live universe with {!curated}
+    is a separate decision, not this module's default. *)
+
+(** The kind of non-equity instrument a blocklisted symbol is. Kept distinct
+    from {!Eodhd.Asset_type.t} on purpose: these are exactly the instruments the
+    vendor {i mis}classifies, so the category records what the symbol truly is,
+    not what EODHD labels it. *)
+type category =
+  | Bond_cef  (** Closed-end fund holding bonds / fixed income. *)
+  | Equity_cef  (** Closed-end fund holding equities. *)
+  | Bullion_trust  (** Physical precious-metal trust (gold / silver / PGM). *)
+  | Spac
+      (** Special-purpose acquisition company shell (pre-merger blank check). *)
+[@@deriving sexp, eq, show]
+
+type entry = { symbol : string; category : category }
+[@@deriving sexp, eq, show]
+(** One blocklist member: the ticker and why it is excluded. Symbol matching is
+    case-insensitive (see {!find}); the stored form is uppercased. *)
+
+type t [@@deriving sexp]
+(** An immutable blocklist: a set of symbols, each tagged with its {!category}.
+    Round-trips through sexp as a sorted {!entry} list, so a {!t} can be a
+    [[@@deriving sexp]] config field. *)
+
+val empty : t
+(** The no-op blocklist: {!is_blocked} is [false] for every symbol. A build
+    filtered with {!empty} is bit-identical to an unfiltered build. *)
+
+val of_entries : entry list -> t
+(** [of_entries entries] builds a blocklist from [entries]. Symbols are
+    uppercased on insertion; on a duplicate symbol the last entry wins. This is
+    the feed point for a fundamentals-derived blocklist (map [General::Type] to
+    a {!category}, then call this). *)
+
+val load : path:string -> t Status.status_or
+(** [load ~path] parses a sexp file whose top-level form is an {!entry} list —
+    e.g.
+    [(((symbol FTHY) (category Bond_cef)) ((symbol PHYS) (category
+     Bullion_trust)))]. Returns [Error Status.Internal] on read or decode
+    failure. *)
+
+val curated : t
+(** The checked-in curated seed — the source of record for known mislabelled
+    CEFs / bullion trusts. SPAC coverage is intentionally minimal here (SPAC
+    tickers are ephemeral and better served by a heuristic / fundamentals feed);
+    the {!Spac} category exists so such a feed can populate it via
+    {!of_entries}. *)
+
+val find : t -> symbol:string -> category option
+(** [find t ~symbol] is the symbol's {!category} if blocklisted, else [None].
+    Case-insensitive. *)
+
+val is_blocked : t -> symbol:string -> bool
+(** [is_blocked t ~symbol] is [true] iff [symbol] is in the blocklist.
+    Case-insensitive; equivalent to [Option.is_some (find t ~symbol)]. *)
+
+val union : t -> t -> t
+(** [union a b] is the blocklist containing every symbol in either [a] or [b].
+    On a symbol present in both, [b]'s category wins. Use to combine {!curated}
+    with a derived (e.g. fundamentals) blocklist. *)
+
+val entries : t -> entry list
+(** [entries t] is the blocklist as an {!entry} list, sorted by symbol for
+    determinism. *)
+
+val size : t -> int
+(** [size t] is the number of blocklisted symbols. *)

--- a/trading/analysis/data/universe/lib/build_eligible_universe.ml
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.ml
@@ -35,10 +35,8 @@ type config = {
   reit_policy : CPT.reit_policy;
   exclude_preferred : bool;
   asset_type_blocklist : ATB.t; [@sexp.default ATB.empty]
-      (* Symbol-level exclusion of instruments EODHD mislabels as common stock
-         (bond / equity CEFs, bullion trusts). No-op default [ATB.empty] keeps
-         the build bit-identical; arming it (e.g. [ATB.curated]) is a separate
-         decision. *)
+      (* EODHD-mislabeled non-equities; [ATB.empty] = bit-identical no-op.
+         Documented in build_eligible_universe.mli. *)
   bars_root : string;
   symbol_types_path : string;
   sectors_csv_path : string;
@@ -216,9 +214,8 @@ let _policy_config ~config : CPT.config =
     exclude_preferred = config.exclude_preferred;
   }
 
-(* Drop candidates whose symbol is in the asset-type blocklist (instruments
-   EODHD mislabels as common stock). A no-op when the blocklist is empty (the
-   default), so the pre-blocklist behaviour is preserved bit-for-bit. *)
+(* Drop blocklisted symbols; empty blocklist (the default) is a bit-identical
+   no-op. *)
 let _apply_blocklist ~config (candidates : CPT.candidate list) =
   if ATB.size config.asset_type_blocklist = 0 then candidates
   else

--- a/trading/analysis/data/universe/lib/build_eligible_universe.ml
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.ml
@@ -5,6 +5,7 @@ module BFI = Build_from_individuals
 module CP = Composition_policy
 module CPT = Composition_policy_types
 module S = Staleness
+module ATB = Asset_type_blocklist
 
 (* Defaults documented in [build_eligible_universe.mli]. *)
 let _default_trailing_window_days = 60
@@ -33,6 +34,11 @@ type config = {
   min_window_bars : int;
   reit_policy : CPT.reit_policy;
   exclude_preferred : bool;
+  asset_type_blocklist : ATB.t; [@sexp.default ATB.empty]
+      (* Symbol-level exclusion of instruments EODHD mislabels as common stock
+         (bond / equity CEFs, bullion trusts). No-op default [ATB.empty] keeps
+         the build bit-identical; arming it (e.g. [ATB.curated]) is a separate
+         decision. *)
   bars_root : string;
   symbol_types_path : string;
   sectors_csv_path : string;
@@ -56,6 +62,7 @@ let default_config ~bars_root ~symbol_types_path ~sectors_csv_path
     min_window_bars = _default_min_window_bars;
     reit_policy = CPT.Include;
     exclude_preferred = false;
+    asset_type_blocklist = ATB.empty;
     bars_root;
     symbol_types_path;
     sectors_csv_path;
@@ -209,6 +216,15 @@ let _policy_config ~config : CPT.config =
     exclude_preferred = config.exclude_preferred;
   }
 
+(* Drop candidates whose symbol is in the asset-type blocklist (instruments
+   EODHD mislabels as common stock). A no-op when the blocklist is empty (the
+   default), so the pre-blocklist behaviour is preserved bit-for-bit. *)
+let _apply_blocklist ~config (candidates : CPT.candidate list) =
+  if ATB.size config.asset_type_blocklist = 0 then candidates
+  else
+    List.filter candidates ~f:(fun c ->
+        not (ATB.is_blocked config.asset_type_blocklist ~symbol:c.CPT.symbol))
+
 (* ------------------------------------------------------------------ *)
 (* Snapshot assembly                                                   *)
 (* ------------------------------------------------------------------ *)
@@ -256,7 +272,10 @@ let _build_validated ~date ~config ~inventory ~equity_like_lookup
     List.filter active ~f:(_is_equity_like ~equity_like_lookup)
   in
   let eligible = _score_all ~date ~config equity_like in
-  let candidates = _to_candidates ~asset_type_lookup ~sector_lookup eligible in
+  let candidates =
+    _to_candidates ~asset_type_lookup ~sector_lookup eligible
+    |> _apply_blocklist ~config
+  in
   let { CPT.kept; reports = _ } =
     CP.apply ~config:(_policy_config ~config) candidates
   in

--- a/trading/analysis/data/universe/lib/build_eligible_universe.mli
+++ b/trading/analysis/data/universe/lib/build_eligible_universe.mli
@@ -25,7 +25,11 @@
 
     2. {b Equity-like filter} — drop ETF / Mutual_fund / Fund / Bond / Index /
     Currency / Commodity via {!Eodhd.Asset_type.is_equity_like}; keeps
-    Common_stock / Preferred_stock / ADR / GDR.
+    Common_stock / Preferred_stock / ADR / GDR. Then drop any symbol in the
+    configured {!Asset_type_blocklist} — instruments (bond / equity CEFs,
+    bullion trusts) EODHD {i mis}labels as common stock so the equity-like
+    filter alone lets them through. Empty by default, so this is a no-op unless
+    armed.
 
     3. {b Eligibility gates} (all configurable, see {!config}): drop symbols
     whose latest close is below [min_price], whose trailing-window average
@@ -93,6 +97,16 @@ type config = {
   exclude_preferred : bool;
       (** Passed through to {!Composition_policy}. No-op default [false]; spec
           uses [true]. *)
+  asset_type_blocklist : Asset_type_blocklist.t;
+      (** Symbol-level exclusion of instruments EODHD mislabels as
+          ["Common Stock"] — bond / equity closed-end funds and physical-bullion
+          trusts (see {!Asset_type_blocklist}). Blocked symbols are dropped
+          before the composition policy runs. No-op default
+          {!Asset_type_blocklist.empty} (both {!default_config} and
+          {!spec_config}) keeps the build bit-identical to the pre-blocklist
+          behaviour — per [.claude/rules/experiment-flag-discipline.md] R1,
+          arming the live universe with {!Asset_type_blocklist.curated} is a
+          separate decision. *)
   bars_root : string;
       (** Root of cached bars ([<L1>/<L2>/<symbol>/data.csv]). *)
   symbol_types_path : string;  (** Path to [symbol_types.sexp]. *)
@@ -111,7 +125,8 @@ val default_config :
 (** [default_config ...] is the keep-all no-op: [min_price = 0.0],
     [min_avg_dollar_volume = 0.0], [max_staleness_trading_days = 0],
     [trailing_window_days = 60], [min_window_bars = 30],
-    [reit_policy = Include], [exclude_preferred = false]. A build through this
+    [reit_policy = Include], [exclude_preferred = false],
+    [asset_type_blocklist = Asset_type_blocklist.empty]. A build through this
     config keeps every active equity-like symbol (the only drop is the always-on
     dual-class dedup). *)
 
@@ -124,7 +139,10 @@ val spec_config :
 (** [spec_config ...] is {!default_config} with the live-universe gates flipped
     on: [min_price = 5.0], [min_avg_dollar_volume = 1_000_000.0],
     [reit_policy = Exclude], [exclude_preferred = true].
-    [max_staleness_trading_days] stays at the no-op [0]. *)
+    [max_staleness_trading_days] stays at the no-op [0], and
+    [asset_type_blocklist] stays at the no-op {!Asset_type_blocklist.empty} —
+    arming the live universe against the curated blocklist is a separate
+    decision. *)
 
 type staleness_report = { excluded_count : int; sample : string list }
 [@@deriving sexp, show, eq]

--- a/trading/analysis/data/universe/lib/dune
+++ b/trading/analysis/data/universe/lib/dune
@@ -10,6 +10,7 @@
   composition_inputs
   composition_bar_reader
   composition_policy_types
+  asset_type_blocklist
   dual_class
   composition_policy
   composition_policy_report

--- a/trading/analysis/data/universe/test/data/asset_type_blocklist_malformed.sexp
+++ b/trading/analysis/data/universe/test/data/asset_type_blocklist_malformed.sexp
@@ -1,0 +1,1 @@
+(((symbol FTHY) (category Not_a_real_category)))

--- a/trading/analysis/data/universe/test/data/asset_type_blocklist_sample.sexp
+++ b/trading/analysis/data/universe/test/data/asset_type_blocklist_sample.sexp
@@ -1,0 +1,4 @@
+(((symbol FTHY) (category Bond_cef))
+ ((symbol PHYS) (category Bullion_trust))
+ ((symbol PSLV) (category Bullion_trust))
+ ((symbol GAB) (category Equity_cef)))

--- a/trading/analysis/data/universe/test/dune
+++ b/trading/analysis/data/universe/test/dune
@@ -3,6 +3,7 @@
   test_snapshot
   test_build_from_index
   test_build_from_individuals
+  test_asset_type_blocklist
   test_build_eligible_universe
   test_build_synthetic_universes_runner
   test_build_composition_universes_runner
@@ -13,6 +14,8 @@
   test_apply_composition_policy_runner
   test_enrich_composition_volume_runner
   test_cross_validation)
+ (deps
+  (glob_files data/*.sexp))
  (libraries
   apply_composition_policy_runner_lib
   build_composition_universes_runner_lib

--- a/trading/analysis/data/universe/test/test_asset_type_blocklist.ml
+++ b/trading/analysis/data/universe/test/test_asset_type_blocklist.ml
@@ -1,0 +1,185 @@
+open Core
+open OUnit2
+open Matchers
+module ATB = Universe.Asset_type_blocklist
+
+(* ---------------------------------------------------------------------- *)
+(* empty is a true no-op                                                    *)
+(* ---------------------------------------------------------------------- *)
+
+let test_empty_size_zero _ = assert_that (ATB.size ATB.empty) (equal_to 0)
+
+let test_empty_is_blocked_false _ =
+  assert_that (ATB.is_blocked ATB.empty ~symbol:"FTHY") (equal_to false)
+
+(* ---------------------------------------------------------------------- *)
+(* of_entries / find / is_blocked                                          *)
+(* ---------------------------------------------------------------------- *)
+
+let _entries =
+  [
+    { ATB.symbol = "FTHY"; category = ATB.Bond_cef };
+    { ATB.symbol = "PHYS"; category = ATB.Bullion_trust };
+    { ATB.symbol = "GAB"; category = ATB.Equity_cef };
+  ]
+
+let test_find_returns_category _ =
+  let t = ATB.of_entries _entries in
+  assert_that (ATB.find t ~symbol:"FTHY") (is_some_and (equal_to ATB.Bond_cef))
+
+let test_find_absent_is_none _ =
+  let t = ATB.of_entries _entries in
+  assert_that (ATB.find t ~symbol:"AAPL") is_none
+
+(* Symbol matching is case-insensitive: the stored form is uppercased and the
+   lookup uppercases its argument. *)
+let test_find_is_case_insensitive _ =
+  let t = ATB.of_entries [ { ATB.symbol = "fthy"; category = ATB.Bond_cef } ] in
+  assert_that (ATB.find t ~symbol:"FtHy") (is_some_and (equal_to ATB.Bond_cef))
+
+let test_is_blocked _ =
+  let t = ATB.of_entries _entries in
+  assert_that
+    (List.map [ "PHYS"; "AAPL" ] ~f:(fun symbol -> ATB.is_blocked t ~symbol))
+    (elements_are [ equal_to true; equal_to false ])
+
+(* On a duplicate symbol the last entry wins. *)
+let test_duplicate_last_wins _ =
+  let t =
+    ATB.of_entries
+      [
+        { ATB.symbol = "X"; category = ATB.Bond_cef };
+        { ATB.symbol = "X"; category = ATB.Equity_cef };
+      ]
+  in
+  assert_that (ATB.find t ~symbol:"X") (is_some_and (equal_to ATB.Equity_cef))
+
+(* ---------------------------------------------------------------------- *)
+(* entries is sorted + size                                                *)
+(* ---------------------------------------------------------------------- *)
+
+let test_entries_sorted_by_symbol _ =
+  let t = ATB.of_entries _entries in
+  assert_that
+    (List.map (ATB.entries t) ~f:(fun e -> e.ATB.symbol))
+    (elements_are [ equal_to "FTHY"; equal_to "GAB"; equal_to "PHYS" ])
+
+let test_size _ = assert_that (ATB.size (ATB.of_entries _entries)) (equal_to 3)
+
+(* ---------------------------------------------------------------------- *)
+(* union                                                                   *)
+(* ---------------------------------------------------------------------- *)
+
+let test_union_size_and_precedence _ =
+  let a =
+    ATB.of_entries
+      [
+        { ATB.symbol = "A"; category = ATB.Bond_cef };
+        { ATB.symbol = "SHARED"; category = ATB.Bond_cef };
+      ]
+  in
+  let b =
+    ATB.of_entries
+      [
+        { ATB.symbol = "B"; category = ATB.Equity_cef };
+        { ATB.symbol = "SHARED"; category = ATB.Bullion_trust };
+      ]
+  in
+  let u = ATB.union a b in
+  assert_that u
+    (all_of
+       [
+         field (fun u -> ATB.size u) (equal_to 3);
+         field
+           (fun u -> ATB.find u ~symbol:"SHARED")
+           (is_some_and (equal_to ATB.Bullion_trust));
+       ])
+
+(* ---------------------------------------------------------------------- *)
+(* curated seed                                                            *)
+(* ---------------------------------------------------------------------- *)
+
+(* The curated seed catches the specific leaks that motivated this module. *)
+let test_curated_blocks_known_leaks _ =
+  assert_that
+    (List.map [ "FTHY"; "PHYS"; "PSLV" ] ~f:(fun symbol ->
+         ATB.is_blocked ATB.curated ~symbol))
+    (elements_are [ equal_to true; equal_to true; equal_to true ])
+
+(* A genuine operating company is not in the curated blocklist. *)
+let test_curated_allows_common_stock _ =
+  assert_that (ATB.is_blocked ATB.curated ~symbol:"AAPL") (equal_to false)
+
+let test_curated_categories _ =
+  assert_that
+    (List.map [ "FTHY"; "GAB"; "PHYS" ] ~f:(fun symbol ->
+         ATB.find ATB.curated ~symbol))
+    (elements_are
+       [
+         is_some_and (equal_to ATB.Bond_cef);
+         is_some_and (equal_to ATB.Equity_cef);
+         is_some_and (equal_to ATB.Bullion_trust);
+       ])
+
+(* ---------------------------------------------------------------------- *)
+(* load from a committed sexp fixture                                      *)
+(* ---------------------------------------------------------------------- *)
+
+let _fixture_path = "data/asset_type_blocklist_sample.sexp"
+
+let test_load_parses_fixture _ =
+  match ATB.load ~path:_fixture_path with
+  | Error err -> assert_failure ("load failed: " ^ Status.show err)
+  | Ok t ->
+      assert_that t
+        (all_of
+           [
+             field (fun t -> ATB.size t) (equal_to 4);
+             field
+               (fun t -> ATB.find t ~symbol:"FTHY")
+               (is_some_and (equal_to ATB.Bond_cef));
+             field
+               (fun t -> ATB.find t ~symbol:"GAB")
+               (is_some_and (equal_to ATB.Equity_cef));
+           ])
+
+let test_load_missing_file_is_error _ =
+  assert_that
+    (ATB.load ~path:"data/does_not_exist.sexp")
+    (is_error_with Status.Internal)
+
+(* sexp round-trip: to-sexp then of-sexp preserves membership + categories. *)
+let test_sexp_round_trip _ =
+  let t = ATB.of_entries _entries in
+  let round = ATB.t_of_sexp (ATB.sexp_of_t t) in
+  assert_that
+    (List.map (ATB.entries round) ~f:(fun e -> (e.ATB.symbol, e.ATB.category)))
+    (elements_are
+       [
+         equal_to ("FTHY", ATB.Bond_cef);
+         equal_to ("GAB", ATB.Equity_cef);
+         equal_to ("PHYS", ATB.Bullion_trust);
+       ])
+
+let suite =
+  "Asset_type_blocklist"
+  >::: [
+         "test_empty_size_zero" >:: test_empty_size_zero;
+         "test_empty_is_blocked_false" >:: test_empty_is_blocked_false;
+         "test_find_returns_category" >:: test_find_returns_category;
+         "test_find_absent_is_none" >:: test_find_absent_is_none;
+         "test_find_is_case_insensitive" >:: test_find_is_case_insensitive;
+         "test_is_blocked" >:: test_is_blocked;
+         "test_duplicate_last_wins" >:: test_duplicate_last_wins;
+         "test_entries_sorted_by_symbol" >:: test_entries_sorted_by_symbol;
+         "test_size" >:: test_size;
+         "test_union_size_and_precedence" >:: test_union_size_and_precedence;
+         "test_curated_blocks_known_leaks" >:: test_curated_blocks_known_leaks;
+         "test_curated_allows_common_stock" >:: test_curated_allows_common_stock;
+         "test_curated_categories" >:: test_curated_categories;
+         "test_load_parses_fixture" >:: test_load_parses_fixture;
+         "test_load_missing_file_is_error" >:: test_load_missing_file_is_error;
+         "test_sexp_round_trip" >:: test_sexp_round_trip;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/analysis/data/universe/test/test_asset_type_blocklist.ml
+++ b/trading/analysis/data/universe/test/test_asset_type_blocklist.ml
@@ -148,6 +148,14 @@ let test_load_missing_file_is_error _ =
     (ATB.load ~path:"data/does_not_exist.sexp")
     (is_error_with Status.Internal)
 
+(* Pins the decode arm of [load]: a readable file whose sexp does not
+   match the entry-list shape (unknown category variant) must be
+   [Error Internal], not an exception. *)
+let test_load_malformed_sexp_is_error _ =
+  assert_that
+    (ATB.load ~path:"data/asset_type_blocklist_malformed.sexp")
+    (is_error_with Status.Internal)
+
 (* sexp round-trip: to-sexp then of-sexp preserves membership + categories. *)
 let test_sexp_round_trip _ =
   let t = ATB.of_entries _entries in
@@ -179,6 +187,8 @@ let suite =
          "test_curated_categories" >:: test_curated_categories;
          "test_load_parses_fixture" >:: test_load_parses_fixture;
          "test_load_missing_file_is_error" >:: test_load_missing_file_is_error;
+         "test_load_malformed_sexp_is_error"
+         >:: test_load_malformed_sexp_is_error;
          "test_sexp_round_trip" >:: test_sexp_round_trip;
        ]
 

--- a/trading/analysis/data/universe/test/test_build_eligible_universe.ml
+++ b/trading/analysis/data/universe/test/test_build_eligible_universe.ml
@@ -484,6 +484,50 @@ let test_staleness_report_counts_and_samples _ =
            (elements_are [ equal_to "STALE1D"; equal_to "STALE3D" ]);
        ])
 
+(* Asset-type blocklist wiring: when armed with a blocklist containing FTHY, the
+   mislabelled bond-CEF is dropped even though EODHD tags it "Common Stock" and
+   it clears every liquidity gate. The genuine common stock survives. *)
+let test_blocklist_drops_mislabelled_symbol _ =
+  let specs =
+    [
+      _spec "AAPL" ~close:80.0 ~volume:1_000_000 ~asset_type:_common;
+      _spec "FTHY" ~close:20.0 ~volume:1_000_000 ~asset_type:_common;
+    ]
+  in
+  let root, spec_cfg = _setup ~specs in
+  let config =
+    {
+      spec_cfg with
+      BEU.asset_type_blocklist =
+        Universe.Asset_type_blocklist.of_entries
+          [
+            {
+              Universe.Asset_type_blocklist.symbol = "FTHY";
+              category = Universe.Asset_type_blocklist.Bond_cef;
+            };
+          ];
+    }
+  in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that (_symbols snapshot) (elements_are [ equal_to "AAPL" ])
+
+(* Empty blocklist (the default) is a no-op: both symbols survive, identical to
+   the pre-blocklist behaviour. *)
+let test_empty_blocklist_is_noop _ =
+  let specs =
+    [
+      _spec "AAA" ~close:80.0 ~volume:1_000_000;
+      _spec "FTHY" ~close:20.0 ~volume:1_000_000;
+    ]
+  in
+  let root, config = _setup ~specs in
+  let snapshot = _build_or_fail ~config in
+  _cleanup_dir root;
+  assert_that
+    (List.sort (_symbols snapshot) ~compare:String.compare)
+    (elements_are [ equal_to "AAA"; equal_to "FTHY" ])
+
 let suite =
   "Build_eligible_universe"
   >::: [
@@ -503,6 +547,9 @@ let suite =
          >:: test_staleness_tolerance_includes_within_budget;
          "test_staleness_report_counts_and_samples"
          >:: test_staleness_report_counts_and_samples;
+         "test_blocklist_drops_mislabelled_symbol"
+         >:: test_blocklist_drops_mislabelled_symbol;
+         "test_empty_blocklist_is_noop" >:: test_empty_blocklist_is_noop;
        ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
## What & why

C3 of the visual-trade-audit (`dev/notes/visual-trade-audit-2026-07-12.md`, fix #3; W14). EODHD's `/api/exchange-symbol-list` `Type` field mislabels a class of non-equity instruments as **"Common Stock"** — bond CEFs, equity CEFs, and physical-bullion trusts. Because `Eodhd.Asset_type.of_eodhd_string` parses them as `Common_stock`, `Build_eligible_universe`'s equity-like filter admitted them: **FTHY (a bond CEF) surfaced as a top-7 live pick**; PHYS/PSLV (bullion trusts) and dozens of CEFs leaked into the tradeable universe.

## What it does

New pure module `analysis/data/universe/lib/asset_type_blocklist.{ml,mli}`: a symbol→`category` (`Bond_cef | Equity_cef | Bullion_trust | Spac`) blocklist that drops mislabelled instruments **independent of the wrong vendor `Type`**.

- Three interchangeable membership sources: `curated` (embedded checked-in seed, 22 tickers), `load ~path` (sexp file), and `of_entries` — the named feed point for a **future `General::Type` fundamentals enrichment** (map EODHD fundamentals type → category → `of_entries`; `union` merges with `curated`). The EODHD fundamentals fetch is intentionally NOT built here.
- SPAC coverage is intentionally minimal (SPAC tickers are ephemeral → de-SPAC/liquidate); the `Spac` category exists for a heuristic/fundamentals feed. **Follow-up:** SPAC heuristic (vol/age) gate.

Wired into `Build_eligible_universe.config` as a new field `asset_type_blocklist : Asset_type_blocklist.t [@sexp.default empty]`, applied to candidates before `Composition_policy.apply`.

## Default-off / bit-identical (experiment-flag-discipline R1)

Both `default_config` and `spec_config` set `asset_type_blocklist = Asset_type_blocklist.empty`; an empty blocklist blocks nothing, so the build is **bit-identical to the pre-blocklist behaviour**. Arming the live universe with `curated` is a separate decision (not in this PR).

## Test plan

`dune build && dune runtest analysis/data/universe/` — green (exit 0), `dune build @fmt` clean, no Python.

- `test/test_asset_type_blocklist.ml` (16 tests): empty no-op; `find`/`is_blocked`/case-insensitive; duplicate-last-wins; sorted `entries`; `union` size + right-precedence; `curated` blocks FTHY/PHYS/PSLV and allows AAPL; `curated` categories; `load` from committed fixture `test/data/asset_type_blocklist_sample.sexp`; missing-file → `Status.Internal`; sexp round-trip.
- `test/test_build_eligible_universe.ml` (+2 wiring tests): armed blocklist drops FTHY while keeping the genuine common stock; empty blocklist is a no-op (both survive).

## Scope

Contained to `analysis/data/universe/` (A2 boundary respected). No external consumers of `Build_eligible_universe` exist. Does not touch historical PIT snapshot files or the snapshot warehouse builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
