### PR TITLE
feat(snapshot-warehouse): twin-detector v2 — returns-basis comparison (default levels)

### DIFF
--- a/dev/status/rename-twin-dedup.md
+++ b/dev/status/rename-twin-dedup.md
@@ -54,15 +54,61 @@ duplicated legs can be dropped before the warehouse is written.
 
 Verify: `dune build && dune runtest trading/trading/backtest/snapshot_warehouse/test/`
 
+## What was built (v2 — returns-basis comparison)
+
+Real-data finding: the v1 level-basis detector, armed on the real
+top-3000 warehouse, found 15 exact-feed rename groups (incl. NLS/BFX)
+but **missed 9 of the 10 known rename-twin groups** — the two feeds
+carry different adjustment bases, so the adjusted-close *levels* diverge
+(constant or drifting ratio) even though it's the same instrument.
+Measured on the CSV store: level match@1e-4 was 0.000–0.831 for those 9
+pairs (all below the 0.95 bar), while their **daily-return** match
+(|ret_a − ret_b| ≤ 1e-3 absolute) was 0.951–0.993 (all above). Controls
+BALL/TAP and ASB/CDX_old (different companies) score 0.055 / 0.061 on
+returns → correctly rejected.
+
+v2 adds a `basis` axis to `Twin_detector.Config`:
+
+- `type basis = Levels | Returns [@@deriving sexp, equal]`;
+  `basis : basis [@sexp.default Levels]` + `ret_epsilon : float
+  [@sexp.default 1e-3]`. `Levels` = exactly the v1 behaviour
+  (bit-identical; existing 9 tests untouched, un-annotated config sexps
+  parse unchanged). `Returns` = twin iff ≥ `min_overlap_days` shared
+  dates AND > `match_fraction` of consecutive-shared-date return pairs
+  have `|ret_a − ret_b| ≤ ret_epsilon` (absolute). Return pairs whose
+  prior close ≤ 0 are skipped (undefined return); fraction is over the
+  valid pairs.
+- **Prefilter is basis-aware** so it stays scale-invariant under
+  `Returns`: anchors on the anchor-date *return* (each leg's close vs
+  its own prior bar) instead of the close, grouping near-equal *returns*
+  (absolute gap) rather than near-equal levels (relative gap). Preserves
+  the documented completeness property — a dense ≥ `min_overlap_days`
+  overlap always contains an interior anchor where both legs have a
+  defined, near-identical return (a leg's first bar has no prior return
+  and is harmlessly skipped). Documented in the `.mli`.
+- CLI: `build_scenario_snapshots` gains `-twin-basis <levels|returns>`
+  (default levels) + `-twin-ret-epsilon` (default 1e-3). Report header
+  now prints `basis=` + `ret_epsilon=`; per-group `match=` fraction is
+  the return-match fraction when basis=returns.
+- Tests (extend `test_twin_detector.ml`, 16 total): scaled twin
+  (×0.78 — levels miss, returns catch), drifting-ratio twin (mid-series
+  2:1 step — returns catch at 38/39=0.974, levels miss), independent
+  same-start-price control (not a twin under returns), scaled/drifting
+  pairs explicitly missed under levels, tie-break + offset-window
+  re-hold under returns.
+
+Verify: `dune build && dune runtest trading/trading/backtest/snapshot_warehouse/test/`
+
 ## Next task (dispatcher-owned)
 
-Rebuild the deep warehouse with `-dedupe-rename-twins`, diff the emitted
-`rename_twin_report.txt` against the 10 known twin groups (NLS/BFX,
-ISIS/IONS, JW-A/JWA/WLY, COR/ABC(+COR_old), BKR/BHI, BLL/BALL, SWM/MATV,
-TXNM/PNM, NVRI/HSC, SJW/HTO; plus new candidate ASB/CDX_old), then re-pin
-the record deep-run goldens on the deduped warehouse and re-measure the
-realized-PnL delta. This is a warehouse rebuild + golden re-pin — kept
-out of this code-only PR.
+Rebuild the deep warehouse with `-dedupe-rename-twins -twin-basis
+returns`, diff the emitted `rename_twin_report.txt` against the 10 known
+twin groups (NLS/BFX, ISIS/IONS, JW-A/JWA/WLY, COR/ABC(+COR_old),
+BKR/BHI, BLL/BALL, SWM/MATV, TXNM/PNM, NVRI/HSC, SJW/HTO; plus new
+candidate ASB/CDX_old) — returns basis should now catch all 10 —, then
+re-pin the record deep-run goldens on the deduped warehouse and
+re-measure the realized-PnL delta. This is a warehouse rebuild + golden
+re-pin — kept out of these code-only PRs.
 
 ## Follow-ups
 

