### PR TITLE
feat(snapshot-warehouse): rename-twin dedup pass (default-off)

### DIFF
--- a/dev/plans/snapshot-twin-dedup-2026-07-12.md
+++ b/dev/plans/snapshot-twin-dedup-2026-07-12.md
@@ -1,0 +1,111 @@
+# Rename-twin dedup pass for the snapshot warehouse builder — 2026-07-12
+
+## Context
+
+Historical PIT universe snapshots contain **rename-twins**: the same
+company listed under an old and a new ticker with a near-identical price
+series (the vendor duplicates the underlying series onto both symbols).
+The record deep run held both legs simultaneously — ~$2.14M of $18.0M
+realized PnL (11.9%) is clone legs. Live universe is clean (0 active
+twins); the duplication lives in the historical snapshots consumed by the
+warehouse builder (`trading/trading/backtest/snapshot_warehouse/`).
+
+Known twin groups (visual audit + a fresh V6 validator run):
+NLS/BFX, ISIS/IONS, WLY-triple (JW-A/JWA/WLY), COR/ABC (+COR_old triple),
+BKR/BHI, BLL/BALL, SWM/MATV, TXNM/PNM, NVRI/HSC, SJW/HTO, plus the new
+candidate ASB/CDX_old. `_old`-suffix symbols (USG_old, COR_old, CDX_old)
+are ordinary symbols; they are typically the *dropped* leg because their
+data ends earlier.
+
+The V6 validator (`validator_row_checks.ml`) is a *trade-level* heuristic
+(same entry/exit date + price + qty within 5%). That is deliberately
+weaker and produces false positives (BALL/TAP — Ball Corp vs Molson Coors,
+coincidental same-date trades). The builder-side detector here uses the
+**stronger** criterion (≥100 overlapping days with >95% near-identical
+adjusted_close), so the two cross-check rather than duplicate.
+
+## Approach
+
+A **default-off** rename-twin dedup pass, armed at warehouse build time.
+
+Two parts:
+
+1. **Pure detector** — new `twin_detector` library (core-only, no
+   filesystem), fully unit-testable:
+   - `Config.t` = `{ enabled; min_overlap_days; match_fraction;
+     close_epsilon; prefilter_rel_tol }` with `default` (all thresholds
+     routed through config; `enabled` defaults `false`).
+   - Input `series = { symbol; data_end; closes : (Date * float) array }`.
+   - **Criterion**: two symbols are twins iff they share ≥
+     `min_overlap_days` dates AND `> match_fraction` of overlapping dates
+     have relative `|a-b|/max(|a|,|b|)` ≤ `close_epsilon`.
+   - **Prefilter** (avoid O(n²) full compares over ~3000 symbols): pick
+     global anchor dates every `stride = max(1, min_overlap_days/2)`-th
+     unique date; at each anchor sort active symbols by close and emit
+     candidate pairs only within near-equal runs (consecutive relative
+     gap ≤ `prefilter_rel_tol`). stride < `min_overlap_days` guarantees a
+     dense ≥`min_overlap_days`-overlapping twin shares ≥1 anchor. Only
+     candidate pairs get the full compare.
+   - **Grouping**: union-find over verified twin edges → components
+     (handles triples).
+   - **Survivor**: latest `data_end` (the rename survivor); tie →
+     lexicographically smallest. Others dropped. `_old` legs fall out as
+     dropped automatically (earlier data_end).
+   - Output `report = { config; groups; dropped_symbols }`; `survivors
+     report ~all_symbols` = `all_symbols` minus dropped, order preserved;
+     `render report` = human-readable text.
+
+2. **Wiring** in `build_scenario_snapshots.ml` (the existing bridge
+   executable, already links analysis libs via `scripts.build_runner`):
+   load windowed bars per symbol → `series` → `Twin_detector.detect` →
+   write `<output-dir>/rename_twin_report.txt` + stderr summary → pass the
+   surviving symbol list to `Build_runner.build`. Gated on a
+   `-dedupe-rename-twins` CLI flag (default off) plus optional threshold
+   flags.
+
+**Rejected alternatives:**
+- Copying V6's trade-level heuristic — weaker, false-positive-prone; the
+  builder should dedup on the *series*, not on realized trades.
+- Bucketed hashing with neighbour emission — boundary-fragile and can
+  blow up popular price buckets; the sorted-run prefilter is simpler and
+  boundary-robust.
+- Excluding the dropped leg only for the overlapping window (keeping its
+  non-overlapping tail) — more correct in principle but adds windowing
+  complexity; v1 excludes the dropped leg from the snapshot entirely
+  (documented limitation in the `.mli`).
+
+## Files to change
+
+- `trading/trading/backtest/snapshot_warehouse/twin_detector.mli` (new)
+- `trading/trading/backtest/snapshot_warehouse/twin_detector.ml` (new)
+- `trading/trading/backtest/snapshot_warehouse/build_scenario_snapshots.ml`
+  (wire the pass in, default-off)
+- `trading/trading/backtest/snapshot_warehouse/dune` (new lib target +
+  loader deps on the executable)
+- `trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml`
+  (new) + `test/dune`
+- `dev/status/rename-twin-dedup.md` (new track)
+
+## Risks / unknowns
+
+- Prefilter assumes reasonably dense daily overlap; extremely sparse
+  overlaps could be missed. Documented; real market bars are dense.
+- v1 drops the whole losing leg (not just the overlap window) — loses any
+  genuinely-independent tail of the dropped ticker. Acceptable for the
+  rename-twin case (series are duplicates); documented.
+- No warehouse rebuild here — code + tests only; the rebuild + record
+  re-pin is dispatcher-owned.
+
+## Acceptance criteria
+
+- `dune build && dune runtest` green, zero warnings.
+- Detector: true pair (one survives), near-miss / brief-coincidence pair
+  (both kept), triple group, flag-off passthrough — all pinned.
+- Every public function documented in the `.mli`; no fn > 50 lines;
+  thresholds all config-routed; default-off.
+
+## Out of scope
+
+- Warehouse rebuild, record re-pin, golden re-measurement (dispatcher).
+- Any change to `analysis/data/universe/` or core modules.
+- V6 validator changes.

