### PR TITLE
fix(ci): pin owl to portable SIMD flags — kills the #1955 runner lottery

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -109,6 +109,22 @@ COPY --chown=opam:opam trading/ /workspaces/trading-1/trading/
 RUN opam repository set-url default https://opam.ocaml.org && opam update
 
 # -----------------------------------------------------------------------------
+# owl portable SIMD flags (issue #1955)
+# -----------------------------------------------------------------------------
+# owl's configure defaults to -march=native on x86_64 (owl.1.2
+# src/owl/config/configure.ml), so its C stubs inherit the IMAGE-BUILD host's
+# ISA. When the weekly image rebuild lands on an AVX-512 runner, dllowl_stubs.so
+# embeds AVX-512 instructions and every owl-linked test binary SIGILLs on the
+# (majority) non-AVX512 CI runners — the ~50-90% build-and-test "rerun lottery"
+# of 2026-07-13. Same failure class and same fix as ta-lib above (#1129):
+# pin -march=x86-64-v2 -mtune=generic. OWL_CFLAGS fully REPLACES owl's default
+# flag list, so this mirrors the default set with only the arch pinned.
+# Must be set before ANY opam layer that may build owl (the deps-only loop
+# below can pull it in, not just the pinned install).
+# -----------------------------------------------------------------------------
+ENV OWL_CFLAGS="-g -O3 -march=x86-64-v2 -mtune=generic -mfpmath=sse -msse2 -funroll-loops -fno-math-errno -fno-rounding-math -fno-signaling-nans -fexcess-precision=fast -DSFMT_MEXP=19937 -fno-strict-aliasing"
+
+# -----------------------------------------------------------------------------
 # OCaml Dependencies
 # -----------------------------------------------------------------------------
 # Iterate every *.opam file in the source and install its --deps-only.
@@ -135,6 +151,21 @@ RUN opam install --yes \
     ppx_deriving ppx_jane ppx_let \
     sexplib sexp_pretty \
     uri yojson
+
+# -----------------------------------------------------------------------------
+# Verify owl stubs are AVX-512-free (issue #1955) — fail the IMAGE build (the
+# only place the bad binary can be produced) rather than lottery-failing CI.
+# Mirrors the ci.yml ta-lib objdump check (#1129).
+# -----------------------------------------------------------------------------
+RUN OWL_SO=$(find /home/opam/.opam -name 'dllowl_stubs.so' -type f | head -1) && \
+    test -n "$OWL_SO" && \
+    echo "owl stubs found at: $OWL_SO" && \
+    if objdump -d "$OWL_SO" 2>/dev/null | grep -q 'zmm\|evex\|knc'; then \
+        echo "FAIL: dllowl_stubs.so contains AVX-512 instructions — will SIGILL on non-AVX512 runners"; \
+        exit 1; \
+    else \
+        echo "OK: dllowl_stubs.so contains no AVX-512 instructions"; \
+    fi
 
 # -----------------------------------------------------------------------------
 # memtrace — Jane Street's Gc.Memprof-based statistical OCaml allocation


### PR DESCRIPTION
## Root cause (answers "is it new owl calls?": no)

owl.1.2's configure defaults to `-march=native` on x86_64 (`src/owl/config/configure.ml` — overridable via `OWL_CFLAGS`). The CI image bakes owl at image-build time, and **image.yml rebuilds weekly (Mondays 06:00 UTC)**. The 2026-07-13T07:19Z rebuild landed on an **AVX-512 build runner**, so `dllowl_stubs.so` now contains AVX-512 instructions; GitHub's runner fleet is heterogeneous and the majority of `ubuntu-latest` hosts lack AVX-512 → every owl-linked tuner test binary dies with `Command got signal ILL` on those hosts. That's the ~50-90% build-and-test rerun lottery (#1955, watchdog #1958).

The owl calls themselves (`test_bayesian_opt`, `Owl_lapacke.potrf`, etc.) are months old and were green for weeks — prior weekly rebuilds just happened to land on non-AVX512 hosts. The trigger was the image-rebuild host, not new code.

This is the **same failure class as the ta-lib SIGILL (#1129)**, fixed in this same Dockerfile with `-march=x86-64-v2 -mtune=generic`.

## Fix (no workflow file / PAT needed)

1. `ENV OWL_CFLAGS` pinning `-march=x86-64-v2 -mtune=generic` — mirrors owl's default flag list exactly, with only the arch pinned (OWL_CFLAGS fully replaces the defaults, so the rest of the set — `-O3`, fast-math switches, `-DSFMT_MEXP=19937`, … — is reproduced verbatim). Set before **any** opam layer that can build owl (the deps-only loop can pull it in, not just the pinned install).
2. Image-build-time objdump gate: the image build itself fails if `dllowl_stubs.so` contains zmm/evex/knc instructions — the bad binary can only be produced there, so that's where it should die (instead of a week of CI lottery).

Merging this auto-triggers the image rebuild: `image.yml` already fires on any `.devcontainer/Dockerfile` push to main. No `.github/workflows` change, so no workflow-scope PAT required.

## Caveat

This PR's own CI still runs on the **current broken image**, so it can itself lose the lottery — the session's auto-reroll bot covers it. After merge + image rebuild (~20 min), the lottery is gone for all subsequent runs; #1955 and watchdog #1958 can then be closed.

## Follow-up (optional, needs workflow scope)

Extend the ci.yml smoke-test step to objdump-check `dllowl_stubs.so` alongside `libta-lib.so` — belt-and-braces against a future owl/opam layout change. Left out of this PR to keep it PAT-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)