--- a/trading/trading/backtest/snapshot_warehouse/build_scenario_snapshots.ml
+++ b/trading/trading/backtest/snapshot_warehouse/build_scenario_snapshots.ml
@@ -171,15 +171,37 @@ let command =
      and twin_close_epsilon =
        flag "twin-close-epsilon"
          (optional_with_default Twin_detector.Config.default.close_epsilon float)
-         ~doc:"E Relative tolerance for a single-day close match"
+         ~doc:"E Relative tolerance for a single-day close match (basis=levels)"
+     and twin_basis =
+       flag "twin-basis"
+         (optional_with_default "levels" string)
+         ~doc:
+           "B Comparison basis: levels (default, adjusted-close levels) or \
+            returns (consecutive daily returns — catches renames whose feeds \
+            carry different adjustment bases)"
+     and twin_ret_epsilon =
+       flag "twin-ret-epsilon"
+         (optional_with_default Twin_detector.Config.default.ret_epsilon float)
+         ~doc:
+           "E Absolute tolerance on the daily-return difference (basis=returns)"
      in
      fun () ->
+       let basis =
+         match String.lowercase twin_basis with
+         | "levels" -> Twin_detector.Config.Levels
+         | "returns" -> Twin_detector.Config.Returns
+         | other ->
+             failwithf "unknown -twin-basis %s (expected levels|returns)" other
+               ()
+       in
        let twin_config =
          {
            Twin_detector.Config.enabled = dedupe_rename_twins;
            min_overlap_days = twin_min_overlap_days;
            match_fraction = twin_match_fraction;
            close_epsilon = twin_close_epsilon;
+           basis;
+           ret_epsilon = twin_ret_epsilon;
            prefilter_rel_tol = Twin_detector.Config.default.prefilter_rel_tol;
          }
        in

--- a/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
@@ -3,15 +3,21 @@ open OUnit2
 open Matchers
 
 (* Small thresholds so the tiny fixtures below qualify as twins:
-   >= 5 overlapping days, > 95% near-identical closes. *)
+   >= 5 overlapping days, > 95% near-identical closes. Default [Levels] basis. *)
 let test_config =
   {
     Twin_detector.Config.enabled = true;
     min_overlap_days = 5;
     match_fraction = 0.95;
     close_epsilon = 1e-4;
+    basis = Twin_detector.Config.Levels;
+    ret_epsilon = 1e-3;
     prefilter_rel_tol = 2e-2;
   }
+
+(* Same thresholds under the returns basis. *)
+let returns_config =
+  { test_config with basis = Twin_detector.Config.Returns; ret_epsilon = 1e-3 }
 
 let start = Date.of_string "2020-01-01"
 
@@ -191,6 +197,136 @@ let test_offset_window_detected _ =
            ];
        ])
 