--- a/dev/status/rename-twin-dedup.md
+++ b/dev/status/rename-twin-dedup.md
@@ -8,8 +8,10 @@ IN_PROGRESS
 
 ## Interface stable
 
-NO — `Twin_detector.Config` field set may still change when the
-dispatcher-side warehouse rebuild exercises it on real data.
+NO
+
+(`Twin_detector.Config` field set may still change when the
+dispatcher-side warehouse rebuild exercises it on real data.)
 
 ## Owner
 

--- a/dev/status/rename-twin-dedup.md
+++ b/dev/status/rename-twin-dedup.md
@@ -1,0 +1,64 @@
+# rename-twin-dedup
+
+## Status
+
+IN_PROGRESS
+
+## Owner
+
+feat-backtest
+
+## Summary
+
+Rename-twins — the same company listed under old + new ticker with a
+near-identical price series — live in the historical PIT universe
+snapshots consumed by the snapshot-warehouse builder. A backtest that
+holds both legs double-counts the position (the record deep run had
+~$2.14M of $18.0M realized PnL, 11.9%, in clone legs). This track adds a
+**default-off** rename-twin dedup pass at warehouse build time so the
+duplicated legs can be dropped before the warehouse is written.
+
+## What was built (this PR)
+
+- `trading/trading/backtest/snapshot_warehouse/twin_detector.{ml,mli}` —
+  pure, core-only detector. `Config.t` routes all thresholds
+  (`min_overlap_days`, `match_fraction`, `close_epsilon`,
+  `prefilter_rel_tol`) through config; `enabled` defaults `false`.
+  `detect` prefilters candidate pairs by shared anchor-date price
+  proximity (anchors every `min_overlap_days/2`-th distinct date; sorted
+  near-equal runs), verifies each with the full overlap /
+  match-fraction criterion (≥100 shared days, >95% closes identical
+  within 1e-4 relative), unions verified edges into components (triples
+  handled), and keeps the latest-`data_end` leg (ties → lexicographically
+  smallest). `survivors` / `render` expose the result + a human-readable
+  sidecar report.
+- `build_scenario_snapshots.ml` — wired the pass in behind a
+  `-dedupe-rename-twins` CLI flag (default off) + optional threshold
+  flags; when armed it loads windowed bars, detects, writes
+  `<output-dir>/rename_twin_report.txt`, and passes the surviving symbol
+  set to `Build_runner.build`. Default-off → symbol set unchanged, no
+  report (existing warehouses / goldens stay reproducible).
+- Tests: true twin pair (one survives), brief-coincidence pair (both
+  kept — guards the V6 BALL/TAP false positive), triple group, `_old`
+  suffix leg dropped, below-min-overlap not-twin, disabled passthrough,
+  reported match-fraction.
+
+Verify: `dune build && dune runtest trading/trading/backtest/snapshot_warehouse/test/`
+
+## Next task (dispatcher-owned)
+
+Rebuild the deep warehouse with `-dedupe-rename-twins`, diff the emitted
+`rename_twin_report.txt` against the 10 known twin groups (NLS/BFX,
+ISIS/IONS, JW-A/JWA/WLY, COR/ABC(+COR_old), BKR/BHI, BLL/BALL, SWM/MATV,
+TXNM/PNM, NVRI/HSC, SJW/HTO; plus new candidate ASB/CDX_old), then re-pin
+the record deep-run goldens on the deduped warehouse and re-measure the
+realized-PnL delta. This is a warehouse rebuild + golden re-pin — kept
+out of this code-only PR.
+
+## Follow-ups
+
+- v1 drops the whole losing leg, not just the overlapping window. For
+  true rename-twins (duplicated series) this is correct; if a partial
+  overlap ever needs the dropped leg's independent tail, revisit.
+- The prefilter assumes reasonably dense daily overlap; extremely sparse
+  overlaps could be missed.

--- a/dev/status/rename-twin-dedup.md
+++ b/dev/status/rename-twin-dedup.md
@@ -4,6 +4,13 @@
 
 IN_PROGRESS
 
+## Last updated: 2026-07-12
+
+## Interface stable
+
+NO — `Twin_detector.Config` field set may still change when the
+dispatcher-side warehouse rebuild exercises it on real data.
+
 ## Owner
 
 feat-backtest

--- a/trading/trading/backtest/snapshot_warehouse/build_scenario_snapshots.ml
+++ b/trading/trading/backtest/snapshot_warehouse/build_scenario_snapshots.ml
@@ -60,15 +60,64 @@ let _log_plan (plan : Plan.t) ~scenario_path =
     (Date.to_string plan.end_date)
     plan.benchmark_symbol
 
