### PR TITLE
docs: armed-run matrix results + next-session priorities (2026-07-14)

### DIFF
--- a/dev/notes/armed-run-matrix-2026-07-13.md
+++ b/dev/notes/armed-run-matrix-2026-07-13.md
@@ -1,0 +1,95 @@
+# Armed-run matrix on the dedup-v2 basis (2026-07-13/14)
+
+Follow-through on the user directive ("work through all of them; record
+multiple labeled versions"): six 28y record runs on the returns-basis
+deduped warehouse (`/tmp/snap_top3000_1998_2026_dedup_v2`), each with a
+trade-audit report + full-coverage validator run, all artifacts labeled.
+
+## The matrix
+
+| run | config delta vs baseline | MTM | realized | Sharpe | CAGR | MaxDD | trades |
+|---|---|---:|---:|---:|---:|---:|---:|
+| baseline | (all dials off) | +3,407% | $10.4M | 0.68 | 14.4% | 40.9% | 1,171 |
+| A EXTSTOP | extension_stop 2.0×WMA30 / 25% trail | +7,455% | $66.8M | 0.82 | 17.7% | 32.3% | 1,190 |
+| B MAGATE | reject_declining_ma_long_entry | +3,621% | $11.0M | 0.69 | 14.6% | 40.9% | 1,168 |
+| C MINHIST | resistance_min_history_bars 520 | +1,720% | — | — | — | 40.6% | 1,132 |
+| D ALLARMED | A + B | **+7,914%** | **$70.9M** | **0.83** | **18.0%** | **32.3%** | 1,187 |
+| E LONGSHORT | D + enable_short_side | (+22,097%)* | ($183.9M)* | (0.97)* | (22.6%)* | (30.6%)* | 1,285 |
+
+\* PRELIMINARY / NOT COMPARABLE — see §Run E.
+
+Run dirs: `trading/dev/backtest/scenarios-2026-07-13-{052958,170900,182717,205919,194522,221224}/`.
+Reports: session scratchpad `audit_report_*` / `validator_*` (labeled), plus
+interactive artifacts (baseline + Run D).
+
+## A — extension_stop: insurance acceptance PASSES
+
+Fired 8×/26y; **every firing banked a parabolic top** (+89% to +5,196%):
+AXTI 2026-05-30 **$59.0M** (vs riding $140→$70 to a $24M mark in baseline),
+DDD at its Feb-2021 peak, BFX Nov-2020, four dot-com-era names Mar-Apr 2000.
+Zero premature on-ramp kills (2.0× trigger only arms parabolics; the 25%
+trail survived the AXTI April shakeout as the screen pinned). Realized/mark
+composition flips from $10.4M/$24.6M to $66.8M/$9.0M; MaxDD 40.9→32.3;
+Sharpe 0.68→0.82. Utilization trace shows the mechanism's signature: ~94%
+deployed → 18.8% the week after the AXTI exit → redeploying 38-58% into
+period end. Caveats stated: single path, AXTI ≈88% of the realized delta —
+but the sanctioned insurance basis (left-tail/event-level, never fold Sharpe
+at a ~1% event rate) is met in every cell. **Recommend ARM for record
+convention + live**; promotion PR should cite this note (flag-discipline R3,
+insurance precedent #1695).
+
+## B — declining-MA gate: surgical, small positive
+
+Trade-set diff vs baseline (and D vs A — identical result on both bases):
+removes exactly 4 entries — AIR 2020-03-14 (−$0.38/−$0.49M COVID-waterfall
+buy), DO_old 2018, AKS 2018, MOD 2019 — direct ≈ +$0.4M, path effects small.
+Validator V8 goes 4→PASS when armed (mechanism/validator cross-confirm).
+Consistent with #1775's ARM-FOR-BROAD. **Recommend ARM together with A.**
+
+## C — min_history_bars 520: NOT armable (important negative)
+
+Return HALVES (+3,407→+1,720%). Why: backtest panels carry only ~52-110
+weekly bars, so a 520-bar floor marks EVERY name Insufficient_history —
+it deletes the virgin/clean resistance signal wholesale instead of fixing
+false virgins (V7 goes 102→PASS trivially: nothing can claim virgin).
+Removing the signal costs far more than the false-virgin subset it targets.
+**The real fix is feeding history, not the label floor**: (a) live
+weekly-review warehouse → ~520 weekly bars (cheap, fixes CWST-class live
+text with real data); (b) backtest panels → a resistance-specific deeper
+window (NOT global lookback_bars ×10), perf-spiked first. Tracked as the
+resistance-history follow-up. The label floor stays default-off everywhere.
+
+## D — A+B combined: the record-convention candidate
+
+Effects additive (D ≈ A + B deltas; 1,061 of 1,085 shared trades vs B
+changed PnL purely from post-AXTI-banking position sizing). V5/V8 PASS,
+V6 = its 2 known false positives, audit join 1,187/1,187. **This config —
+extension_stop(2.0, 0.25) + reject_declining_ma — is the proposed new
+record convention pending user sign-off.**
+
+## E — long-short: PRELIMINARY, leverage artifact dominates
+
+Headline +22,097% is NOT short alpha: the 43 short round-trips netted
+**$0.0M**. The delta vs D comes from the long book LEVERING on short
+proceeds/margin: marked LONG exposure exceeds NAV in 269 sampled weeks
+(median 92%, peak 158%). The `max_long_exposure_pct 0.70` override in the
+scenario does nothing (known dead envelope knob,
+`project_envelope_knobs_dead`). A fair long-short comparison needs a real
+long-exposure cap or margin convention pinned first — follow-up before any
+conclusion is drawn from this run. Validator: V5/V8 PASS, join 1285/1285.
+
+## Validator cross-checks (every run)
+
+Audit join 100% on all six runs (C6b fix), V5 PASS everywhere (#1942 fix),
+V6 stable at its 2 known trade-level false positives, V7/V8 respond exactly
+to their corresponding dials — the validator now discriminates configs, not
+just runs.
+
+## CI note
+
+The day's ~50-90% build-and-test failure rate was diagnosed: owl-linked
+tuner tests die on part of GitHub's heterogeneous runner fleet (SIGILL, plus
+one `Owl_lapacke.potrf` variant). Tracked in #1955 (needs human PAT for the
+workflow/cache fix — portable owl build flags or pinned runners); repo-side
+find-race noise hardened in #1954. Interim: rerun on the documented
+signature.

--- a/dev/notes/next-session-priorities-2026-07-14.md
+++ b/dev/notes/next-session-priorities-2026-07-14.md
@@ -1,0 +1,106 @@
+# Next-session priorities — 2026-07-14
+
+**Supersedes** `next-session-priorities-2026-07-12.md` (its C1-C6 queue is DONE;
+P1-P4 research items carried below). Main green.
+
+## What the 07-13/14 marathon shipped (context)
+
+Ten merged PRs + six labeled 28y record runs. Full writeups:
+`dev/notes/dedup-record-rerun-2026-07-13.md` (new record basis) +
+`dev/notes/armed-run-matrix-2026-07-13.md` (the matrix). Compressed:
+
+1. **C1-C4 correctness sweep merged** (#1939 asset-type blocklist, #1940+#1946
+   twin dedup v1+v2 returns-basis, #1941 Insufficient_history label, #1942
+   export-join + position_id). **Dedup re-based the record**: 83 duplicate-feed
+   groups removed; honest baseline now realized +1,037%/14.4% CAGR vs SPY TR
+   +706% (pre-dedup +1670%/+6885% superseded).
+2. **Validator at full coverage** (#1947 audit join by position_id; joins
+   1171/1171 vs 0/1140 before). V-checks now discriminate configs: V5↔#1942,
+   V6↔dedup, V7↔min-hist, V8↔MA-gate all verified both directions.
+3. **Armed-run matrix**: ext-stop insurance acceptance PASS (8/8 parabolic tops
+   banked, AXTI $59M, Sharpe .68→.82, MaxDD 40.9→32.3); MA-gate surgical +
+   (removes AIR-2020 class, V8→PASS); min-hist-520 NOT armable (halves return —
+   deletes the resistance signal wholesale on 52-110-bar panels); D = A+B
+   additive = **proposed convention**; E long-short = leverage artifact
+   (shorts $0.0M / 43 trades; long exposure >NAV 269 wks, peak 158% — dead
+   `max_long_exposure_pct` knob).
+4. **Audit tooling**: R6 plunge-buy fixed (was a stub; AIR-2020 pinned),
+   decision-quality quartiles fixed, `--html` interactive report (#1956 —
+   check merged; was QC-double-approved in the CI rerun lottery at session end).
+5. **CI diagnosis**: the day's 50-90% build-and-test failures = owl tuner tests
+   SIGILL / `Owl_lapacke.potrf` on part of GitHub's runner fleet — **#1955,
+   needs human PAT** (portable owl build flags or pinned runners). #1954 merged
+   (find-race noise). Interim: rerun on the documented signature.
+
+## P0 — arming package (user-aligned, execute on sign-off)
+
+Per the 07-14 discussion: NO code-default flips; arm via explicit config.
+1. Ledger entry: insurance-ACCEPT for `extension_stop(2.0, 0.25)` (basis =
+   armed-vs-off event-level record pair, #1695 precedent, WF-CV powerless at
+   ~1% event rate) + confirming-evidence note for `reject_declining_ma`
+   (WF-CV already in #1775 ARM-FOR-BROAD).
+2. Add both overrides to the record-convention staged scenario + the live
+   weekly-review config.
+3. Cheap robustness backfill: one **sp500-basis armed-vs-off cell** for
+   ext-stop (rules out top-3000-specific artifact; ~2 short runs).
+
+## P0b — long-short realism precondition (gates any Run-E conclusion)
+
+1. Wire `max_long_exposure_pct` enforcement into the entry walk (envelope
+   knobs are DEAD — `check_limits` zero callers, memory
+   `project_envelope_knobs_dead`). Default = no-op/uncapped (R1; long-only
+   goldens bit-identical). 2. Pin the margin convention (short proceeds → cash
+   vs long buying power up to cap). 3. Re-run E with long ≤100% NAV pinned.
+   Expectation: lands near D + small hedge term (shorts made $0).
+
+## P1
+
+- **Resistance history feed** (the real false-virgin fix; min-hist label stays
+  default-off): (a) live weekly-review warehouse → ~520 weekly bars (cheap,
+  fixes CWST-class live text); (b) backtest = resistance-specific deeper
+  window, perf-spike FIRST (NOT global lookback_bars ×10). Then one armed run
+  quantifies honest-virgin vs no-signal (Run C says signal removal costs
+  ~half the return; this isolates the false-virgin share).
+- **#1956 merge completion** if the CI lottery outlasted the session
+  (auto-merge armed; QC double-approved at tip 6aaf9453f).
+- **#1955 CI fix** — human-gated (user PAT): portable owl build in the GHA
+  opam cache or pinned runner generation. Until then rerun-on-signature.
+
+## P2 — research queue (carried from 07-12, unchanged priorities)
+
+- **Trader-preset bundle audit + WF-CV** (presets as wholes per
+  weinstein-faithful-core W3; plan `weinstein-trader-investor-presets-2026-05-31.md`).
+- **Floor-quality P1b step 3**: SPY-sleeve lens screen vs TR-SPY
+  (`Breaker_spy_sleeve` #1913; melt-up-lag anatomy made this the structural
+  bull-year answer).
+- **decision_audit Phase-2**: forward-return counterfactual of cash-REJECTED
+  vs funded (NVDA skipped 6×; new evidence: AIR's three entries were all in
+  bad windows, never late-2016/late-2022 — capacity-at-signal keeps surfacing).
+- **P3 grind-weeks exposure** (carried).
+- **P4 faithful per-week universes** (M6.6 design + cost doc; GME-class
+  capture loss).
+
+## Lower-priority follow-ups (accumulated, `[non-blocking]`)
+
+- V6 known-false-positive allowlist in validator config (deferred from #1953;
+  ASB/CDX_old + BALL/TAP).
+- Stale re-entry gap: CY re-bought 2020-04-25 on 10-day-stale bars then
+  stale-exited again — entry-side staleness check (tiny PnL impact).
+- Arm `ATB.curated` for the LIVE universe build (+ General::Type enrichment
+  feed later); wire `fetch_finviz_sectors` so live picks regain sector spread.
+- C6 leftovers: `scenario_runner --validate` post-step; weekly-picks
+  validation reuse.
+- QC advisory carries: render-substring test for the validator coverage line;
+  R6 threshold config-flip test.
+- goldens-small still at concentration 0.14 (old carry).
+- Memory export refresh (`sh dev/scripts/export-memory.sh`) — new memories:
+  `project_rename_twin_dedup_returns_basis`, `project_extension_stop_acceptance`.
+
+## Standing constraints (unchanged)
+
+NO reversal timing; entry-selection/scale-in/reallocation/stop-tuning closed;
+Weinstein spine fixed; comparators TOTAL-RETURN; horizon-sweep/rolling-start
+before tail-dependent verdicts; container long runs solo; WIP-push ≤30 min.
+New: CI failures matching (0 `FAIL:` + SIGILL/potrf in tuner tests) = #1955
+runner lottery, rerun; min-hist label floor stays OFF everywhere; Run-E-class
+long-short numbers are NOT quotable until P0b lands.


### PR DESCRIPTION
Session-closing docs for the 07-13/14 marathon:

- `dev/notes/armed-run-matrix-2026-07-13.md` — six labeled 28y runs on the dedup-v2 basis: ext-stop insurance acceptance PASS (8/8 tops banked, Sharpe .68→.82, MaxDD 40.9→32.3), MA-gate surgical +, min-hist-520 NOT armable (halves return), D=A+B additive proposed convention, E long-short = leverage artifact (shorts $0; dead exposure knob).
- `dev/notes/next-session-priorities-2026-07-14.md` — P0 arming package (config-arming, no default flips), P0b long-short realism precondition (wire max_long_exposure_pct), P1/P2 queue + accumulated follow-ups.

Docs-only → two-gate (CI + skip QC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)