+(* A scaled copy: leg B closes are leg A's closes times [factor]. Different
+   adjustment basis → levels diverge by a constant ratio, returns are identical. *)
+let scaled_series ~symbol ~factor closes =
+  series_of ~symbol (List.map closes ~f:(fun c -> c *. factor))
+
+(* (a) Scaled twin — leg [SML] is leg [BIG] * 0.78 (a constant adjustment-basis
+   ratio). Levels diverge (0.78 gap on every day) so [Levels] misses it; the
+   daily returns are identical so [Returns] catches it. [BIG] < [SML]
+   lexicographically and both share every date, so [BIG] survives. *)
+let test_scaled_twin_returns _ =
+  let closes = ramp ~n:20 ~base:100.0 in
+  let big = series_of ~symbol:"BIG" closes in
+  let small = scaled_series ~symbol:"SML" ~factor:0.78 closes in
+  let report = Twin_detector.detect returns_config [ big; small ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "BIG");
+             field group_dropped (equal_to [ "SML" ]);
+           ];
+       ]);
+  assert_that report.dropped_symbols (equal_to [ "SML" ])
+
+(* (d) The same scaled pair under [Levels] is NOT a twin — the constant 0.78
+   gap exceeds [close_epsilon] on every day. Confirms the levels basis is
+   scale-sensitive (v1 behaviour, unchanged). *)
+let test_scaled_twin_missed_by_levels _ =
+  let closes = ramp ~n:20 ~base:100.0 in
+  let big = series_of ~symbol:"BIG" closes in
+  let small = scaled_series ~symbol:"SML" ~factor:0.78 closes in
+  let report = Twin_detector.detect test_config [ big; small ] in
+  assert_that report.groups is_empty;
+  assert_that report.dropped_symbols is_empty
+
+(* (b) Drifting-ratio twin — [OLDCO] equals [NEWCO] for the first 20 shared days
+   then carries an extra 2:1 adjustment (halved) for the next 20. Returns match
+   on every consecutive pair except the single boundary day (38/39 = 0.974 >
+   0.95), so [Returns] catches it; levels match only half the window so [Levels]
+   misses it. [NEWCO] ends 2 days later, so it survives. *)
+let drifting_closes ~n ~split ~base =
+  List.init n ~f:(fun i ->
+      let c = base +. Float.of_int i in
+      if i < split then c else c *. 0.5)
+
+let test_drifting_ratio_twin_returns _ =
+  let newco = series_of ~symbol:"NEWCO" (ramp ~n:42 ~base:100.0) in
+  let oldco =
+    series_of ~symbol:"OLDCO" (drifting_closes ~n:40 ~split:20 ~base:100.0)
+  in
+  let report = Twin_detector.detect returns_config [ newco; oldco ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "NEWCO");
+             field group_dropped (equal_to [ "OLDCO" ]);
+             field
+               (fun (g : Twin_detector.group) ->
+                 List.map g.matches ~f:(fun m -> m.match_fraction))
+               (elements_are
+                  [ is_between (module Float_ord) ~low:0.95 ~high:1.0 ]);
+           ];
+       ])
+
+(* The same drifting-ratio pair matches only half the shared days on levels,
+   so [Levels] does not call it a twin. *)
+let test_drifting_ratio_missed_by_levels _ =
+  let newco = series_of ~symbol:"NEWCO" (ramp ~n:42 ~base:100.0) in
+  let oldco =
+    series_of ~symbol:"OLDCO" (drifting_closes ~n:40 ~split:20 ~base:100.0)
+  in
+  let report = Twin_detector.detect test_config [ newco; oldco ] in
+  assert_that report.groups is_empty
+
+(* (c) Different-instruments control — two series that start at the same price
+   but follow independent return paths ([UP] arithmetic +1/day, [GEO] geometric
+   +2%/day). Returns differ on every day, so [Returns] does NOT call them
+   twins. Guards against the returns basis over-matching same-priced names. *)
+let test_independent_returns_not_twin _ =
+  let up = series_of ~symbol:"UP" (ramp ~n:30 ~base:100.0) in
+  let geo =
+    series_of ~symbol:"GEO"
+      (List.init 30 ~f:(fun i -> 100.0 *. (1.02 ** Float.of_int i)))
+  in
+  let report = Twin_detector.detect returns_config [ up; geo ] in
+  assert_that report.groups is_empty;
+  assert_that report.dropped_symbols is_empty;
+  assert_that
+    (Twin_detector.survivors report ~all_symbols:[ "UP"; "GEO" ])
+    (equal_to [ "UP"; "GEO" ])
+
+(* (e) Tie-break re-holds under [Returns]: two identical full-window legs have
+   identical returns; with no later-ending leg the survivor is the smaller
+   symbol ([BFX] < [NLS]). *)
+let test_identical_data_end_tiebreak_returns _ =
+  let closes = ramp ~n:20 ~base:60.0 in
+  let nls = series_of ~symbol:"NLS" closes in
+  let bfx = series_of ~symbol:"BFX" closes in
+  let report = Twin_detector.detect returns_config [ nls; bfx ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "BFX");
+             field group_dropped (equal_to [ "NLS" ]);
+           ];
+       ])
+
+(* (e) Offset-window prefilter re-holds under [Returns]: [OLD] starts at day 7
+   (its first bar has no prior return and is skipped by the prefilter) but its
+   interior returns match [NEW] on days 8..26, so the twin is still detected. *)
+let test_offset_window_detected_returns _ =
+  let newco = series_of ~symbol:"NEW" (ramp ~n:30 ~base:80.0) in
+  let old_closes = List.init 20 ~f:(fun i -> 80.0 +. Float.of_int (7 + i)) in
+  let oldco = series_from ~symbol:"OLD" ~offset:7 old_closes in
+  let report = Twin_detector.detect returns_config [ newco; oldco ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "NEW");
+             field group_dropped (equal_to [ "OLD" ]);
+           ];
+       ])
+
 let suite =
   "twin_detector"
   >::: [
@@ -203,6 +339,16 @@ let suite =
          "reported_match_fraction" >:: test_reported_match_fraction;
          "identical_data_end_tiebreak" >:: test_identical_data_end_tiebreak;
          "offset_window_detected" >:: test_offset_window_detected;
+         "scaled_twin_returns" >:: test_scaled_twin_returns;
+         "scaled_twin_missed_by_levels" >:: test_scaled_twin_missed_by_levels;
+         "drifting_ratio_twin_returns" >:: test_drifting_ratio_twin_returns;
+         "drifting_ratio_missed_by_levels"
+         >:: test_drifting_ratio_missed_by_levels;
+         "independent_returns_not_twin" >:: test_independent_returns_not_twin;
+         "identical_data_end_tiebreak_returns"
+         >:: test_identical_data_end_tiebreak_returns;
+         "offset_window_detected_returns"
+         >:: test_offset_window_detected_returns;
        ]
 
 let () = run_test_tt_main suite