+(* Load a symbol's windowed adjusted-close series for twin detection. Returns
+   [None] when the CSV is missing / unreadable / empty in-window (that symbol
+   simply cannot be a twin candidate). *)
+let _load_series ~data_dir ~warmup_start ~end_date symbol =
+  let open Option.Let_syntax in
+  let%bind storage = Result.ok (Csv.Csv_storage.create ~data_dir symbol) in
+  let%bind bars = Result.ok (Csv.Csv_storage.get storage ()) in
+  match Bar_window.filter ~start:warmup_start ~end_:end_date bars with
+  | [] -> None
+  | windowed ->
+      let closes =
+        List.map windowed ~f:(fun (b : Types.Daily_price.t) ->
+            (b.date, b.adjusted_close))
+        |> Array.of_list
+      in
+      Array.sort closes ~compare:(fun (d1, _) (d2, _) -> Date.compare d1 d2);
+      let last_date, _ = closes.(Array.length closes - 1) in
+      Some { Twin_detector.symbol; data_end = last_date; closes }
+
+let _write_twin_report ~output_dir report =
+  (if not (Stdlib.Sys.file_exists output_dir) then
+     try Stdlib.Sys.mkdir output_dir 0o755 with _ -> ());
+  let path = Filename.concat output_dir "rename_twin_report.txt" in
+  let text = Twin_detector.render report in
+  (try Out_channel.write_all path ~data:(text ^ "\n")
+   with Sys_error msg -> Printf.eprintf "twin report write failed: %s\n%!" msg);
+  Printf.eprintf "%s\n%!" text
+
+(* When armed, detect rename-twins across [all_symbols] and drop the losing
+   legs; emit the sidecar report. Default-off config → [all_symbols] unchanged,
+   no report. *)
+let _dedupe_symbols ~config ~data_dir ~warmup_start ~end_date ~output_dir
+    all_symbols =
+  if not config.Twin_detector.Config.enabled then all_symbols
+  else begin
+    let series =
+      List.filter_map all_symbols
+        ~f:(_load_series ~data_dir ~warmup_start ~end_date)
+    in
+    let report = Twin_detector.detect config series in
+    _write_twin_report ~output_dir report;
+    Twin_detector.survivors report ~all_symbols
+  end
+
 let main ~scenario_path ~fixtures_root ~csv_data_dir ~output_dir ~incremental
-    ~progress_every () =
+    ~progress_every ~twin_config () =
   let scenario = Scenario.load scenario_path in
   let universe =
     _resolve_universe ~fixtures_root ~universe_path:scenario.universe_path
   in
   let plan = Plan.derive ~scenario ~universe in
   _log_plan plan ~scenario_path;
-  Build_runner.build ~symbols:plan.all_symbols ~csv_data_dir ~output_dir
+  let symbols =
+    _dedupe_symbols ~config:twin_config ~data_dir:(Fpath.v csv_data_dir)
+      ~warmup_start:plan.warmup_start ~end_date:plan.end_date ~output_dir
+      plan.all_symbols
+  in
+  Build_runner.build ~symbols ~csv_data_dir ~output_dir
     ~benchmark_symbol:(Some plan.benchmark_symbol)
     ~start_date:(Some plan.warmup_start) ~end_date:(Some plan.end_date)
     ~incremental ~progress_every ()
@@ -103,9 +152,38 @@ let command =
            (Printf.sprintf
               "N Emit progress.sexp every N symbols processed (default %d)"
               Build_runner.default_progress_every)
+     and dedupe_rename_twins =
+       flag "dedupe-rename-twins" no_arg
+         ~doc:
+           "Drop rename-twin duplicate legs (same series under old+new ticker) \
+            before building; writes rename_twin_report.txt. Default off — \
+            existing warehouses stay reproducible."
+     and twin_min_overlap_days =
+       flag "twin-min-overlap-days"
+         (optional_with_default Twin_detector.Config.default.min_overlap_days
+            int)
+         ~doc:"N Min shared trading days for a twin match"
+     and twin_match_fraction =
+       flag "twin-match-fraction"
+         (optional_with_default Twin_detector.Config.default.match_fraction
+            float)
+         ~doc:"F Min fraction of overlapping days with near-identical closes"
+     and twin_close_epsilon =
+       flag "twin-close-epsilon"
+         (optional_with_default Twin_detector.Config.default.close_epsilon float)
+         ~doc:"E Relative tolerance for a single-day close match"
      in
      fun () ->
+       let twin_config =
+         {
+           Twin_detector.Config.enabled = dedupe_rename_twins;
+           min_overlap_days = twin_min_overlap_days;
+           match_fraction = twin_match_fraction;
+           close_epsilon = twin_close_epsilon;
+           prefilter_rel_tol = Twin_detector.Config.default.prefilter_rel_tol;
+         }
+       in
        main ~scenario_path ~fixtures_root ~csv_data_dir ~output_dir ~incremental
-         ~progress_every ())
+         ~progress_every ~twin_config ())
 
 let () = Command_unix.run command

--- a/trading/trading/backtest/snapshot_warehouse/dune
+++ b/trading/trading/backtest/snapshot_warehouse/dune
@@ -5,6 +5,13 @@
  (preprocess
   (pps ppx_jane)))
 
+(library
+ (name twin_detector)
+ (modules twin_detector)
+ (libraries core)
+ (preprocess
+  (pps ppx_jane)))
+
 (executable
  (name build_scenario_snapshots)
  (modules build_scenario_snapshots)
@@ -14,9 +21,13 @@
   core_unix.command_unix
   fpath
   status
+  types
+  csv
+  scripts.bar_window
   backtest
   scenario_lib
   scripts.build_runner
-  scenario_snapshot_plan)
+  scenario_snapshot_plan
+  twin_detector)
  (preprocess
   (pps ppx_jane)))

--- a/trading/trading/backtest/snapshot_warehouse/test/dune
+++ b/trading/trading/backtest/snapshot_warehouse/test/dune
@@ -1,5 +1,13 @@
 (test
  (name test_scenario_snapshot_plan)
+ (modules test_scenario_snapshot_plan)
  (libraries core ounit2 matchers scenario_lib scenario_snapshot_plan)
+ (preprocess
+  (pps ppx_jane)))
+
+(test
+ (name test_twin_detector)
+ (modules test_twin_detector)
+ (libraries core ounit2 matchers twin_detector)
  (preprocess
   (pps ppx_jane)))

