### PR TITLE
fix(backtest): key trades.csv exit_trigger + stop_trigger_kind by position_id

### DIFF
--- a/dev/status/backtest-infra.md
+++ b/dev/status/backtest-infra.md
@@ -19,6 +19,28 @@ moved to its own track at `dev/status/backtest-perf.md`. The 12-step
 incremental-indicators refactor (the follow-on architecture for
 Tier 3) tracked separately at `dev/status/incremental-indicators.md`.
 
+## 2026-07-12 — trades.csv export-join fix (C2)
+
+- [x] **Key `exit_trigger` + `stop_trigger_kind` by position_id** — the
+  trades.csv export sourced `exit_trigger` (and `entry_stop` / `exit_stop`)
+  from a symbol-keyed FIFO pop of `stop_info`s while `stop_trigger_kind`
+  (via `Trade_context`) resolved position-keyed through the audit record.
+  On re-traded symbols the two joins mis-aligned, producing blank and
+  contradictory trigger rows (record run: 129 validator-V5 violations; e.g.
+  WSM 2017-10-14 `exit_trigger=laggard_rotation` vs `stop_trigger_kind=gap_down`).
+  Fix routes both columns through the single position-keyed join
+  `Trade_context.stop_info_for_trade`, and appends a trailing **`position_id`**
+  column to trades.csv (canonical audit id; join key for the validator's
+  audit lookup). No strategy-behaviour change — backtest returns/positions are
+  bit-identical; only trigger columns change on re-traded symbols. `position_id`
+  is appended last so positional readers (validator fixed indices
+  `exit_trigger`=12, `stop_trigger_kind`=16; hold-period/extension analyzers)
+  stay valid. Lives at `trading/trading/backtest/lib/{trade_context,result_writer}.ml`.
+  **Verify:** `dune runtest trading/backtest/test/` (test_trade_context +
+  test_result_writer: new re-traded-symbol per-position join tests) and
+  `dune runtest trading/backtest/validation/` (new V5 re-traded-consistent
+  fixture). PR: `feat/trades-export-join-fix`.
+
 ## 2026-07-09 — `audit_bars` warehouse corrupt-bar scanner
 
 - [x] **`audit_bars` exe + `audit_bars_detector` lib** — scans a snapshot

--- a/trading/trading/backtest/lib/result_writer.ml
+++ b/trading/trading/backtest/lib/result_writer.ml
@@ -41,13 +41,6 @@ let _write_params ~output_dir (result : Runner.result) =
   in
   Sexp.save_hum (output_dir ^ "/params.sexp") (Sexp.List with_overrides)
 
-let _build_stop_index (stop_infos : Stop_log.stop_info list) =
-  List.fold stop_infos
-    ~init:(Map.empty (module String))
-    ~f:(fun acc (info : Stop_log.stop_info) ->
-      let existing = Map.find acc info.symbol |> Option.value ~default:[] in
-      Map.set acc ~key:info.symbol ~data:(existing @ [ info ]))
-
 let _exit_trigger_label (trigger : Stop_log.exit_trigger) =
   match trigger with
   | Stop_loss _ -> "stop_loss"
@@ -78,13 +71,6 @@ let _force_liq_label (reason : Portfolio_risk.Force_liquidation.reason) =
   match reason with
   | Per_position -> "force_liquidation_position"
   | Portfolio_floor -> "force_liquidation_portfolio"
-
-let _pop_stop_info stop_index ~symbol =
-  match Map.find !stop_index symbol with
-  | Some (info :: rest) ->
-      stop_index := Map.set !stop_index ~key:symbol ~data:rest;
-      Some info
-  | _ -> None
 
 let _fmt_float_opt = function Some s -> sprintf "%.2f" s | None -> ""
 
@@ -123,9 +109,12 @@ let _trades_csv_header =
   in
   String.concat ~sep:"," (base @ Trade_context.csv_header_fields)
 