--- a/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/test/test_twin_detector.ml
@@ -259,8 +259,10 @@ let test_drifting_ratio_twin_returns _ =
              field
                (fun (g : Twin_detector.group) ->
                  List.map g.matches ~f:(fun m -> m.match_fraction))
-               (elements_are
-                  [ is_between (module Float_ord) ~low:0.95 ~high:1.0 ]);
+               (* Exactly 38/39: the split-boundary day is a genuine return
+                  MISMATCH that the fraction must count — an all-match 1.0
+                  would mean the boundary was silently absorbed. *)
+               (elements_are [ float_equal (38.0 /. 39.0) ]);
            ];
        ])
 
@@ -273,6 +275,32 @@ let test_drifting_ratio_missed_by_levels _ =
   in
   let report = Twin_detector.detect test_config [ newco; oldco ] in
   assert_that report.groups is_empty
+
+(* Corrupt-bar guard — a zero close mid-series (real warehouses carry such
+   rows; MSZ precedent). The pair whose PRIOR close is the zero is skipped
+   rather than counted as a mismatch, so an otherwise-identical twin still
+   reports a full match fraction over the valid pairs. Pins the
+   [_returns_match_fraction] prior-close <= 0 guard. *)
+let test_zero_close_pair_skipped_not_diluted _ =
+  let closes =
+    List.init 30 ~f:(fun i -> if i = 15 then 0.0 else 100.0 +. Float.of_int i)
+  in
+  let newco = series_of ~symbol:"NEWCO" closes in
+  let oldco = truncate_series ~symbol:"OLDCO" ~n:28 closes in
+  let report = Twin_detector.detect returns_config [ newco; oldco ] in
+  assert_that report.groups
+    (elements_are
+       [
+         all_of
+           [
+             field group_survivor (equal_to "NEWCO");
+             field group_dropped (equal_to [ "OLDCO" ]);
+             field
+               (fun (g : Twin_detector.group) ->
+                 List.map g.matches ~f:(fun m -> m.match_fraction))
+               (elements_are [ float_equal 1.0 ]);
+           ];
+       ])
 
 (* (c) Different-instruments control — two series that start at the same price
    but follow independent return paths ([UP] arithmetic +1/day, [GEO] geometric
@@ -344,6 +372,8 @@ let suite =
          "drifting_ratio_twin_returns" >:: test_drifting_ratio_twin_returns;
          "drifting_ratio_missed_by_levels"
          >:: test_drifting_ratio_missed_by_levels;
+         "zero_close_pair_skipped_not_diluted"
+         >:: test_zero_close_pair_skipped_not_diluted;
          "independent_returns_not_twin" >:: test_independent_returns_not_twin;
          "identical_data_end_tiebreak_returns"
          >:: test_identical_data_end_tiebreak_returns;

--- a/trading/trading/backtest/snapshot_warehouse/twin_detector.ml
+++ b/trading/trading/backtest/snapshot_warehouse/twin_detector.ml
@@ -1,11 +1,15 @@
 open Core
 
 module Config = struct
+  type basis = Levels | Returns [@@deriving sexp, equal]
+
   type t = {
     enabled : bool;
     min_overlap_days : int;
     match_fraction : float;
     close_epsilon : float;
+    basis : basis; [@sexp.default Levels]
+    ret_epsilon : float; [@sexp.default 1e-3]
     prefilter_rel_tol : float;
   }
   [@@deriving sexp, equal]
@@ -16,6 +20,8 @@ module Config = struct
       min_overlap_days = 100;
       match_fraction = 0.95;
       close_epsilon = 1e-4;
+      basis = Levels;
+      ret_epsilon = 1e-3;
       prefilter_rel_tol = 2e-2;
     }
 end
@@ -54,46 +60,103 @@ let _relative_diff a b =
   let denom = Float.max (Float.abs a) (Float.abs b) in
   if Float.( <= ) denom 0.0 then 0.0 else Float.abs (a -. b) /. denom
 
-(* Merge two date-sorted close arrays, counting shared dates and, among
-   those, how many have near-identical closes within [epsilon]. *)
-let _overlap_and_match a b ~epsilon =
+(* Merge two date-sorted close arrays into the (close_a, close_b) pairs on the
+   dates both series have, in ascending date order. *)
+let _shared_closes a b =
   let la = Array.length a and lb = Array.length b in
   let i = ref 0 and j = ref 0 in
-  let overlap = ref 0 and matched = ref 0 in
+  let acc = ref [] in
   while !i < la && !j < lb do
     let da, ca = a.(!i) and db, cb = b.(!j) in
     let c = Date.compare da db in
     if c < 0 then incr i
     else if c > 0 then incr j
     else begin
-      incr overlap;
-      if Float.( <= ) (_relative_diff ca cb) epsilon then incr matched;
+      acc := (ca, cb) :: !acc;
       incr i;
       incr j
     end
   done;
-  (!overlap, !matched)
+  Array.of_list (List.rev !acc)
+
+(* [Levels] fraction: shared dates whose closes match within [epsilon]. *)
+let _levels_match_fraction shared ~epsilon =
+  let overlap = Array.length shared in
+  if Int.equal overlap 0 then 0.0
+  else
+    let matched =
+      Array.count shared ~f:(fun (ca, cb) ->
+          Float.( <= ) (_relative_diff ca cb) epsilon)
+    in
+    Float.of_int matched /. Float.of_int overlap
+
+(* [Returns] fraction: consecutive-shared-date return pairs whose simple daily
+   returns differ by at most [epsilon] (absolute). A pair is skipped when the
+   prior close of either leg is <= 0 (undefined return); the fraction is over
+   the surviving (valid) pairs. Returns 0.0 when no valid pair exists. *)
+let _returns_match_fraction shared ~epsilon =
+  let valid = ref 0 and matched = ref 0 in
+  for k = 1 to Array.length shared - 1 do
+    let pa, pb = shared.(k - 1) and ca, cb = shared.(k) in
+    if Float.( > ) pa 0.0 && Float.( > ) pb 0.0 then begin
+      incr valid;
+      let ra = (ca -. pa) /. pa and rb = (cb -. pb) /. pb in
+      if Float.( <= ) (Float.abs (ra -. rb)) epsilon then incr matched
+    end
+  done;
+  if Int.equal !valid 0 then 0.0
+  else Float.of_int !matched /. Float.of_int !valid
+
+(* Number of shared dates and the basis-appropriate match fraction. *)
+let _overlap_and_fraction (config : Config.t) a b =
+  let shared = _shared_closes a b in
+  let frac =
+    match config.basis with
+    | Levels -> _levels_match_fraction shared ~epsilon:config.close_epsilon
+    | Returns -> _returns_match_fraction shared ~epsilon:config.ret_epsilon
+  in
+  (Array.length shared, frac)
 
 (* [Some (overlap, fraction)] when [a] and [b] meet the twin criterion. *)
 let _twin_stats (config : Config.t) a b =
-  let overlap, matched =
-    _overlap_and_match a.closes b.closes ~epsilon:config.close_epsilon
-  in
+  let overlap, frac = _overlap_and_fraction config a.closes b.closes in
   if overlap < config.min_overlap_days then None
-  else
-    let frac = Float.of_int matched /. Float.of_int overlap in
-    if Float.( > ) frac config.match_fraction then Some (overlap, frac)
-    else None
+  else if Float.( > ) frac config.match_fraction then Some (overlap, frac)
+  else None
+
+(* Index of [date] in the date-sorted array, if present. *)
+let _index_on arr ~date =
+  Array.binary_search arr
+    ~compare:(fun (d1, _) (d2, _) -> Date.compare d1 d2)
+    `First_equal_to (date, Float.nan)
 
 (* Adjusted close on [date] via binary search of the sorted array. *)
 let _close_on arr ~date =
-  match
-    Array.binary_search arr
-      ~compare:(fun (d1, _) (d2, _) -> Date.compare d1 d2)
-      `First_equal_to (date, Float.nan)
-  with
-  | Some i -> Some (snd arr.(i))
-  | None -> None
+  Option.map (_index_on arr ~date) ~f:(fun i -> snd arr.(i))
+
+(* Simple daily return on [date] — close on [date] vs the leg's own prior bar.
+   [None] when [date] is the leg's first bar (no prior) or the prior close is
+   non-positive (undefined return). *)
+let _return_on arr ~date =
+  match _index_on arr ~date with
+  | Some i when i > 0 ->
+      let prev = snd arr.(i - 1) and cur = snd arr.(i) in
+      if Float.( > ) prev 0.0 then Some ((cur -. prev) /. prev) else None
+  | _ -> None
+
+(* Anchor key of series [s] on [date] under the configured basis: the close
+   ([Levels]) or the anchor-date return ([Returns]). *)
+let _anchor_key (config : Config.t) s ~date =
+  match config.basis with
+  | Levels -> _close_on s.closes ~date
+  | Returns -> _return_on s.closes ~date
+
+(* Whether two anchor keys are near enough to co-run in the prefilter: a
+   relative close gap ([Levels]) or an absolute return gap ([Returns]). *)
+let _prefilter_close_enough (config : Config.t) a b =
+  match config.basis with
+  | Levels -> Float.( <= ) (_relative_diff a b) config.prefilter_rel_tol
+  | Returns -> Float.( <= ) (Float.abs (a -. b)) config.prefilter_rel_tol
 
 (* Every distinct date across all series, sorted ascending. *)
 let _unique_sorted_dates series_arr =
@@ -109,25 +172,25 @@ let _anchor_dates ~stride series_arr =
   let all = _unique_sorted_dates series_arr in
   Array.filteri all ~f:(fun idx _ -> idx % stride = 0)
 
-(* Series active on [date], as (index, close) sorted ascending by close. *)
-let _actives_at series_arr ~date =
+(* Series with a defined anchor key on [date], as (index, key) sorted ascending
+   by key. Under [Returns] a leg without a prior bar on [date] is omitted. *)
+let _actives_at (config : Config.t) series_arr ~date =
   Array.filter_mapi series_arr ~f:(fun i s ->
-      Option.map (_close_on s.closes ~date) ~f:(fun c -> (i, c)))
+      Option.map (_anchor_key config s ~date) ~f:(fun k -> (i, k)))
   |> Array.to_list
