### PR TITLE
fix(checks): harden linter find calls against dune sandbox races

### DIFF
--- a/trading/devtools/checks/arch_layer_test.sh
+++ b/trading/devtools/checks/arch_layer_test.sh
@@ -40,7 +40,7 @@ _is_allowed() {
 
 # Find dune files that reference trading.* (trading core libraries)
 VIOLATIONS=$(
-  find "$ANALYSIS_DIR" -name "dune" \
+  find "$ANALYSIS_DIR" -name '_build' -prune -o -name "dune" -print 2>/dev/null \
     | while read -r f; do
         _is_allowed "$f" && continue
         if grep -qE '\btrading\.(portfolio|orders|simulation|engine|strategy|base)\b' "$f"; then

--- a/trading/devtools/checks/fmt_check.sh
+++ b/trading/devtools/checks/fmt_check.sh
@@ -24,12 +24,15 @@ _find_workspace_root() {
 TRADING_DIR="$(_find_workspace_root)"
 VIOLATIONS=""
 
-for f in $(find "$TRADING_DIR" \( -name "*.ml" -o -name "*.mli" \) \
-    -not -path "*/_build/*" \
-    -not -path "*/.formatted/*" \
+# Name-anchored prunes + race guard: -not -path filters still DESCEND into
+# _build, racing dune's concurrent sandbox cleanup (find exits non-zero when a
+# dir vanishes mid-walk). Same pattern as no_python_check.sh.
+for f in $(find "$TRADING_DIR" \
+    \( -name '_build' -o -name '.formatted' -o -name 'ta_ocaml' \) -prune -o \
+    \( -name "*.ml" -o -name "*.mli" \) \
     -not -name "*.pp.ml" \
     -not -name "*.pp.mli" \
-    -not -path "*/ta_ocaml/*"); do
+    -print 2>/dev/null || true); do
   if ! ocamlformat --check "$f" 2>/dev/null; then
     VIOLATIONS="${VIOLATIONS}  ${f}\n"
   fi

--- a/trading/devtools/checks/linter_file_length.sh
+++ b/trading/devtools/checks/linter_file_length.sh
@@ -27,10 +27,12 @@ VIOLATIONS=""
 TOTAL=0
 LARGE_COUNT=0
 
-for ml_file in $(find "$TRADING_DIR" -path "*/lib/*.ml" \
-    -not -path "*/_build/*" \
-    -not -path "*/.formatted/*" \
-    -not -name "*.pp.ml"); do
+# Name-anchored prunes + race guard (see no_python_check.sh).
+for ml_file in $(find "$TRADING_DIR" \
+    \( -name '_build' -o -name '.formatted' \) -prune -o \
+    -path "*/lib/*.ml" \
+    -not -name "*.pp.ml" \
+    -print 2>/dev/null || true); do
   TOTAL=$((TOTAL + 1))
   line_count=$(wc -l < "$ml_file")
 

--- a/trading/devtools/checks/linter_magic_numbers.sh
+++ b/trading/devtools/checks/linter_magic_numbers.sh
@@ -53,10 +53,12 @@ _is_excluded() {
   printf '%s' "$1" | grep -qE "$EXCLUDE_PATTERN"
 }
 
-for f in $(find "$TRADING_DIR" -path "*/lib/*.ml" \
-    -not -path "*/_build/*" \
-    -not -path "*/.formatted/*" \
-    -not -name "*.pp.ml"); do
+# Name-anchored prunes + race guard (see no_python_check.sh).
+for f in $(find "$TRADING_DIR" \
+    \( -name '_build' -o -name '.formatted' \) -prune -o \
+    -path "*/lib/*.ml" \
+    -not -name "*.pp.ml" \
+    -print 2>/dev/null || true); do
   _is_excluded "$f" && continue
 
   # Track multi-line comment depth across lines. Lines inside an open comment

--- a/trading/devtools/checks/linter_mli_coverage.sh
+++ b/trading/devtools/checks/linter_mli_coverage.sh
@@ -39,11 +39,13 @@ _is_excluded() {
   printf '%s' "$1" | grep -qE "$EXCLUDE_PATTERN"
 }
 
-for ml_file in $(find "$TRADING_DIR" -path "*/lib/*.ml" \
+# Name-anchored prunes + race guard (see no_python_check.sh).
+for ml_file in $(find "$TRADING_DIR" \
+    \( -name '_build' -o -name '.formatted' \) -prune -o \
+    -path "*/lib/*.ml" \
     -not -name "*.mli" \
-    -not -path "*/_build/*" \
-    -not -path "*/.formatted/*" \
-    -not -name "*.pp.ml"); do
+    -not -name "*.pp.ml" \
+    -print 2>/dev/null || true); do
   _is_excluded "$ml_file" && continue
   mli_file="${ml_file%.ml}.mli"
   if [ ! -f "$mli_file" ]; then

--- a/trading/devtools/checks/testing_only_check.sh
+++ b/trading/devtools/checks/testing_only_check.sh
@@ -24,7 +24,7 @@ trap 'rm -f "$TMPFILE"' EXIT
 
 # ── Step 1: collect @testing-only library names (internal + public) ───────────
 
-find "$ROOT" -name "dune" | while IFS= read -r dune_file; do
+find "$ROOT" -name '_build' -prune -o -name "dune" -print 2>/dev/null | while IFS= read -r dune_file; do
   awk '
     /; @testing-only/ { annotated = 1; next }
     annotated && /\(library/ { in_lib = 1; next }
@@ -53,7 +53,7 @@ VIOLATIONS=""
 while IFS= read -r lib_name; do
   [ -z "$lib_name" ] && continue
   matches=$(
-    find "$ROOT" -name "dune" | while IFS= read -r f; do
+    find "$ROOT" -name '_build' -prune -o -name "dune" -print 2>/dev/null | while IFS= read -r f; do
       awk -v lib="$lib_name" '
         /^\(library[ \t]/ { in_lib = 1 }
         /^\(tests?[ \t(]/ { in_lib = 0 }


### PR DESCRIPTION
CI `build-and-test` has been failing ~50% of runs today with **zero `FAIL:` lines** and `find: ..._build/.sandbox/...: No such file or directory` on stderr — 4 consecutive occurrences on #1953, 2 on #1952, and one on main (d9072efe6).

Root cause is the race already documented (and fixed) in `no_python_check.sh`: `-not -path "*/_build/*"` **filters** results but still **descends** into `_build`, racing dune's concurrent sandbox cleanup — `find` exits non-zero when a directory vanishes mid-walk, failing the check with no lint violation.

This applies `no_python_check.sh`'s own guard (name-anchored `-prune` + `-print 2>/dev/null || true`) to the remaining unguarded scripts:
- `fmt_check.sh`
- `linter_mli_coverage.sh`
- `linter_file_length.sh`
- `linter_magic_numbers.sh`
- `testing_only_check.sh` (2 sites)
- `arch_layer_test.sh`

## Test plan
- `dune runtest devtools/checks` exit 0 — all 9 checks OK on identical inputs (fn-length, nesting, testing-only, mli-coverage, file-length, fmt, magic-numbers, arch-layer, posix-sh)
- `posix_sh_check` passes on the edited scripts (57 clean)
- Behavior on violations unchanged: prunes only exclude `_build`/`.formatted` (previously filtered), and `|| true` only fires on transient find errors

Unblocks #1952/#1953, which are QC-double-approved and losing the CI coin flip repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)