-let _write_trade_row oc stop_index force_liq_index ~ctx_pre
-    (t : Metrics.trade_metrics) =
-  let info = _pop_stop_info stop_index ~symbol:t.symbol in
+let _write_trade_row oc force_liq_index ~ctx_pre (t : Metrics.trade_metrics) =
+  (* Resolve the stop_info via the same position-keyed join {!Trade_context}
+     uses for [stop_trigger_kind], so [entry_stop] / [exit_stop] / [exit_trigger]
+     stay consistent with it. The prior symbol-keyed FIFO pop misaligned against
+     that join on re-traded symbols (Nth position got the wrong trigger). *)
+  let info = Trade_context.stop_info_for_trade ctx_pre ~trade:t in
   let entry_stop, exit_stop, base_exit_trigger = _stop_fields info in
   let force_liq_key = t.symbol ^ "|" ^ Date.to_string t.exit_date in
   let exit_trigger =
@@ -161,15 +150,15 @@ let _write_trades ~output_dir ~(round_trips : Metrics.trade_metrics list)
   let path = output_dir ^ "/trades.csv" in
   let oc = Out_channel.create path in
   fprintf oc "%s\n" _trades_csv_header;
-  let stop_index = ref (_build_stop_index stop_infos) in
   let force_liq_index = _build_force_liq_index force_liquidations in
   (* Build the audit + stop-log indexes once, not per row. Without this hoist,
      [Trade_context.of_audit_and_stop_log] rebuilt the audit_idx Map every
      call — turning [trades.csv] writing into O(N²) on Cell E 15 y
-     (~3 700 round-trips × ~3 700 audit records). *)
+     (~3 700 round-trips × ~3 700 audit records). The same [ctx_pre] also backs
+     the per-row stop_info join, so [exit_trigger] and [stop_trigger_kind]
+     resolve against one index. *)
   let ctx_pre = Trade_context.precompute ~audit ~stop_infos in
-  List.iter round_trips
-    ~f:(_write_trade_row oc stop_index force_liq_index ~ctx_pre);
+  List.iter round_trips ~f:(_write_trade_row oc force_liq_index ~ctx_pre);
   Out_channel.close oc
 
 let _write_equity_curve ~output_dir

--- a/trading/trading/backtest/lib/trade_context.ml
+++ b/trading/trading/backtest/lib/trade_context.ml
@@ -11,6 +11,7 @@ type t = {
   stop_trigger_kind : string option;
   days_to_first_stop_trigger : int option;
   screener_score_at_entry : int option;
+  position_id : string option;
 }
 [@@deriving sexp]
 
@@ -37,6 +38,7 @@ let csv_header_fields =
     "stop_trigger_kind";
     "days_to_first_stop_trigger";
     "screener_score_at_entry";
+    "position_id";
   ]
 
 let _fmt_float4_opt = function Some f -> Printf.sprintf "%.4f" f | None -> ""
@@ -51,6 +53,7 @@ let csv_row_fields (t : t) =
     _fmt_string_opt t.stop_trigger_kind;
     _fmt_int_opt t.days_to_first_stop_trigger;
     _fmt_int_opt t.screener_score_at_entry;