-  |> List.sort ~compare:(fun (_, c1) (_, c2) -> Float.compare c1 c2)
+  |> List.sort ~compare:(fun (_, k1) (_, k2) -> Float.compare k1 k2)
 
-(* Partition a close-sorted (index, close) list into maximal runs whose
-   consecutive relative gap stays within [rel_tol]. Twins land in one run. *)
-let _group_runs ~rel_tol sorted =
+(* Partition a key-sorted (index, key) list into maximal runs whose consecutive
+   keys stay near per [close_enough]. Twins land in one run. *)
+let _group_runs ~close_enough sorted =
   match sorted with
   | [] -> []
-  | (i0, c0) :: tl ->
+  | (i0, k0) :: tl ->
       let runs, cur, _ =
-        List.fold tl ~init:([], [ i0 ], c0)
-          ~f:(fun (runs, cur, prev_c) (i, c) ->
-            if Float.( <= ) (_relative_diff prev_c c) rel_tol then
-              (runs, i :: cur, c)
-            else (cur :: runs, [ i ], c))
+        List.fold tl ~init:([], [ i0 ], k0)
+          ~f:(fun (runs, cur, prev_k) (i, k) ->
+            if close_enough prev_k k then (runs, i :: cur, k)
+            else (cur :: runs, [ i ], k))
       in
       cur :: runs
 