--- a/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
@@ -23,6 +23,16 @@ let series_of ~symbol closes =
 
 (* A truncated copy sharing the first [n] closes of [closes]. *)
 let truncate_series ~symbol ~n closes = series_of ~symbol (List.take closes n)
+
+(* A series whose i-th close sits on [start + offset + i] days — used to build
+   a twin whose shared window does not begin at date index 0. *)
+let series_from ~symbol ~offset closes =
+  let dated =
+    List.mapi closes ~f:(fun i c -> (Date.add_days start (offset + i), c))
+  in
+  let data_end, _ = List.last_exn dated in
+  { Twin_detector.symbol; data_end; closes = Array.of_list dated }
+
 let ramp ~n ~base = List.init n ~f:(fun i -> base +. Float.of_int i)
 let group_survivor (g : Twin_detector.group) = g.survivor
 let group_dropped (g : Twin_detector.group) = g.dropped
@@ -141,6 +151,46 @@ let test_reported_match_fraction _ =
            (elements_are [ float_equal 1.0 ]);
        ])
 
+(* Tie-break: two twin legs with an IDENTICAL data_end (same full window).
+   With no later-ending leg, the survivor is the lexicographically smallest
+   symbol ([BFX] < [NLS]); the other is dropped. *)
+let test_identical_data_end_tiebreak _ =
+  let closes = ramp ~n:20 ~base:60.0 in
+  let nls = series_of ~symbol:"NLS" closes in
+  let bfx = series_of ~symbol:"BFX" closes in
+  let report = Twin_detector.detect test_config [ nls; bfx ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "BFX");
+             field group_dropped (equal_to [ "NLS" ]);
+           ];
+       ]);
+  assert_that report.dropped_symbols (equal_to [ "NLS" ])
+
+(* Prefilter completeness on an offset shared window: the dropped leg [OLD]
+   starts at day 7 (> stride = min_overlap_days/2 = 2, and 7 is not a multiple
+   of the stride), sharing days 7..26 with [NEW]. The twin must still be
+   detected — i.e. it is not filtered out before the full compare. *)
+let test_offset_window_detected _ =
+  let new_closes = ramp ~n:30 ~base:80.0 in
+  let newco = series_of ~symbol:"NEW" new_closes in
+  (* Closes matching [NEW] on days 7..26 exactly. *)
+  let old_closes = List.init 20 ~f:(fun i -> 80.0 +. Float.of_int (7 + i)) in
+  let oldco = series_from ~symbol:"OLD" ~offset:7 old_closes in
+  let report = Twin_detector.detect test_config [ newco; oldco ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "NEW");
+             field group_dropped (equal_to [ "OLD" ]);
+           ];
+       ])
+
 let suite =
   "twin_detector"
   >::: [
@@ -151,6 +201,8 @@ let suite =
          "disabled_passthrough" >:: test_disabled_passthrough;
          "below_min_overlap_not_twin" >:: test_below_min_overlap_not_twin;
          "reported_match_fraction" >:: test_reported_match_fraction;
+         "identical_data_end_tiebreak" >:: test_identical_data_end_tiebreak;
+         "offset_window_detected" >:: test_offset_window_detected;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
@@ -1,0 +1,156 @@
+open Core
+open OUnit2
+open Matchers
+
+(* Small thresholds so the tiny fixtures below qualify as twins:
+   >= 5 overlapping days, > 95% near-identical closes. *)
+let test_config =
+  {
+    Twin_detector.Config.enabled = true;
+    min_overlap_days = 5;
+    match_fraction = 0.95;
+    close_epsilon = 1e-4;
+    prefilter_rel_tol = 2e-2;
+  }
+
+let start = Date.of_string "2020-01-01"
+
+(* Build a series whose i-th close sits on [start + i] days. *)
+let series_of ~symbol closes =
+  let dated = List.mapi closes ~f:(fun i c -> (Date.add_days start i, c)) in
+  let data_end, _ = List.last_exn dated in
+  { Twin_detector.symbol; data_end; closes = Array.of_list dated }
+
+(* A truncated copy sharing the first [n] closes of [closes]. *)
+let truncate_series ~symbol ~n closes = series_of ~symbol (List.take closes n)
+let ramp ~n ~base = List.init n ~f:(fun i -> base +. Float.of_int i)
+let group_survivor (g : Twin_detector.group) = g.survivor
+let group_dropped (g : Twin_detector.group) = g.dropped
+
+(* (a) True twin pair: identical overlapping closes, [IONS] ends later, so it
+   survives and the earlier-ending [ISIS] is dropped. *)
+let test_true_twin_pair _ =
+  let closes = ramp ~n:20 ~base:100.0 in
+  let ions = series_of ~symbol:"IONS" closes in
+  let isis = truncate_series ~symbol:"ISIS" ~n:15 closes in
+  let report = Twin_detector.detect test_config [ isis; ions ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "IONS");
+             field group_dropped (equal_to [ "ISIS" ]);
+           ];
+       ]);
+  assert_that report.dropped_symbols (equal_to [ "ISIS" ]);
+  assert_that
+    (Twin_detector.survivors report ~all_symbols:[ "ISIS"; "IONS" ])
+    (equal_to [ "IONS" ])
+
+(* (b) Near-miss / brief-coincidence: two series that touch the same price on a
+   couple of days but diverge across the full window are NOT twins — both kept.
+   Guards against the V6 BALL/TAP-style false positive. *)
+let test_brief_coincidence_not_twin _ =
+  let ball = series_of ~symbol:"BALL" (ramp ~n:20 ~base:50.0) in
+  (* Starts at the same 50.0 for two days, then diverges steeply. *)
+  let tap =
+    series_of ~symbol:"TAP"
+      (List.init 20 ~f:(fun i ->
+           if i < 2 then 50.0 +. Float.of_int i else 200.0 +. Float.of_int i))
+  in
+  let report = Twin_detector.detect test_config [ ball; tap ] in
+  assert_that report.groups is_empty;
+  assert_that report.dropped_symbols is_empty;
+  assert_that
+    (Twin_detector.survivors report ~all_symbols:[ "BALL"; "TAP" ])
+    (equal_to [ "BALL"; "TAP" ])
+
+(* (c) Triple group (JW-A / JWA / WLY): all three share one series; the
+   latest-ending leg survives, the other two are dropped together. *)
+let test_triple_group _ =
+  let closes = ramp ~n:30 ~base:80.0 in
+  let wly = series_of ~symbol:"WLY" closes in
+  let jwa = truncate_series ~symbol:"JWA" ~n:20 closes in
+  let jw_a = truncate_series ~symbol:"JW-A" ~n:12 closes in
+  let report = Twin_detector.detect test_config [ jw_a; jwa; wly ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "WLY");
+             field group_dropped (equal_to [ "JW-A"; "JWA" ]);
+           ];
+       ]);
+  assert_that report.dropped_symbols (equal_to [ "JW-A"; "JWA" ])
+
+(* [_old]-suffix legs are ordinary symbols and, ending earlier, drop out. *)
+let test_old_suffix_leg_dropped _ =
+  let closes = ramp ~n:25 ~base:30.0 in
+  let cor = series_of ~symbol:"COR" closes in
+  let cor_old = truncate_series ~symbol:"COR_old" ~n:15 closes in
+  let report = Twin_detector.detect test_config [ cor; cor_old ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "COR");
+             field group_dropped (equal_to [ "COR_old" ]);
+           ];
+       ])
+
+(* (d) Flag-off passthrough: a disabled config detects nothing and drops
+   nothing, even on an obvious twin pair — bit-identical symbol set. *)
+let test_disabled_passthrough _ =
+  let closes = ramp ~n:20 ~base:100.0 in
+  let ions = series_of ~symbol:"IONS" closes in
+  let isis = truncate_series ~symbol:"ISIS" ~n:15 closes in
+  let report =
+    Twin_detector.detect { test_config with enabled = false } [ isis; ions ]
+  in
+  assert_that report.groups is_empty;
+  assert_that report.dropped_symbols is_empty;
+  assert_that
+    (Twin_detector.survivors report ~all_symbols:[ "ISIS"; "IONS" ])
+    (equal_to [ "ISIS"; "IONS" ])
+
+(* Overlap shorter than [min_overlap_days] is not a twin even when identical. *)
+let test_below_min_overlap_not_twin _ =
+  let closes = ramp ~n:20 ~base:100.0 in
+  let long = series_of ~symbol:"LONG" closes in
+  (* Only 3 shared days (< min_overlap_days = 5). *)
+  let short = truncate_series ~symbol:"SHORT" ~n:3 closes in
+  let report = Twin_detector.detect test_config [ long; short ] in
+  assert_that report.groups is_empty
+
+(* The match-fraction reported for a detected group is measured vs the
+   survivor and reflects the near-identical overlap. *)
+let test_reported_match_fraction _ =
+  let closes = ramp ~n:20 ~base:100.0 in
+  let ions = series_of ~symbol:"IONS" closes in
+  let isis = truncate_series ~symbol:"ISIS" ~n:15 closes in
+  let report = Twin_detector.detect test_config [ isis; ions ] in
+  assert_that report.groups
+    (elements_are
+       [
+         field
+           (fun (g : Twin_detector.group) ->
+             List.map g.matches ~f:(fun m -> m.match_fraction))
+           (elements_are [ float_equal 1.0 ]);
+       ])
+
+let suite =
+  "twin_detector"
+  >::: [
+         "true_twin_pair" >:: test_true_twin_pair;
+         "brief_coincidence_not_twin" >:: test_brief_coincidence_not_twin;
+         "triple_group" >:: test_triple_group;
+         "old_suffix_leg_dropped" >:: test_old_suffix_leg_dropped;
+         "disabled_passthrough" >:: test_disabled_passthrough;
+         "below_min_overlap_not_twin" >:: test_below_min_overlap_not_twin;
+         "reported_match_fraction" >:: test_reported_match_fraction;
+       ]
+
+let () = run_test_tt_main suite