+    _fmt_string_opt t.position_id;
   ]
 
 type precomputed = {
@@ -178,6 +181,20 @@ let _days_to_first_stop_trigger ~(entry_date : Date.t) ~(exit_date : Date.t)
   | Some (Stop_loss _) -> Some (Date.diff exit_date entry_date)
   | _ -> None
 
+(** Position ID for [trade], recovered from the matched audit record. This is
+    the join key that every stop-derived column resolves through — see
+    {!stop_info_for_trade}. *)
+let _position_id_for_trade (pre : precomputed)
+    ~(trade : Trading_simulation.Metrics.trade_metrics) : string option =
+  _lookup_audit_for_trade pre ~symbol:trade.symbol ~entry_date:trade.entry_date
+  |> Option.map ~f:(fun (r : Trade_audit.audit_record) -> r.entry.position_id)
+
+let stop_info_for_trade (pre : precomputed)
+    ~(trade : Trading_simulation.Metrics.trade_metrics) :
+    Stop_log.stop_info option =
+  let position_id = _position_id_for_trade pre ~trade in
+  _stop_info_for ~position_id ~symbol:trade.symbol pre
+
 let of_precomputed (pre : precomputed)
     ~(trade : Trading_simulation.Metrics.trade_metrics) : t =
   let audit_record =
@@ -188,7 +205,7 @@ let of_precomputed (pre : precomputed)
     Option.map audit_record ~f:(fun (r : Trade_audit.audit_record) -> r.entry)
   in
   let position_id = Option.map entry ~f:(fun e -> e.position_id) in
-  let stop_info = _stop_info_for ~position_id ~symbol:trade.symbol pre in
+  let stop_info = stop_info_for_trade pre ~trade in
   let entry_stage = Option.map entry ~f:(fun e -> stage_label e.stage) in
   let entry_volume_ratio = Option.bind entry ~f:(fun e -> e.volume_ratio) in
   let stop_initial_distance_pct =
@@ -220,6 +237,7 @@ let of_precomputed (pre : precomputed)
     stop_trigger_kind;
     days_to_first_stop_trigger;
     screener_score_at_entry;
+    position_id;
   }
 
 (** Convenience wrapper: builds [precomputed] inline. Per-trade callers in a

--- a/trading/trading/backtest/lib/trade_context.mli
+++ b/trading/trading/backtest/lib/trade_context.mli
@@ -20,6 +20,13 @@
     - [screener_score_at_entry] — cascade score the screener assigned at
       decision time. Links to the [optimal-strategy] oracle for M5.5 ML training
       (per-Friday counterfactual labels).
+    - [position_id] — the strategy position ID resolved for this round-trip
+      (from the matched {!Trade_audit.audit_record}). Surfaced as the trailing
+      [trades.csv] column so downstream consumers (post-run validator, trade
+      audit tooling) can join a trade row back to its {!Trade_audit} /
+      {!Stop_log} record by position rather than by the ambiguous
+      [(symbol, entry_date)] tuple — the latter misaligns on re-traded symbols.
+      [None] when no audit record matched.
 
     Pure projection — no computation beyond simple subtraction / ratio / label
     rendering. The audit + stop-log inputs are joined on [(symbol, entry_date)]
@@ -38,6 +45,7 @@ type t = {
   stop_trigger_kind : string option;
   days_to_first_stop_trigger : int option;
   screener_score_at_entry : int option;
+  position_id : string option;
 }
 [@@deriving sexp]
 (** One per-trade context row, keyed by [(symbol, entry_date)] for join with
@@ -53,14 +61,17 @@ val stop_trigger_kind_label : Stop_log.stop_trigger_kind -> string
     label: [gap_down] / [intraday] / [end_of_period] / [non_stop_exit]. *)
 
 val csv_header_fields : string list
-(** The 6 trailing column names for [trades.csv] in M5.2e order: [entry_stage],
-    [entry_volume_ratio], [stop_initial_distance_pct], [stop_trigger_kind],
-    [days_to_first_stop_trigger], [screener_score_at_entry]. Producers
-    concatenate these onto the legacy 13-column header so consumers can locate
-    columns by name. *)
+(** The 7 trailing column names for [trades.csv]: the 6 M5.2e columns
+    ([entry_stage], [entry_volume_ratio], [stop_initial_distance_pct],
+    [stop_trigger_kind], [days_to_first_stop_trigger],
+    [screener_score_at_entry]) followed by [position_id]. Producers concatenate
+    these onto the legacy 13-column header so consumers can locate columns by
+    name. [position_id] is intentionally last so the fixed base-column indices
+    used by positional readers (e.g. the post-run validator's [exit_trigger]=12,
+    [stop_trigger_kind]=16) stay valid. *)
 
 val csv_row_fields : t -> string list
-(** Render a {!t} as the 6 trailing CSV cells in the same order as
+(** Render a {!t} as the 7 trailing CSV cells in the same order as
     {!csv_header_fields}. Floats render at %.4f, ints as decimal, string labels
     verbatim. [None] renders as the empty cell — consumers must tolerate empty
     cells (the canonical M5.2e missing-data sentinel). *)
@@ -87,6 +98,23 @@ val of_precomputed :
 (** Compute the context row for a single trade against pre-built indexes.
     Field-population semantics match {!of_audit_and_stop_log}. O(log N) per call
     (Map lookups). *)
+
+val stop_info_for_trade :
+  precomputed ->
+  trade:Trading_simulation.Metrics.trade_metrics ->
+  Stop_log.stop_info option
+(** Resolve the {!Stop_log.stop_info} that belongs to [trade], keyed by the
+    position ID recovered from the matched audit record (falling back to the
+    first {!Stop_log.stop_info} for the symbol when no audit record matches).
+
+    This is the {b canonical} trade → stop-info join and the single source of
+    truth for every stop-derived [trades.csv] column: {!of_precomputed} uses it
+    for [stop_trigger_kind] / [days_to_first_stop_trigger], and the result
+    writer uses it for the [entry_stop] / [exit_stop] / [exit_trigger] columns.
+    Routing both through this one function keeps those columns mutually
+    consistent — the previous symbol-keyed FIFO pop in the writer misaligned
+    against this position-keyed lookup on re-traded symbols. O(log N) per call.
+*)
 
 val of_audit_and_stop_log :
   audit:Trade_audit.audit_record list ->

--- a/trading/trading/backtest/test/test_result_writer.ml
+++ b/trading/trading/backtest/test/test_result_writer.ml
@@ -763,6 +763,111 @@ let test_trades_csv_context_falls_back_to_empty_when_no_audit _ =
            ]))
 
 (* ------------------------------------------------------------------ *)