@@ -149,9 +212,10 @@ let _candidate_pairs (config : Config.t) series_arr =
   let stride = Int.max 1 (config.min_overlap_days / 2) in
   let anchors = _anchor_dates ~stride series_arr in
   let seen = Hash_set.create (module Int) in
+  let close_enough = _prefilter_close_enough config in
   Array.iter anchors ~f:(fun date ->
-      _actives_at series_arr ~date
-      |> _group_runs ~rel_tol:config.prefilter_rel_tol
+      _actives_at config series_arr ~date
+      |> _group_runs ~close_enough
       |> List.iter ~f:(fun run ->
           List.iter (_run_pairs run) ~f:(fun (i, j) ->
               Hash_set.add seen ((i * n) + j))));
@@ -184,13 +248,8 @@ let _pick_survivor members =
       | _ -> if String.compare a.symbol b.symbol <= 0 then a else b)
 
 let _make_pair_match (config : Config.t) survivor dropped =
-  let overlap, matched =
-    _overlap_and_match survivor.closes dropped.closes
-      ~epsilon:config.close_epsilon
-  in
-  let frac =
-    if Int.equal overlap 0 then 0.0
-    else Float.of_int matched /. Float.of_int overlap
+  let overlap, frac =
+    _overlap_and_fraction config survivor.closes dropped.closes
   in
   {
     survivor = survivor.symbol;
@@ -255,14 +314,19 @@ let _render_group (g : group) =
   in
   String.concat ~sep:"\n" (hdr :: List.map g.matches ~f:_render_match)
 
+let _basis_label = function
+  | Config.Levels -> "levels"
+  | Config.Returns -> "returns"
+
 let render report =
   let cfg = report.config in
   let header =
     Printf.sprintf
-      "rename-twin report: enabled=%b min_overlap_days=%d match_fraction=%.4f \
-       close_epsilon=%.6g\n\
+      "rename-twin report: basis=%s enabled=%b min_overlap_days=%d \
+       match_fraction=%.4f close_epsilon=%.6g ret_epsilon=%.6g\n\
        %d group(s), %d symbol(s) dropped"
-      cfg.enabled cfg.min_overlap_days cfg.match_fraction cfg.close_epsilon
+      (_basis_label cfg.basis) cfg.enabled cfg.min_overlap_days
+      cfg.match_fraction cfg.close_epsilon cfg.ret_epsilon
       (List.length report.groups)
       (List.length report.dropped_symbols)
   in

--- a/trading/trading/backtest/snapshot_warehouse/twin_detector.mli
+++ b/trading/trading/backtest/snapshot_warehouse/twin_detector.mli
@@ -15,6 +15,19 @@
     large-caps that happen to trade near the same price on one day) are {b not}
     twins under this criterion.
 
