### PR TITLE
fix(validation): join audit records by position_id (V1/V2/V7/V8 were 100% skipped)

### DIFF
--- a/dev/status/post-run-validation.md
+++ b/dev/status/post-run-validation.md
@@ -30,7 +30,8 @@ expectations so we never make these kinds of trades again."
 - `trading/trading/backtest/validation/bin/post_run_validator_cli.ml` — CLI
   (`-run-dir -data-dir [-config] -out`).
 - `trading/trading/backtest/validation/test/test_post_run_validator.ml` — unit
-  tests for V1, V2, V5, V6, V9, V10, V11 + severity/validate wiring (12 tests).
+  tests for V1, V2, V5, V6, V9, V10, V11, audit-join + severity/validate wiring
+  (22 tests).
 
 ## Checks (V1-V11)
 
@@ -62,6 +63,20 @@ docker exec trading-1-dev bash -c \
    dune runtest trading/backtest/validation/'
 ```
 
+## Fixes
+
+- [x] **C6b: audit join rekeyed by `position_id`** (feat/validator-audit-join).
+  The join keyed `trade_audit.sexp` records to `trades.csv` rows by
+  `(symbol, entry_date)`, but audit records carry the SIGNAL Friday while rows
+  carry the FILL date — the lookup missed 100% of rows, silently skipping
+  V1/V2/V7/V8 (reported "PASS (N skipped)"). Now `build_audit_lookup` joins on
+  the `position_id` column (#1942, trailing column) when present, falling back
+  to `symbol|entry_date` for legacy 19-column runs. Report + CLI now print
+  `audit join: N/M rows matched` so a dead join can't masquerade as PASS.
+  Verify: `dune runtest trading/backtest/validation/test/` (join tests:
+  `join_by_position_id_survives_date_skew`,
+  `join_legacy_falls_back_to_symbol_date`, `audit_join_coverage_counts`).
+
 ## Follow-ups
 
 - Wire `scenario_runner --validate` post-step (out of scope for v1 per plan).
@@ -72,7 +87,7 @@ docker exec trading-1-dev bash -c \
   the bar-dependent V3/V4/V7 are covered structurally but want a golden-run
   integration test.
 
-## Last updated: 2026-07-12
+## Last updated: 2026-07-12 (C6b audit-join fix)
 
 ## Interface stable
 

--- a/dev/status/post-run-validation.md
+++ b/dev/status/post-run-validation.md
@@ -87,7 +87,7 @@ docker exec trading-1-dev bash -c \
   the bar-dependent V3/V4/V7 are covered structurally but want a golden-run
   integration test.
 
-## Last updated: 2026-07-12 (C6b audit-join fix)
+## Last updated: 2026-07-12
 
 ## Interface stable
 

--- a/trading/trading/backtest/validation/bin/post_run_validator_cli.ml
+++ b/trading/trading/backtest/validation/bin/post_run_validator_cli.ml
@@ -19,6 +19,8 @@ let _run ~run_dir ~data_dir ~config_path ~out =
   let config = Vt.load_config config_path in
   let report = Vr.run ~run_dir ~data_dir ~config ~out in
   List.iter report.checks ~f:(fun r -> printf "%s\n" (_summary_line r));
+  printf "audit join: %d/%d rows matched\n" report.audit_join.matched
+    report.audit_join.total;
   printf "wrote %s.sexp + %s.md\n" out out
 
 let command =

--- a/trading/trading/backtest/validation/lib/validator_artifacts.ml
+++ b/trading/trading/backtest/validation/lib/validator_artifacts.ml
@@ -124,7 +124,8 @@ let _build_audit_tables records =
 let _lookup (by_pid, by_sd) (row : trade_row) =
   match row.position_id with
   | Some pid -> Hashtbl.find by_pid pid
-  | None -> Hashtbl.find by_sd (_sd_key ~symbol:row.symbol ~entry_date:row.entry_date)
+  | None ->
+      Hashtbl.find by_sd (_sd_key ~symbol:row.symbol ~entry_date:row.entry_date)
 
 let build_audit_lookup rows = _lookup (_build_audit_tables rows)
 
@@ -141,7 +142,8 @@ let load_audit_lookup path =
   match try Some (Sexp.load_sexp path) with _ -> None with
   | None -> fun _ -> None
   | Some sexp ->
-      build_audit_lookup (List.map (_records_of_sexp sexp) ~f:_join_row_of_record)
+      build_audit_lookup
+        (List.map (_records_of_sexp sexp) ~f:_join_row_of_record)
 
 (* Two dates share an ISO trading week iff (year, week_number) match. *)
 let _same_week d1 d2 =

--- a/trading/trading/backtest/validation/lib/validator_artifacts.ml
+++ b/trading/trading/backtest/validation/lib/validator_artifacts.ml
@@ -4,6 +4,7 @@ open Validator_types
 let _date_opt s = try Some (Date.of_string s) with _ -> None
 let _float_opt s = if String.is_empty s then None else Float.of_string_opt s
 let _cell a i = if i < Array.length a then a.(i) else ""
+let _str_opt s = if String.is_empty s then None else Some s
 
 (* trades.csv column indices (see [Result_writer._trades_csv_header]). *)
 let _t_symbol = 0
@@ -16,6 +17,10 @@ let _t_quantity = 7
 let _t_exit_trigger = 12
 let _t_stop_distance = 15
 let _t_stop_kind = 16
+
+(* Trailing [position_id] column (added by #1942); absent on legacy 19-column
+   rows, where [_cell] returns "" and the join falls back to symbol|entry_date. *)
+let _t_position_id = 19
 
 (* open_positions.csv column indices (symbol,side,entry_date,entry_price,qty). *)
 let _o_symbol = 0
@@ -36,6 +41,7 @@ let _mk_trade a =
     exit_trigger = _cell a _t_exit_trigger;
     stop_trigger_kind = _cell a _t_stop_kind;
     stop_initial_distance_pct = _float_opt (_cell a _t_stop_distance);
+    position_id = _str_opt (_cell a _t_position_id);
   }
 
 (* A trades.csv row is well-formed when its date + numeric cells all parse. *)
@@ -86,28 +92,56 @@ let _entry_context_of (e : Backtest.Trade_audit.entry_decision) =
     resistance_quality = e.resistance_quality;
   }
 
-let _audit_key ~symbol ~entry_date = symbol ^ "|" ^ Date.to_string entry_date
+type audit_join_row = {
+  position_id : string;
+  symbol : string;
+  entry_date : Date.t;
+  context : entry_context;
+}
+
+let _sd_key ~symbol ~entry_date = symbol ^ "|" ^ Date.to_string entry_date
 
 let _records_of_sexp sexp =
   try (Backtest.Trade_audit.audit_blob_of_sexp sexp).audit_records
   with _ -> (
     try Backtest.Trade_audit.audit_records_of_sexp sexp with _ -> [])
 
-let _build_audit_table records =
-  let tbl = Hashtbl.create (module String) in
-  List.iter records ~f:(fun (r : Backtest.Trade_audit.audit_record) ->
-      let e = r.entry in
-      let key = _audit_key ~symbol:e.symbol ~entry_date:e.entry_date in
-      Hashtbl.set tbl ~key ~data:(_entry_context_of e));
-  tbl
+(* Audit records are keyed by position_id AND (symbol, entry_date). The latter
+   misses on real runs because the audit entry_date is the SIGNAL Friday while a
+   trades.csv row carries the FILL date (next trading day) — so a row that
+   carries a position_id must join on it, and only legacy rows without one fall
+   back to the symbol|date key. *)
+let _build_audit_tables records =
+  let by_pid = Hashtbl.create (module String) in
+  let by_sd = Hashtbl.create (module String) in
+  List.iter records ~f:(fun (r : audit_join_row) ->
+      Hashtbl.set by_pid ~key:r.position_id ~data:r.context;
+      Hashtbl.set by_sd
+        ~key:(_sd_key ~symbol:r.symbol ~entry_date:r.entry_date)
+        ~data:r.context);
+  (by_pid, by_sd)
 
-let _lookup_of_table tbl (row : trade_row) =
-  Hashtbl.find tbl (_audit_key ~symbol:row.symbol ~entry_date:row.entry_date)
+let _lookup (by_pid, by_sd) (row : trade_row) =
+  match row.position_id with
+  | Some pid -> Hashtbl.find by_pid pid
+  | None -> Hashtbl.find by_sd (_sd_key ~symbol:row.symbol ~entry_date:row.entry_date)
+
+let build_audit_lookup rows = _lookup (_build_audit_tables rows)
+
+let _join_row_of_record (r : Backtest.Trade_audit.audit_record) =
+  let e = r.entry in
+  {
+    position_id = e.position_id;
+    symbol = e.symbol;
+    entry_date = e.entry_date;
+    context = _entry_context_of e;
+  }
 
 let load_audit_lookup path =
   match try Some (Sexp.load_sexp path) with _ -> None with
   | None -> fun _ -> None
-  | Some sexp -> _lookup_of_table (_build_audit_table (_records_of_sexp sexp))
+  | Some sexp ->
+      build_audit_lookup (List.map (_records_of_sexp sexp) ~f:_join_row_of_record)
 
 (* Two dates share an ISO trading week iff (year, week_number) match. *)
 let _same_week d1 d2 =

--- a/trading/trading/backtest/validation/lib/validator_artifacts.mli
+++ b/trading/trading/backtest/validation/lib/validator_artifacts.mli
@@ -9,10 +9,26 @@ val parse_trades_csv : string -> trade_row list
 val parse_open_positions_csv : string -> open_row list
 (** Parse [open_positions.csv] at [path]; malformed rows are dropped. *)
 
+type audit_join_row = {
+  position_id : string;
+  symbol : string;
+  entry_date : Date.t;
+  context : entry_context;
+}
+(** A [trade_audit.sexp] entry leg projected to the fields the join needs. *)
+
+val build_audit_lookup : audit_join_row list -> trade_row -> entry_context option
+(** [build_audit_lookup rows] returns the {!trade_row} -> {!entry_context}
+    lookup. A trade row carrying a [position_id] joins on it — immune to the
+    audit's signal-date vs the trade's fill-date entry-date skew that made the
+    old [(symbol, entry_date)] join miss 100% of rows. A legacy row without a
+    [position_id] falls back to the [(symbol, entry_date)] key. *)
+
 val load_audit_lookup : string -> trade_row -> entry_context option
 (** [load_audit_lookup path] parses [trade_audit.sexp] and returns a lookup from
-    a {!trade_row} to its {!entry_context} (keyed by [(symbol, entry_date)]).
-    Returns an always-[None] lookup when the file cannot be read. *)
+    a {!trade_row} to its {!entry_context} via {!build_audit_lookup} (position_id
+    when the row has one, else [(symbol, entry_date)]). Returns an always-[None]
+    lookup when the file cannot be read. *)
 
 val load_bars : data_dir:string -> run_end:Date.t -> string -> bars option
 (** [load_bars ~data_dir ~run_end] returns a memoised per-symbol bar loader over

--- a/trading/trading/backtest/validation/lib/validator_artifacts.mli
+++ b/trading/trading/backtest/validation/lib/validator_artifacts.mli
@@ -17,7 +17,8 @@ type audit_join_row = {
 }
 (** A [trade_audit.sexp] entry leg projected to the fields the join needs. *)
 
-val build_audit_lookup : audit_join_row list -> trade_row -> entry_context option
+val build_audit_lookup :
+  audit_join_row list -> trade_row -> entry_context option
 (** [build_audit_lookup rows] returns the {!trade_row} -> {!entry_context}
     lookup. A trade row carrying a [position_id] joins on it — immune to the
     audit's signal-date vs the trade's fill-date entry-date skew that made the
@@ -26,9 +27,9 @@ val build_audit_lookup : audit_join_row list -> trade_row -> entry_context optio
 
 val load_audit_lookup : string -> trade_row -> entry_context option
 (** [load_audit_lookup path] parses [trade_audit.sexp] and returns a lookup from
-    a {!trade_row} to its {!entry_context} via {!build_audit_lookup} (position_id
-    when the row has one, else [(symbol, entry_date)]). Returns an always-[None]
-    lookup when the file cannot be read. *)
+    a {!trade_row} to its {!entry_context} via {!build_audit_lookup}
+    (position_id when the row has one, else [(symbol, entry_date)]). Returns an
+    always-[None] lookup when the file cannot be read. *)
 
 val load_bars : data_dir:string -> run_end:Date.t -> string -> bars option
 (** [load_bars ~data_dir ~run_end] returns a memoised per-symbol bar loader over

--- a/trading/trading/backtest/validation/lib/validator_checks.ml
+++ b/trading/trading/backtest/validation/lib/validator_checks.ml
@@ -45,10 +45,21 @@ let run_check ~id inputs =
   | Some (_, default_sev, fn) ->
       _result_of ~id ~default_sev ~config:inputs.config (fn inputs)
 
+(* How many trades resolved to a trade_audit record. Surfaced in the report so a
+   dead join (matched = 0) can't masquerade as "PASS (all skipped)". *)
+let _audit_join inputs =
+  let matched =
+    List.count inputs.trades ~f:(fun t -> Option.is_some (inputs.audit t))
+  in
+  { matched; total = List.length inputs.trades }
+
 let validate inputs =
   let disabled = inputs.config.disabled_checks in
   let ids =
     List.filter all_check_ids ~f:(fun id ->
         not (List.mem disabled id ~equal:String.equal))
   in
-  { checks = List.map ids ~f:(fun id -> run_check ~id inputs) }
+  {
+    checks = List.map ids ~f:(fun id -> run_check ~id inputs);
+    audit_join = _audit_join inputs;
+  }

--- a/trading/trading/backtest/validation/lib/validator_report.ml
+++ b/trading/trading/backtest/validation/lib/validator_report.ml
@@ -32,7 +32,8 @@ let render_md report =
       "# Post-run validation report\n\n\
        Invariant checks failing: %d\n\
        audit join: %d/%d rows matched\n\n"
-      (_failing_invariants report) j.matched j.total
+      (_failing_invariants report)
+      j.matched j.total
   in
   let body = List.map report.checks ~f:_check_line |> String.concat ~sep:"\n" in
   header ^ body ^ "\n"

--- a/trading/trading/backtest/validation/lib/validator_report.ml
+++ b/trading/trading/backtest/validation/lib/validator_report.ml
@@ -26,9 +26,13 @@ let _failing_invariants report =
       (not c.passed) && equal_severity c.severity Invariant)
 
 let render_md report =
+  let j = report.audit_join in
   let header =
-    sprintf "# Post-run validation report\n\nInvariant checks failing: %d\n\n"
-      (_failing_invariants report)
+    sprintf
+      "# Post-run validation report\n\n\
+       Invariant checks failing: %d\n\
+       audit join: %d/%d rows matched\n\n"
+      (_failing_invariants report) j.matched j.total
   in
   let body = List.map report.checks ~f:_check_line |> String.concat ~sep:"\n" in
   header ^ body ^ "\n"

--- a/trading/trading/backtest/validation/lib/validator_types.ml
+++ b/trading/trading/backtest/validation/lib/validator_types.ml
@@ -23,6 +23,7 @@ type trade_row = {
   exit_trigger : string;
   stop_trigger_kind : string;
   stop_initial_distance_pct : float option;
+  position_id : string option;
 }
 
 type open_row = {
@@ -76,7 +77,10 @@ type check_result = {
 }
 [@@deriving sexp]
 
-type report = { checks : check_result list } [@@deriving sexp]
+type audit_join = { matched : int; total : int } [@@deriving sexp]
+
+type report = { checks : check_result list; audit_join : audit_join }
+[@@deriving sexp]
 
 type inputs = {
   trades : trade_row list;

--- a/trading/trading/backtest/validation/lib/validator_types.mli
+++ b/trading/trading/backtest/validation/lib/validator_types.mli
@@ -24,6 +24,11 @@ type trade_row = {
           / [non_stop_exit]; empty string when absent. *)
   stop_initial_distance_pct : float option;
       (** [stop_initial_distance_pct] column; [None] when the cell is empty. *)
+  position_id : string option;
+      (** [position_id] column (trailing column added by #1942), e.g.
+          ["A-wein-5618"]. [None] for legacy runs whose [trades.csv] predates the
+          column; the audit join falls back to [(symbol, entry_date)] for those.
+      *)
 }
 (** A parsed [trades.csv] round-trip row (only the fields the checks read). *)
 
@@ -102,8 +107,17 @@ type check_result = {
 [@@deriving sexp]
 (** The outcome of one check. *)
 
-type report = { checks : check_result list } [@@deriving sexp]
-(** The full validation report — one {!check_result} per enabled check. *)
+type audit_join = { matched : int; total : int } [@@deriving sexp]
+(** Audit-join coverage: how many [trades.csv] rows resolved to a
+    [trade_audit.sexp] record ([matched]) out of [total] trades. Surfaced in the
+    report so a dead join ([matched = 0], the signal-vs-fill entry_date skew that
+    silently skipped V1/V2/V7/V8 on the record run) can never again masquerade as
+    "PASS (all skipped)". *)
+
+type report = { checks : check_result list; audit_join : audit_join }
+[@@deriving sexp]
+(** The full validation report — one {!check_result} per enabled check, plus the
+    audit-join coverage over the run's trades. *)
 
 type inputs = {
   trades : trade_row list;

--- a/trading/trading/backtest/validation/lib/validator_types.mli
+++ b/trading/trading/backtest/validation/lib/validator_types.mli
@@ -26,9 +26,9 @@ type trade_row = {
       (** [stop_initial_distance_pct] column; [None] when the cell is empty. *)
   position_id : string option;
       (** [position_id] column (trailing column added by #1942), e.g.
-          ["A-wein-5618"]. [None] for legacy runs whose [trades.csv] predates the
-          column; the audit join falls back to [(symbol, entry_date)] for those.
-      *)
+          ["A-wein-5618"]. [None] for legacy runs whose [trades.csv] predates
+          the column; the audit join falls back to [(symbol, entry_date)] for
+          those. *)
 }
 (** A parsed [trades.csv] round-trip row (only the fields the checks read). *)
 
@@ -110,9 +110,9 @@ type check_result = {
 type audit_join = { matched : int; total : int } [@@deriving sexp]
 (** Audit-join coverage: how many [trades.csv] rows resolved to a
     [trade_audit.sexp] record ([matched]) out of [total] trades. Surfaced in the
-    report so a dead join ([matched = 0], the signal-vs-fill entry_date skew that
-    silently skipped V1/V2/V7/V8 on the record run) can never again masquerade as
-    "PASS (all skipped)". *)
+    report so a dead join ([matched = 0], the signal-vs-fill entry_date skew
+    that silently skipped V1/V2/V7/V8 on the record run) can never again
+    masquerade as "PASS (all skipped)". *)
 
 type report = { checks : check_result list; audit_join : audit_join }
 [@@deriving sexp]

--- a/trading/trading/backtest/validation/test/test_post_run_validator.ml
+++ b/trading/trading/backtest/validation/test/test_post_run_validator.ml
@@ -9,8 +9,8 @@ module Va = Post_run_validator.Validator_artifacts
 
 let trade ?(side = "LONG") ?(exit_trigger = "") ?(stop_trigger_kind = "")
     ?(entry_price = 100.0) ?(exit_price = 100.0) ?(exit_date = "2020-06-01")
-    ?(stop_initial_distance_pct = None) ?(position_id = None) ~symbol ~entry_date
-    () : Vt.trade_row =
+    ?(stop_initial_distance_pct = None) ?(position_id = None) ~symbol
+    ~entry_date () : Vt.trade_row =
   {
     symbol;
     side;
@@ -336,15 +336,14 @@ let test_join_by_position_id_survives_date_skew _ =
   let lookup =
     Va.build_audit_lookup
       [
-        join_row ~position_id:"A-wein-5618" ~symbol:"A"
-          ~entry_date:"2014-11-28"
+        join_row ~position_id:"A-wein-5618" ~symbol:"A" ~entry_date:"2014-11-28"
           ~context:(ctx ~macro_trend:Weinstein_types.Bearish ())
           ();
       ]
   in
   let row =
-    trade ~symbol:"A" ~entry_date:"2014-11-29"
-      ~position_id:(Some "A-wein-5618") ()
+    trade ~symbol:"A" ~entry_date:"2014-11-29" ~position_id:(Some "A-wein-5618")
+      ()
   in
   assert_that (lookup row)
     (is_some_and

--- a/trading/trading/backtest/validation/test/test_post_run_validator.ml
+++ b/trading/trading/backtest/validation/test/test_post_run_validator.ml
@@ -3,12 +3,14 @@ open OUnit2
 open Matchers
 module Vt = Post_run_validator.Validator_types
 module Vc = Post_run_validator.Validator_checks
+module Va = Post_run_validator.Validator_artifacts
 
 (* ---- builders ---------------------------------------------------------- *)
 
 let trade ?(side = "LONG") ?(exit_trigger = "") ?(stop_trigger_kind = "")
     ?(entry_price = 100.0) ?(exit_price = 100.0) ?(exit_date = "2020-06-01")
-    ?(stop_initial_distance_pct = None) ~symbol ~entry_date () : Vt.trade_row =
+    ?(stop_initial_distance_pct = None) ?(position_id = None) ~symbol ~entry_date
+    () : Vt.trade_row =
   {
     symbol;
     side;
@@ -20,6 +22,7 @@ let trade ?(side = "LONG") ?(exit_trigger = "") ?(stop_trigger_kind = "")
     exit_trigger;
     stop_trigger_kind;
     stop_initial_distance_pct;
+    position_id;
   }
 
 let ctx ?(stage = Weinstein_types.Stage2 { weeks_advancing = 3; late = false })
@@ -320,6 +323,75 @@ let test_v11 _ =
   in
   assert_that (result ~id:"V11" inputs) (violations_and_pass 1 false)
 
+(* ---- audit join: position_id vs symbol|date ---------------------------- *)
+
+let join_row ?(context = ctx ()) ~position_id ~symbol ~entry_date () :
+    Va.audit_join_row =
+  { position_id; symbol; entry_date = Date.of_string entry_date; context }
+
+(* The audit entry_date is the SIGNAL Friday (2014-11-28); the trades.csv row
+   carries the FILL date (next trading day, 2014-11-29). The old symbol|date join
+   missed 100% of rows on this skew — position_id joins through it. *)
+let test_join_by_position_id_survives_date_skew _ =
+  let lookup =
+    Va.build_audit_lookup
+      [
+        join_row ~position_id:"A-wein-5618" ~symbol:"A"
+          ~entry_date:"2014-11-28"
+          ~context:(ctx ~macro_trend:Weinstein_types.Bearish ())
+          ();
+      ]
+  in
+  let row =
+    trade ~symbol:"A" ~entry_date:"2014-11-29"
+      ~position_id:(Some "A-wein-5618") ()
+  in
+  assert_that (lookup row)
+    (is_some_and
+       (field
+          (fun (c : Vt.entry_context) -> c.macro_trend)
+          (equal_to Weinstein_types.Bearish)))
+
+(* A legacy 19-column row (no position_id) falls back to the symbol|date key,
+   which for legacy runs is the only key available. *)
+let test_join_legacy_falls_back_to_symbol_date _ =
+  let lookup =
+    Va.build_audit_lookup
+      [
+        join_row ~position_id:"B-wein-1" ~symbol:"B" ~entry_date:"2020-02-07" ();
+      ]
+  in
+  let row = trade ~symbol:"B" ~entry_date:"2020-02-07" ~position_id:None () in
+  assert_that (lookup row)
+    (is_some_and
+       (field
+          (fun (c : Vt.entry_context) -> c.macro_trend)
+          (equal_to Weinstein_types.Bullish)))
+
+(* Coverage counts: 2 of 3 trades resolve to an audit record (P9 has none). *)
+let test_audit_join_coverage_counts _ =
+  let lookup =
+    Va.build_audit_lookup
+      [
+        join_row ~position_id:"P1" ~symbol:"A" ~entry_date:"2020-01-03" ();
+        join_row ~position_id:"P2" ~symbol:"B" ~entry_date:"2020-02-07" ();
+      ]
+  in
+  let inputs =
+    {
+      (Vt.empty_inputs ()) with
+      trades =
+        [
+          trade ~symbol:"A" ~entry_date:"2020-01-06" ~position_id:(Some "P1") ();
+          trade ~symbol:"B" ~entry_date:"2020-02-10" ~position_id:(Some "P2") ();
+          trade ~symbol:"C" ~entry_date:"2020-03-02" ~position_id:(Some "P9") ();
+        ];
+      audit = lookup;
+    }
+  in
+  assert_that (Vc.validate inputs).audit_join
+    (equal_to ({ matched = 2; total = 3 } : Vt.audit_join))
+
 (* ---- severity + validate wiring ---------------------------------------- *)
 
 let test_severity_default _ =
@@ -351,6 +423,11 @@ let suite =
          "v10_spike" >:: test_v10;
          "v10_calm" >:: test_v10_calm;
          "v11_stop_bounds" >:: test_v11;
+         "join_by_position_id_survives_date_skew"
+         >:: test_join_by_position_id_survives_date_skew;
+         "join_legacy_falls_back_to_symbol_date"
+         >:: test_join_legacy_falls_back_to_symbol_date;
+         "audit_join_coverage_counts" >:: test_audit_join_coverage_counts;
          "severity_default" >:: test_severity_default;
          "validate_runs_all" >:: test_validate_runs_all;
        ]


### PR DESCRIPTION
## What

Fixes the post-run validator's audit join, which was **100% dead on real runs**.

The validator joined `trades.csv` rows to `trade_audit.sexp` records by
`(symbol, entry_date)`. But audit records key `entry_date` to the **signal
Friday**, while `trades.csv` rows carry the **fill date** (next trading day).
The lookup therefore missed every row on real runs — V1/V2/V7/V8 reported
`PASS (N skipped)`, a silent coverage hole (measured: all 1140 trades skipped
on the honest-tradeable record run).

## Fix

Rekey the join by `position_id` (the trailing `trades.csv` column added by #1942):

- `trade_row` now parses the `position_id` column (last column; `None` on
  legacy 19-column runs).
- `build_audit_lookup` joins on `position_id` when the row carries one — immune
  to the signal-vs-fill date skew. Legacy rows without a `position_id` fall back
  to the old `symbol|entry_date` key (preserving old behavior, with the known
  skew miss documented).
- The report `.md`/`.sexp` header and the CLI now print
  `audit join: N/M rows matched`, so a dead join can never again masquerade as
  "PASS (all skipped)".

Report-only; **no backtest behavior change**.

## Test plan

`dune runtest trading/backtest/validation/test/` — 22 tests pass (19 + 3 new):

- `join_by_position_id_survives_date_skew` — position_id join succeeds when the
  audit `entry_date` (2014-11-28 signal) differs from the trade's `entry_date`
  (2014-11-29 fill); the exact production shape.
- `join_legacy_falls_back_to_symbol_date` — a row with no `position_id` resolves
  via the `symbol|entry_date` fallback.
- `audit_join_coverage_counts` — coverage stats (2/3 matched) are correct.

Verified in-container: `dune build` (exit 0), `dune build @fmt` (exit 0),
`dune runtest trading/backtest/validation/test/` (exit 0, 22 OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