+(* C2 — re-traded symbol: per-position trigger join                     *)
+(* ------------------------------------------------------------------ *)
+
+(** A symbol traded twice must have each row carry {b its own} position's
+    trigger fields. The prior symbol-keyed FIFO pop fed [exit_trigger] /
+    [entry_stop] / [exit_stop] from one stop_info while [stop_trigger_kind]
+    (position-keyed via audit) came from another — producing the blank /
+    contradictory rows validator V5 pins. Both joins now key by position_id, so
+    the first round-trip (stop-loss → intraday) and the second (end-of-period)
+    each render consistent trigger columns. The stop_infos are supplied in
+    reverse of trade order to trip any residual order-dependent join, and the
+    trailing [position_id] column is asserted per row. *)
+let test_retraded_symbol_keys_triggers_by_position_id _ =
+  let entry1_date = _date "2024-01-02" in
+  let exit1_date = _date "2024-02-15" in
+  let entry2_date = _date "2024-03-01" in
+  let exit2_date = _date "2024-04-29" in
+  let trade1 =
+    _make_trade ~symbol:"AAPL" ~entry_date:entry1_date ~exit_date:exit1_date ()
+  in
+  let trade2 =
+    _make_trade ~symbol:"AAPL" ~entry_date:entry2_date ~exit_date:exit2_date ()
+  in
+  let entry1 =
+    _m5_2e_entry ~symbol:"AAPL" ~entry_date:entry1_date
+      ~position_id:"AAPL-wein-1"
+  in
+  let entry2 =
+    _m5_2e_entry ~symbol:"AAPL" ~entry_date:entry2_date
+      ~position_id:"AAPL-wein-2"
+  in
+  let stop1 : Backtest.Stop_log.stop_info =
+    {
+      position_id = "AAPL-wein-1";
+      symbol = "AAPL";
+      entry_date = Some entry1_date;
+      entry_stop = Some 92.0;
+      exit_stop = Some 92.0;
+      exit_trigger =
+        Some
+          (Backtest.Stop_log.Stop_loss
+             { stop_price = 92.0; actual_price = 91.99 });
+    }
+  in
+  let stop2 : Backtest.Stop_log.stop_info =
+    {
+      position_id = "AAPL-wein-2";
+      symbol = "AAPL";
+      entry_date = Some entry2_date;
+      entry_stop = Some 92.0;
+      exit_stop = Some 92.0;
+      exit_trigger = Some Backtest.Stop_log.End_of_period;
+    }
+  in
+  let result : Backtest.Runner.result =
+    {
+      summary = _empty_summary ~start_date:entry1_date ~end_date:exit2_date;
+      round_trips = [ trade1; trade2 ];
+      steps = [];
+      final_portfolio =
+        Trading_portfolio.Portfolio.create ~initial_cash:100_000.0 ();
+      n_stop_eligible_positions = 0;
+      overrides = [];
+      (* Reversed vs trade order — a FIFO pop would mis-assign. *)
+      stop_infos = [ stop2; stop1 ];
+      audit =
+        [ { entry = entry1; exit_ = None }; { entry = entry2; exit_ = None } ];
+      cascade_summaries = [];
+      force_liquidations = [];
+      stale_holds = [];
+      final_prices = [];
+      universe = [];
+    }
+  in
+  _with_writer_output ~result ~prefix:"/tmp/result_writer_retraded_" (fun dir ->
+      let header, rows = _read_trades_csv ~output_dir:dir in
+      let trig_idx = _col_idx header ~name:"exit_trigger" in
+      let kind_idx = _col_idx header ~name:"stop_trigger_kind" in
+      let pid_idx = _col_idx header ~name:"position_id" in
+      assert_that rows
+        (elements_are
+           [
+             all_of
+               [
+                 field (fun c -> List.nth_exn c trig_idx) (equal_to "stop_loss");
+                 field (fun c -> List.nth_exn c kind_idx) (equal_to "intraday");
+                 field
+                   (fun c -> List.nth_exn c pid_idx)
+                   (equal_to "AAPL-wein-1");
+               ];
+             all_of
+               [
+                 field
+                   (fun c -> List.nth_exn c trig_idx)
+                   (equal_to "end_of_period");
+                 field
+                   (fun c -> List.nth_exn c kind_idx)
+                   (equal_to "end_of_period");
+                 field
+                   (fun c -> List.nth_exn c pid_idx)
+                   (equal_to "AAPL-wein-2");
+               ];
+           ]))
+
+(* ------------------------------------------------------------------ *)
 (* Suite                                                                *)
 (* ------------------------------------------------------------------ *)
 