+    {b Comparison basis (v2).} The detector supports two criteria:
+    - [Levels] (default, v1 behaviour): compares adjusted-close {e levels}.
+      Catches exact-feed duplicates (the two legs carry the same adjustment
+      basis).
+    - [Returns]: compares consecutive {e daily returns}. Catches renames whose
+      two feeds carry {e different} adjustment bases — the levels diverge by a
+      constant or drifting ratio, so [Levels] misses them, but the daily returns
+      stay near-identical. On the real top-3000 warehouse [Levels] found 15
+      exact-feed groups yet missed 9 of the 10 known rename twins (e.g.
+      BLL/BALL, BKR/BHI, TXNM/PNM); those 9 all score 0.95–0.99 under [Returns]
+      while genuine different-company controls (BALL/TAP, ASB/CDX_old) score
+      below 0.06.
+
     The detector is a pure function of [Config.t] + a list of {!series} (no
     filesystem, no bar loading), so it is directly unit-testable.
     {!Build_scenario_snapshots} owns the loading + wiring. *)
@@ -22,6 +35,12 @@
 open Core
 
 module Config : sig
+  type basis =
+    | Levels  (** Compare adjusted-close levels (v1 behaviour). *)
+    | Returns
+        (** Compare consecutive daily returns (adjustment-basis-agnostic). *)
+  [@@deriving sexp, equal]
+
   type t = {
     enabled : bool;
         (** Master switch. Defaults to [false] so the detector is a no-op (empty
@@ -32,24 +51,34 @@ module Config : sig
             this many dates. Guards against short coincidental overlaps being
             called twins. *)
     match_fraction : float;
-        (** A twin requires strictly more than this fraction of the overlapping
-            dates to have near-identical adjusted closes. *)
+        (** A twin requires strictly more than this fraction of the compared
+            units — overlapping dates ([Levels]) or consecutive-date return
+            pairs ([Returns]) — to be near-identical. *)
     close_epsilon : float;
-        (** Relative tolerance for "near-identical" on a single date: two closes
+        (** [Levels] tolerance for "near-identical" on a single date: two closes
             [a] and [b] match when [|a - b| / max |a| |b| <= close_epsilon]. *)
+    basis : basis; [@sexp.default Levels]
+        (** Which comparison criterion to use. Defaults to [Levels] so an
+            un-annotated config sexp is bit-identical to v1. *)
+    ret_epsilon : float; [@sexp.default 1e-3]
+        (** [Returns] tolerance: two consecutive-date returns [ra] and [rb]
+            match when [|ra - rb| <= ret_epsilon] (absolute difference of simple
+            daily returns). Unused under [Levels]. *)
     prefilter_rel_tol : float;
         (** Internal perf knob. The prefilter only emits a candidate pair when
-            two symbols sit within this relative gap on a shared anchor date.
-            Must be [>= close_epsilon] (looser) so genuine twins are never
-            filtered out before the full compare; kept small so near-equal price
-            runs stay short. *)
+            two symbols sit within this gap on a shared anchor date — a
+            {e relative} close gap under [Levels], an {e absolute} return gap
+            under [Returns]. Must be looser than the matching tolerance so
+            genuine twins are never filtered out before the full compare; kept
+            small so near-equal runs stay short. *)
   }
   [@@deriving sexp, equal]
 
   val default : t
   (** Default config: disabled; [min_overlap_days = 100],
-      [match_fraction = 0.95], [close_epsilon = 1e-4],
-      [prefilter_rel_tol = 2e-2] — the criterion the visual audit used. *)
+      [match_fraction = 0.95], [close_epsilon = 1e-4], [basis = Levels],
+      [ret_epsilon = 1e-3], [prefilter_rel_tol = 2e-2] — the criterion the
+      visual audit used. *)
 end
 
 type series = {
@@ -68,8 +97,9 @@ type pair_match = {
   dropped : string;
   overlap_days : int;  (** Number of dates the two series share. *)
   match_fraction : float;
-      (** Fraction of overlapping dates whose closes matched within
-          [close_epsilon]. *)
+      (** Fraction of compared units that matched: overlapping dates within
+          [close_epsilon] ([Levels]), or consecutive-date return pairs within
+          [ret_epsilon] ([Returns]). *)
 }
 [@@deriving sexp_of, equal]
 
@@ -93,10 +123,19 @@ type report = {
 val detect : Config.t -> series list -> report
 (** [detect config series] finds rename-twin groups. When [config.enabled] is
     [false] it returns an empty report (no group, no dropped symbol). Otherwise
-    it prefilters candidate pairs by shared anchor-date price proximity,
-    verifies each with the full overlap/match-fraction criterion, unions
-    verified twin edges into connected components (so triples are one group),
-    and picks the latest-[data_end] leg of each component as the survivor.
+    it prefilters candidate pairs by shared anchor-date proximity, verifies each
+    with the full overlap/match-fraction criterion, unions verified twin edges
+    into connected components (so triples are one group), and picks the
+    latest-[data_end] leg of each component as the survivor.
+
+    {b Prefilter completeness.} Anchors are every [min_overlap_days/2]-th
+    distinct date, so any pair whose dense overlap spans at least
+    [min_overlap_days] dates shares an anchor. Under [Levels] the anchor key is
+    the close; under [Returns] it is the anchor-date return (each leg's close vs
+    its own prior bar). A [Returns] anchor is only usable for a leg that has a
+    prior bar on that date, so a leg's very first bar is skipped — harmless
+    because a dense [>= min_overlap_days] overlap always contains an interior
+    anchor where both legs have a defined, near-identical return.
 
     {b Limitation (v1).} A dropped leg is excluded entirely; any
     genuinely-independent tail it may have outside the survivor's window is


### PR DESCRIPTION
## What it does

Adds a **returns-basis** comparison criterion to the builder-side `Twin_detector` (`trading/trading/backtest/snapshot_warehouse/`), behind a new `basis` config field that **defaults to `Levels`** (bit-identical v1 behaviour — experiment-flag-discipline R1).

### Why (real-data finding)

The merged v1 detector compares adjusted-close **levels**. Armed on the real top-3000 warehouse it found 15 exact-feed rename groups (incl. NLS/BFX) but **missed 9 of the 10 known rename-twin groups** — the two feeds carry different adjustment bases, so the levels diverge (constant or drifting ratio) even though it is the same instrument. Measured on the CSV store (adjusted_close):

- Level match@1e-4 for the 9 missed pairs: 0.000–0.831 (all below the 0.95 bar).
- **Daily-return** match (|ret_a − ret_b| ≤ 1e-3 absolute, consecutive shared dates): 0.951–0.993 (all above).
- Different-company controls BALL/TAP and ASB/CDX_old score 0.055 / 0.061 on returns → correctly rejected.

## Design

- `type basis = Levels | Returns [@@deriving sexp, equal]`; `basis : basis [@sexp.default Levels]` + `ret_epsilon : float [@sexp.default 1e-3]`. Un-annotated config sexps parse unchanged.
- `Returns` = twin iff ≥ `min_overlap_days` shared dates AND > `match_fraction` of consecutive-shared-date return pairs have `|ret_a − ret_b| ≤ ret_epsilon` (absolute simple daily returns). Return pairs whose prior close ≤ 0 are skipped; fraction is over the valid pairs.
- **Prefilter is basis-aware** so it stays scale-invariant: under `Returns` it anchors on the anchor-date *return* (each leg's close vs its own prior bar) grouping near-equal returns by absolute gap, instead of near-equal levels by relative gap. Preserves the documented completeness property — a dense ≥ `min_overlap_days` overlap always contains an interior anchor where both legs have a defined, near-identical return (a leg's first bar has no prior return and is harmlessly skipped). Documented in the `.mli`.
- CLI: `-twin-basis <levels|returns>` (default levels) + `-twin-ret-epsilon` (default 1e-3). Report header prints `basis=` + `ret_epsilon=`; per-group `match=` is the return-match fraction when basis=returns.

## Test coverage (`test_twin_detector.ml`, 16 tests)

- `scaled_twin_returns` — leg B = leg A × 0.78 (constant adjustment ratio): levels miss, returns catch.
- `scaled_twin_missed_by_levels` — same pair under `Levels` → not a twin (confirms v1 scale-sensitivity unchanged).
- `drifting_ratio_twin_returns` — mid-series 2:1 adjustment step: returns match 38/39 = 0.974 > 0.95 (single boundary day excepted).
- `drifting_ratio_missed_by_levels` — same pair matches only half the days on levels → not a twin.
- `independent_returns_not_twin` — two series, same start price, independent return paths (arithmetic vs geometric) → not a twin under returns.
- `identical_data_end_tiebreak_returns`, `offset_window_detected_returns` — tie-break + offset-window prefilter re-hold under returns.
- The existing 9 `Levels` tests are untouched and still pass (bit-identical).

## Verify

```
dune build && dune runtest trading/trading/backtest/snapshot_warehouse/test/
```
All 16 tests OK; `dune build @…/fmt` clean.

Default-off (`Levels`) → no warehouse/golden churn until a build passes `-twin-basis returns`. The warehouse rebuild + golden re-pin remains dispatcher-owned (see `dev/status/rename-twin-dedup.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)