--- a/trading/trading/backtest/snapshot_warehouse/twin_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/twin_detector.ml
@@ -1,0 +1,269 @@
+open Core
+
+module Config = struct
+  type t = {
+    enabled : bool;
+    min_overlap_days : int;
+    match_fraction : float;
+    close_epsilon : float;
+    prefilter_rel_tol : float;
+  }
+  [@@deriving sexp, equal]
+
+  let default =
+    {
+      enabled = false;
+      min_overlap_days = 100;
+      match_fraction = 0.95;
+      close_epsilon = 1e-4;
+      prefilter_rel_tol = 2e-2;
+    }
+end
+
+type series = {
+  symbol : string;
+  data_end : Date.t;
+  closes : (Date.t * float) array;
+}
+[@@deriving sexp_of]
+
+type pair_match = {
+  survivor : string;
+  dropped : string;
+  overlap_days : int;
+  match_fraction : float;
+}
+[@@deriving sexp_of, equal]
+
+type group = {
+  survivor : string;
+  dropped : string list;
+  matches : pair_match list;
+}
+[@@deriving sexp_of, equal]
+
+type report = {
+  config : Config.t;
+  groups : group list;
+  dropped_symbols : string list;
+}
+[@@deriving sexp_of]
+
+(* Relative distance between two closes, guarded against a zero magnitude. *)
+let _relative_diff a b =
+  let denom = Float.max (Float.abs a) (Float.abs b) in
+  if Float.( <= ) denom 0.0 then 0.0 else Float.abs (a -. b) /. denom
+
+(* Merge two date-sorted close arrays, counting shared dates and, among
+   those, how many have near-identical closes within [epsilon]. *)
+let _overlap_and_match a b ~epsilon =
+  let la = Array.length a and lb = Array.length b in
+  let i = ref 0 and j = ref 0 in
+  let overlap = ref 0 and matched = ref 0 in
+  while !i < la && !j < lb do
+    let da, ca = a.(!i) and db, cb = b.(!j) in
+    let c = Date.compare da db in
+    if c < 0 then incr i
+    else if c > 0 then incr j
+    else begin
+      incr overlap;
+      if Float.( <= ) (_relative_diff ca cb) epsilon then incr matched;
+      incr i;
+      incr j
+    end
+  done;
+  (!overlap, !matched)
+
+(* [Some (overlap, fraction)] when [a] and [b] meet the twin criterion. *)
+let _twin_stats (config : Config.t) a b =
+  let overlap, matched =
+    _overlap_and_match a.closes b.closes ~epsilon:config.close_epsilon
+  in
+  if overlap < config.min_overlap_days then None
+  else
+    let frac = Float.of_int matched /. Float.of_int overlap in
+    if Float.( > ) frac config.match_fraction then Some (overlap, frac)
+    else None
+
+(* Adjusted close on [date] via binary search of the sorted array. *)
+let _close_on arr ~date =
+  match
+    Array.binary_search arr
+      ~compare:(fun (d1, _) (d2, _) -> Date.compare d1 d2)
+      `First_equal_to (date, Float.nan)
+  with
+  | Some i -> Some (snd arr.(i))
+  | None -> None
+
+(* Every distinct date across all series, sorted ascending. *)
+let _unique_sorted_dates series_arr =
+  let seen = Hash_set.create (module Date) in
+  Array.iter series_arr ~f:(fun s ->
+      Array.iter s.closes ~f:(fun (d, _) -> Hash_set.add seen d));
+  Hash_set.to_list seen |> List.sort ~compare:Date.compare |> Array.of_list
+
+(* Anchor dates: every [stride]-th distinct date. Because [stride <
+   min_overlap_days], any twin pair with a dense >=[min_overlap_days]
+   overlap shares at least one anchor, so the prefilter keeps it. *)
+let _anchor_dates ~stride series_arr =
+  let all = _unique_sorted_dates series_arr in
+  Array.filteri all ~f:(fun idx _ -> idx % stride = 0)
+
+(* Series active on [date], as (index, close) sorted ascending by close. *)
+let _actives_at series_arr ~date =
+  Array.filter_mapi series_arr ~f:(fun i s ->
+      Option.map (_close_on s.closes ~date) ~f:(fun c -> (i, c)))
+  |> Array.to_list
+  |> List.sort ~compare:(fun (_, c1) (_, c2) -> Float.compare c1 c2)
+
+(* Partition a close-sorted (index, close) list into maximal runs whose
+   consecutive relative gap stays within [rel_tol]. Twins land in one run. *)
+let _group_runs ~rel_tol sorted =
+  match sorted with
+  | [] -> []
+  | (i0, c0) :: tl ->
+      let runs, cur, _ =
+        List.fold tl ~init:([], [ i0 ], c0)
+          ~f:(fun (runs, cur, prev_c) (i, c) ->
+            if Float.( <= ) (_relative_diff prev_c c) rel_tol then
+              (runs, i :: cur, c)
+            else (cur :: runs, [ i ], c))
+      in
+      cur :: runs
+
+(* All unordered index pairs within a run, canonicalised as (min, max). *)
+let _run_pairs run =
+  let arr = Array.of_list run in
+  let acc = ref [] in
+  for a = 0 to Array.length arr - 1 do
+    for b = a + 1 to Array.length arr - 1 do
+      let x = arr.(a) and y = arr.(b) in
+      acc := (Int.min x y, Int.max x y) :: !acc
+    done
+  done;
+  !acc
+
+(* Deduplicated candidate index pairs from the anchor-date prefilter. *)
+let _candidate_pairs (config : Config.t) series_arr =
+  let n = Array.length series_arr in
+  let stride = Int.max 1 (config.min_overlap_days / 2) in
+  let anchors = _anchor_dates ~stride series_arr in
+  let seen = Hash_set.create (module Int) in
+  Array.iter anchors ~f:(fun date ->
+      _actives_at series_arr ~date
+      |> _group_runs ~rel_tol:config.prefilter_rel_tol
+      |> List.iter ~f:(fun run ->
+          List.iter (_run_pairs run) ~f:(fun (i, j) ->
+              Hash_set.add seen ((i * n) + j))));
+  Hash_set.to_list seen |> List.map ~f:(fun k -> (k / n, k % n))
+
+(* Minimal index union-find. *)
+let _uf_make n = Array.init n ~f:Fn.id
+
+let rec _uf_root parents i =
+  if Int.equal parents.(i) i then i else _uf_root parents parents.(i)
+
+let _uf_union parents i j =
+  let ri = _uf_root parents i and rj = _uf_root parents j in
+  if not (Int.equal ri rj) then parents.(ri) <- rj
+
+(* Connected components with >= 2 members, as index lists. *)
+let _components parents n =
+  let tbl = Hashtbl.create (module Int) in
+  for i = 0 to n - 1 do
+    Hashtbl.add_multi tbl ~key:(_uf_root parents i) ~data:i
+  done;
+  Hashtbl.data tbl |> List.filter ~f:(fun l -> List.length l >= 2)
+
+(* Rename survivor: latest [data_end]; ties broken by smaller symbol. *)
+let _pick_survivor members =
+  List.reduce_exn members ~f:(fun a b ->
+      match Date.compare a.data_end b.data_end with
+      | c when c > 0 -> a
+      | c when c < 0 -> b
+      | _ -> if String.compare a.symbol b.symbol <= 0 then a else b)
+
+let _make_pair_match (config : Config.t) survivor dropped =
+  let overlap, matched =
+    _overlap_and_match survivor.closes dropped.closes
+      ~epsilon:config.close_epsilon
+  in
+  let frac =
+    if Int.equal overlap 0 then 0.0
+    else Float.of_int matched /. Float.of_int overlap
+  in
+  {
+    survivor = survivor.symbol;
+    dropped = dropped.symbol;
+    overlap_days = overlap;
+    match_fraction = frac;
+  }
+
+let _make_group config members =
+  let survivor = _pick_survivor members in
+  let dropped_series =
+    List.filter members ~f:(fun s ->
+        not (String.equal s.symbol survivor.symbol))
+  in
+  let dropped =
+    List.map dropped_series ~f:(fun s -> s.symbol)
+    |> List.sort ~compare:String.compare
+  in
+  let matches =
+    List.map dropped_series ~f:(_make_pair_match config survivor)
+    |> List.sort ~compare:(fun a b -> String.compare a.dropped b.dropped)
+  in
+  { survivor = survivor.symbol; dropped; matches }
+
+let _empty_report config = { config; groups = []; dropped_symbols = [] }
+
+let detect (config : Config.t) series_list =
+  if not config.enabled then _empty_report config
+  else begin
+    let series_arr = Array.of_list series_list in
+    let n = Array.length series_arr in
+    let parents = _uf_make n in
+    List.iter (_candidate_pairs config series_arr) ~f:(fun (i, j) ->
+        match _twin_stats config series_arr.(i) series_arr.(j) with
+        | Some _ -> _uf_union parents i j
+        | None -> ());
+    let groups =
+      _components parents n
+      |> List.map ~f:(fun idxs ->
+          _make_group config (List.map idxs ~f:(fun i -> series_arr.(i))))
+      |> List.sort ~compare:(fun a b -> String.compare a.survivor b.survivor)
+    in
+    let dropped_symbols =
+      List.concat_map groups ~f:(fun g -> g.dropped)
+      |> List.sort ~compare:String.compare
+    in
+    { config; groups; dropped_symbols }
+  end
+
+let survivors report ~all_symbols =
+  let drop = String.Set.of_list report.dropped_symbols in
+  List.filter all_symbols ~f:(fun s -> not (Set.mem drop s))
+
+let _render_match (m : pair_match) =
+  Printf.sprintf "    %s (overlap=%d, match=%.4f)" m.dropped m.overlap_days
+    m.match_fraction
+
+let _render_group (g : group) =
+  let hdr =
+    Printf.sprintf "  survivor %s <- [%s]" g.survivor
+      (String.concat ~sep:"; " g.dropped)
+  in
+  String.concat ~sep:"\n" (hdr :: List.map g.matches ~f:_render_match)
+
+let render report =
+  let cfg = report.config in
+  let header =
+    Printf.sprintf
+      "rename-twin report: enabled=%b min_overlap_days=%d match_fraction=%.4f \
+       close_epsilon=%.6g\n\
+       %d group(s), %d symbol(s) dropped"
+      cfg.enabled cfg.min_overlap_days cfg.match_fraction cfg.close_epsilon
+      (List.length report.groups)
+      (List.length report.dropped_symbols)
+  in
+  String.concat ~sep:"\n" (header :: List.map report.groups ~f:_render_group)

--- a/trading/trading/backtest/snapshot_warehouse/twin_detector.mli
+++ b/trading/trading/backtest/snapshot_warehouse/twin_detector.mli
@@ -1,0 +1,116 @@
+(** Pure detection of {b rename-twins} in a set of price series.
+
+    A rename-twin is the same company listed under two (or more) tickers with a
+    near-identical price series — old + new ticker after a symbol rename, or a
+    vendor duplicating one underlying series onto several symbols. Historical
+    point-in-time universe snapshots contain these (e.g. NLS/BFX, ISIS/IONS, the
+    JW-A/JWA/WLY triple), and a backtest that holds both legs double-counts the
+    same position.
+
+    This module is the {e builder-side} detector: it compares full
+    adjusted-close series, which is a stronger, lower-false-positive criterion
+    than the trade-level heuristic in the post-run validator (same entry/exit
+    date + price within a tolerance). The two cross-check rather than duplicate;
+    series that merely coincide in price for a short window (e.g. two unrelated
+    large-caps that happen to trade near the same price on one day) are {b not}
+    twins under this criterion.
+
+    The detector is a pure function of [Config.t] + a list of {!series} (no
+    filesystem, no bar loading), so it is directly unit-testable.
+    {!Build_scenario_snapshots} owns the loading + wiring. *)
+
+open Core
+
+module Config : sig
+  type t = {
+    enabled : bool;
+        (** Master switch. Defaults to [false] so the detector is a no-op (empty
+            report, no symbol dropped) unless a build explicitly arms it —
+            existing warehouses and goldens stay reproducible. *)
+    min_overlap_days : int;
+        (** Two symbols are only twin-eligible if their series share at least
+            this many dates. Guards against short coincidental overlaps being
+            called twins. *)
+    match_fraction : float;
+        (** A twin requires strictly more than this fraction of the overlapping
+            dates to have near-identical adjusted closes. *)
+    close_epsilon : float;
+        (** Relative tolerance for "near-identical" on a single date: two closes
+            [a] and [b] match when [|a - b| / max |a| |b| <= close_epsilon]. *)
+    prefilter_rel_tol : float;
+        (** Internal perf knob. The prefilter only emits a candidate pair when
+            two symbols sit within this relative gap on a shared anchor date.
+            Must be [>= close_epsilon] (looser) so genuine twins are never
+            filtered out before the full compare; kept small so near-equal price
+            runs stay short. *)
+  }
+  [@@deriving sexp, equal]
+
+  val default : t
+  (** Default config: disabled; [min_overlap_days = 100],
+      [match_fraction = 0.95], [close_epsilon = 1e-4],
+      [prefilter_rel_tol = 2e-2] — the criterion the visual audit used. *)
+end
+
+type series = {
+  symbol : string;
+  data_end : Date.t;
+      (** Last date on which the symbol has a bar — the rename-survivor
+          tiebreak. The later-ending leg is the survivor. *)
+  closes : (Date.t * float) array;
+      (** Adjusted closes, {b sorted ascending by date}, one entry per trading
+          day the symbol has. *)
+}
+[@@deriving sexp_of]
+
+type pair_match = {
+  survivor : string;
+  dropped : string;
+  overlap_days : int;  (** Number of dates the two series share. *)
+  match_fraction : float;
+      (** Fraction of overlapping dates whose closes matched within
+          [close_epsilon]. *)
+}
+[@@deriving sexp_of, equal]
+
+type group = {
+  survivor : string;  (** The kept leg (latest [data_end]; ties → min). *)
+  dropped : string list;  (** The excluded legs, sorted ascending. *)
+  matches : pair_match list;
+      (** One entry per dropped leg, measuring it against [survivor]. *)
+}
+[@@deriving sexp_of, equal]
+
+type report = {
+  config : Config.t;
+  groups : group list;  (** Detected twin groups, sorted by [survivor]. *)
+  dropped_symbols : string list;
+      (** Flattened, sorted union of every group's dropped legs — the set
+          {!survivors} removes from a symbol list. *)
+}
+[@@deriving sexp_of]
+
+val detect : Config.t -> series list -> report
+(** [detect config series] finds rename-twin groups. When [config.enabled] is
+    [false] it returns an empty report (no group, no dropped symbol). Otherwise
+    it prefilters candidate pairs by shared anchor-date price proximity,
+    verifies each with the full overlap/match-fraction criterion, unions
+    verified twin edges into connected components (so triples are one group),
+    and picks the latest-[data_end] leg of each component as the survivor.
+
+    {b Limitation (v1).} A dropped leg is excluded entirely; any
+    genuinely-independent tail it may have outside the survivor's window is
+    lost. This is appropriate for true rename-twins (duplicated series) but is a
+    coarse choice for partial overlaps. The prefilter also assumes reasonably
+    dense (daily) overlap; extremely sparse overlaps may be missed. *)
+
+val survivors : report -> all_symbols:string list -> string list
+(** [survivors report ~all_symbols] returns [all_symbols] with every entry in
+    [report.dropped_symbols] removed, preserving the input order. With a
+    disabled-config (empty) report this is [all_symbols] unchanged — the
+    bit-identical passthrough. *)
+
+val render : report -> string
+(** [render report] formats the config and each detected group (survivor,
+    dropped legs with their overlap days + match fraction) as human-readable
+    multi-line text for the sidecar report file + stderr summary. *)


### PR DESCRIPTION
## What

Adds a **default-off** rename-twin dedup pass to the snapshot-warehouse
builder. Rename-twins — the same company listed under an old and a new
ticker with a near-identical price series (vendor duplicating one
underlying series onto both symbols) — live in the historical PIT
universe snapshots the builder consumes. A backtest that holds both legs
double-counts the same position (the record deep run had ~$2.14M of
$18.0M realized PnL, 11.9%, in clone legs). Live universe is clean.

## How

**`twin_detector.{ml,mli}`** — new pure, core-only library (fully
unit-testable, no filesystem):
- `Config.t` routes every threshold through config — `min_overlap_days`,
  `match_fraction`, `close_epsilon`, `prefilter_rel_tol`; `enabled`
  defaults `false`.
- **Criterion** (stronger than the V6 trade-level heuristic, so the two
  cross-check): two symbols are twins iff they share ≥ `min_overlap_days`
  dates AND `> match_fraction` of overlapping dates have relative close
  diff ≤ `close_epsilon` (defaults: 100 days, 95%, 1e-4).
- **Prefilter** (avoids O(n²) full compares over ~3000 symbols): anchor
  dates every `min_overlap_days/2`-th distinct date; at each, sort active
  symbols by close and emit candidate pairs only within near-equal runs.
  stride < `min_overlap_days` guarantees a dense overlapping twin shares
  an anchor. Only candidate pairs get the full compare.
- **Grouping**: union-find over verified twin edges → components (triples
  handled). **Survivor**: latest `data_end` (the rename survivor); ties →
  lexicographically smallest. `_old`-suffix legs (COR_old, CDX_old) drop
  out automatically since they end earlier.

**`build_scenario_snapshots.ml`** — wires the pass behind a
`-dedupe-rename-twins` CLI flag (default off) + optional threshold flags.
When armed: load windowed bars → detect → write
`<output-dir>/rename_twin_report.txt` (survivor + dropped legs + overlap
days + match fraction per group) + stderr summary → pass survivors to
`Build_runner.build`. Default-off → symbol set unchanged, no report
(existing warehouses / goldens stay reproducible — flag discipline R1).

## Test plan

`dune runtest trading/backtest/snapshot_warehouse/test/` — 7 new tests:
- true twin pair (one survives, later `data_end`)
- brief-coincidence pair — same price for 2 days then diverge — **both
  kept** (guards the V6 BALL/TAP false positive)
- triple group (JW-A/JWA/WLY), two dropped
- `_old`-suffix leg dropped
- below-`min_overlap_days` overlap → not a twin
- disabled config → bit-identical passthrough
- reported match fraction

## Out of scope (dispatcher-owned)

Warehouse rebuild with the flag armed, diffing `rename_twin_report.txt`
against the 10 known groups (+ new candidate ASB/CDX_old), and re-pinning
the record deep-run goldens on the deduped warehouse. This PR is code +
tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