@@ -794,6 +899,8 @@ let suite =
          >:: test_trades_csv_populates_context_from_audit_and_stop_log;
          "trades.csv context falls back to empty when no audit"
          >:: test_trades_csv_context_falls_back_to_empty_when_no_audit;
+         "trades.csv re-traded symbol keys triggers by position_id"
+         >:: test_retraded_symbol_keys_triggers_by_position_id;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/test/test_trade_audit_report.ml
+++ b/trading/trading/backtest/test/test_trade_audit_report.ml
@@ -506,9 +506,10 @@ let test_load_missing_trades_csv_raises _ =
 (** Mirror of [Backtest.Result_writer._write_trades]'s post-G2 header. M5.2e
     adds 6 trailing per-trade context columns (entry_stage, entry_volume_ratio,
     stop_initial_distance_pct, stop_trigger_kind, days_to_first_stop_trigger,
-    screener_score_at_entry). *)
+    screener_score_at_entry); the trades.csv export-join fix appends a trailing
+    position_id column (kept last so positional readers stay valid). *)
 let _canonical_post_g2_header =
-  "symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger,entry_stage,entry_volume_ratio,stop_initial_distance_pct,stop_trigger_kind,days_to_first_stop_trigger,screener_score_at_entry"
+  "symbol,side,entry_date,exit_date,days_held,entry_price,exit_price,quantity,pnl_dollars,pnl_percent,entry_stop,exit_stop,exit_trigger,entry_stage,entry_volume_ratio,stop_initial_distance_pct,stop_trigger_kind,days_to_first_stop_trigger,screener_score_at_entry,position_id"
 
 (* AAPL LONG round-trip: bought at 280, sold at 404, +12 400 / +44.20%. *)
 let _post_g2_long_row =

--- a/trading/trading/backtest/test/test_trade_context.ml
+++ b/trading/trading/backtest/test/test_trade_context.ml
@@ -121,6 +121,7 @@ let test_csv_header_fields_pinned _ =
          equal_to "stop_trigger_kind";
          equal_to "days_to_first_stop_trigger";
          equal_to "screener_score_at_entry";
+         equal_to "position_id";
        ])
 
 (* of_audit_and_stop_log: full join ----------------------------------- *)
@@ -157,6 +158,9 @@ let test_of_audit_and_stop_log_populates_all_fields _ =
          field
            (fun (c : TC.t) -> c.screener_score_at_entry)
            (is_some_and (equal_to 75));
+         field
+           (fun (c : TC.t) -> c.position_id)
+           (is_some_and (equal_to "AAPL-wein-1"));
        ])
 
 (* Late Stage2 propagates to entry_stage label. *)
@@ -246,6 +250,7 @@ let test_missing_audit_yields_none_for_audit_fields _ =
          field (fun (c : TC.t) -> c.entry_volume_ratio) is_none;
          field (fun (c : TC.t) -> c.stop_initial_distance_pct) is_none;
          field (fun (c : TC.t) -> c.screener_score_at_entry) is_none;
+         field (fun (c : TC.t) -> c.position_id) is_none;
          field
            (fun (c : TC.t) -> c.stop_trigger_kind)
            (is_some_and (equal_to "intraday"));
@@ -272,6 +277,56 @@ let test_missing_stop_log_yields_none_for_stop_fields _ =
          field (fun (c : TC.t) -> c.days_to_first_stop_trigger) is_none;
        ])
 
+(* stop_info_for_trade: re-traded symbol keys by position_id ---------- *)
+
+(* A symbol traded twice must resolve each round-trip to its OWN stop_info via
+   the audit-recovered position_id, independent of the order the stop_infos are
+   supplied in. This is the join the result writer relies on so exit_trigger
+   stays consistent with stop_trigger_kind on re-traded symbols. *)
+let test_stop_info_for_trade_keys_by_position_id _ =
+  let trade1 =
+    make_trade ~entry_date:(_date "2024-01-15") ~exit_date:(_date "2024-02-20")
+      ()
+  in
+  let trade2 =
+    make_trade ~entry_date:(_date "2024-05-01") ~exit_date:(_date "2024-06-10")
+      ()
+  in
+  let entry1 =
+    make_entry ~entry_date:(_date "2024-01-15") ~position_id:"AAPL-wein-1" ()
+  in
+  let entry2 =
+    make_entry ~entry_date:(_date "2024-05-01") ~position_id:"AAPL-wein-2" ()
+  in
+  let stop1 =
+    make_stop_info ~position_id:"AAPL-wein-1" ~symbol:"AAPL"
+      ~exit_trigger:(SL.Stop_loss { stop_price = 138.0; actual_price = 137.99 })
+      ()
+  in
+  let stop2 =
+    make_stop_info ~position_id:"AAPL-wein-2" ~symbol:"AAPL"
+      ~exit_trigger:SL.End_of_period ()
+  in
+  (* stop_infos deliberately reversed relative to trade order so an
+     order-dependent (FIFO) join would mis-assign. *)
+  let pre =
+    TC.precompute
+      ~audit:[ make_record entry1; make_record entry2 ]
+      ~stop_infos:[ stop2; stop1 ]
+  in
+  assert_that
+    (TC.stop_info_for_trade pre ~trade:trade1)
+    (is_some_and
+       (field
+          (fun (i : SL.stop_info) -> i.position_id)
+          (equal_to "AAPL-wein-1")));
+  assert_that
+    (TC.stop_info_for_trade pre ~trade:trade2)
+    (is_some_and
+       (field
+          (fun (i : SL.stop_info) -> i.position_id)
+          (equal_to "AAPL-wein-2")))
+
 (* csv_row_fields formatting ----------------------------------------- *)
 
 let test_csv_row_fields_formats_correctly _ =
@@ -285,6 +340,7 @@ let test_csv_row_fields_formats_correctly _ =
       stop_trigger_kind = Some "intraday";
       days_to_first_stop_trigger = Some 96;
       screener_score_at_entry = Some 75;
+      position_id = Some "AAPL-wein-1";
     }
   in
   assert_that (TC.csv_row_fields ctx)
@@ -296,6 +352,7 @@ let test_csv_row_fields_formats_correctly _ =
          equal_to "intraday";
          equal_to "96";
          equal_to "75";
+         equal_to "AAPL-wein-1";
        ])
 
 let test_csv_row_fields_renders_none_as_empty _ =
@@ -309,11 +366,13 @@ let test_csv_row_fields_renders_none_as_empty _ =
       stop_trigger_kind = None;
       days_to_first_stop_trigger = None;
       screener_score_at_entry = None;
+      position_id = None;
     }
   in
   assert_that (TC.csv_row_fields ctx)
     (elements_are
        [
+         equal_to "";
          equal_to "";
          equal_to "";
          equal_to "";
@@ -340,6 +399,8 @@ let suite =
          >:: test_missing_audit_yields_none_for_audit_fields;
          "missing stop_log -> stop fields None"
          >:: test_missing_stop_log_yields_none_for_stop_fields;
+         "stop_info_for_trade keys by position_id"
+         >:: test_stop_info_for_trade_keys_by_position_id;
          "csv_row_fields formats correctly"
          >:: test_csv_row_fields_formats_correctly;
          "csv_row_fields renders None as empty"

--- a/trading/trading/backtest/validation/test/test_post_run_validator.ml
+++ b/trading/trading/backtest/validation/test/test_post_run_validator.ml
@@ -100,6 +100,27 @@ let test_v5 _ =
   in
   assert_that (result ~id:"V5" inputs) (violations_and_pass 1 false)
 
+(* A re-traded symbol whose two round-trips each carry consistent per-position
+   triggers passes V5. This is the post-fix shape of the WSM specimen the
+   trades.csv export-join defect produced (laggard_rotation paired with
+   gap_down; stop_loss paired with non_stop_exit) — both joins now key by
+   position_id so each row is internally consistent. *)
+let test_v5_retraded_symbol_consistent _ =
+  let inputs =
+    {
+      (Vt.empty_inputs ()) with
+      trades =
+        [
+          trade ~symbol:"WSM" ~entry_date:"2017-08-01" ~exit_date:"2017-10-14"
+            ~exit_trigger:"laggard_rotation" ~stop_trigger_kind:"non_stop_exit"
+            ();
+          trade ~symbol:"WSM" ~entry_date:"2023-05-01" ~exit_date:"2023-07-01"
+            ~exit_trigger:"stop_loss" ~stop_trigger_kind:"intraday" ();
+        ];
+    }
+  in
+  assert_that (result ~id:"V5" inputs) (violations_and_pass 0 true)
+
 (* ---- V6: rename-twin duplicate positions ------------------------------- *)
 
 let test_v6 _ =
@@ -316,6 +337,7 @@ let suite =
          "v1_stage" >:: test_v1;
          "v2_macro" >:: test_v2;
          "v5_trigger_consistency" >:: test_v5;
+         "v5_retraded_symbol_consistent" >:: test_v5_retraded_symbol_consistent;
          "v6_twin" >:: test_v6;
          "v6_no_twin" >:: test_v6_no_twin;
          "v6_price_noise_twin" >:: test_v6_price_noise_twin;


### PR DESCRIPTION
## What / why

`trades.csv` sourced two exit-trigger columns from **two different joins**:

- `exit_trigger` (and `entry_stop` / `exit_stop`) came from a **symbol-keyed
  FIFO pop** of the `stop_info` list in `result_writer.ml`.
- `stop_trigger_kind` came from `Trade_context.of_precomputed`, which resolves
  the `stop_info` **position-keyed** via the matched audit record's
  `position_id`.

On a **re-traded symbol** (a symbol entered/exited more than once in one run)
the FIFO order and the position-keyed order disagree, so a row's `exit_trigger`
and `stop_trigger_kind` describe different positions — producing blank and
contradictory trigger rows. Measured on the honest-tradeable record run: **129
validator-V5 violations** (e.g. `WSM 2017-10-14 exit_trigger=laggard_rotation`
but `stop_trigger_kind=gap_down`; `WSM 2023-07-01 exit_trigger=stop_loss` but
`stop_trigger_kind=non_stop_exit`).

## The fix

- Both columns now resolve the `stop_info` through **one** position-keyed join,
  `Trade_context.stop_info_for_trade` (audit → `position_id` → stop map, with the
  same symbol-first fallback the context join already used). `result_writer`
  drops its symbol-keyed FIFO index entirely and reads `entry_stop` /
  `exit_stop` / `exit_trigger` from that same `stop_info`, so every stop-derived
  column on a row is mutually consistent.
- Appends a trailing **`position_id`** column to `trades.csv` (the canonical
  audit position id). This makes the fix verifiable and gives the post-run
  validator a direct join key back to `trade_audit.sexp` (unblocks the separate
  validator audit-lookup fix). It is appended **last** so the fixed positional
  indices used by downstream readers stay valid (validator `exit_trigger`=12 /
  `stop_trigger_kind`=16; `hold_period_per_stage_analysis` / `extension_screen`
  low indices — all `< 19`).

Pure export-correctness change: **no strategy behaviour changes** — backtest
returns/positions are bit-identical; only trigger columns change on re-traded
symbols. The force-liquidation override keeps its direct `(symbol, exit_date)`
join (per-position-correct for re-trades since distinct positions exit on
distinct dates; unchanged).

## Files

- `trading/trading/backtest/lib/trade_context.{ml,mli}` — add
  `stop_info_for_trade`; add `position_id` field + trailing csv column.
- `trading/trading/backtest/lib/result_writer.ml` — resolve stop_info
  position-keyed; drop the symbol-keyed FIFO index.
- tests (below).

## Test plan

- `trading/backtest/test/test_trade_context.ml` — new
  `stop_info_for_trade keys by position_id` (re-traded symbol resolves each
  round-trip to its own `stop_info` regardless of input order); `position_id`
  populate/blank pins; csv header/row pins extended.
- `trading/backtest/test/test_result_writer.ml` — new end-to-end
  `re-traded symbol keys triggers by position_id`: one symbol traded twice
  (stop-loss→intraday, then end-of-period), `stop_info`s supplied in reverse of
  trade order; asserts each row carries its own `exit_trigger` +
  `stop_trigger_kind` + `position_id`. Fails on the old FIFO code.
- `trading/backtest/validation/test/test_post_run_validator.ml` — new
  `v5_retraded_symbol_consistent`: the post-fix WSM shape (two consistent rows)
  passes V5 with 0 violations.

All three test executables pass (`test_trade_context` 13, `test_result_writer`
14, `test_post_run_validator` 19). Pre-existing failures in the same local run
(`Trade_audit_capture`, `Panel_*` golden tests) are environmental — they need
`data/backtest_scenarios/smoke/*.sexp` fixtures absent from this container and
unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
