### PR TITLE
ops(budget): consolidate 7 orphaned budget-fallback records

### DIFF
--- a/dev/budget/2026-07-12-29176040768.json
+++ b/dev/budget/2026-07-12-29176040768.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-12-29176040768",
+  "timestamp": "2026-07-12T02:51:43Z",
+  "commit_sha": "9aa0f98a3a16356d6ff40c745d4c40987a95b241",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 26.438699500000013,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-12-29185112464.json
+++ b/dev/budget/2026-07-12-29185112464.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-12-29185112464",
+  "timestamp": "2026-07-12T08:10:30Z",
+  "commit_sha": "bbcbe6eb0758131f3f0e34aab6343114966603bb",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 5.1153275,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-12-29206263598.json
+++ b/dev/budget/2026-07-12-29206263598.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-12-29206263598",
+  "timestamp": "2026-07-12T19:52:53Z",
+  "commit_sha": "7f24f2c8db61defe9d7bb4a2792018da45378a66",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 4.4710909,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-13-29235363744.json
+++ b/dev/budget/2026-07-13-29235363744.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-13-29235363744",
+  "timestamp": "2026-07-13T08:39:36Z",
+  "commit_sha": "70580239d4e336fbb610f277783829d6b4522b02",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 4.125943,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-13-29246228889.json
+++ b/dev/budget/2026-07-13-29246228889.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-13-29246228889",
+  "timestamp": "2026-07-13T11:46:54Z",
+  "commit_sha": "d9072efe6966f8512b8b576d1c7dadba05c04681",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 7.546465999999999,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-13-29268822118.json
+++ b/dev/budget/2026-07-13-29268822118.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-13-29268822118",
+  "timestamp": "2026-07-13T17:16:45Z",
+  "commit_sha": "5ee25c7e3035233863296fc03acc5de7b607c28c",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 4.8297349999999994,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}

--- a/dev/budget/2026-07-13-29279918428.json
+++ b/dev/budget/2026-07-13-29279918428.json
@@ -1,0 +1,28 @@
+{
+  "run_id": "2026-07-13-29279918428",
+  "timestamp": "2026-07-13T20:10:37Z",
+  "commit_sha": "e580979b6129b74c33342d1ede2a7911305f4346",
+  "measurement_source": "claude-code-action execution_file (total_cost_usd from SDKResultMessage)",
+  "fallback_branch": "1b",
+  "notes": "total_cost_usd covers entire orchestrator run including all internally-spawned subagents (Agent tool calls). Per-subagent breakdown not available from action output — see dev/status/cost-tracking.md for limitation details.",
+  "subagents": [
+    {
+      "name": "orchestrator-total",
+      "model": "sonnet",
+      "input_tokens": null,
+      "output_tokens": null,
+      "cache_read_input_tokens": null,
+      "cache_creation_input_tokens": null,
+      "estimated_cost_usd": null,
+      "note": "Per-subagent breakdown not available from claude-code-action. total_cost_usd in totals covers all spawned subagents."
+    }
+  ],
+  "totals": {
+    "input_tokens": null,
+    "output_tokens": null,
+    "cache_read_input_tokens": null,
+    "cache_creation_input_tokens": null,
+    "total_cost_usd": 8.7708653,
+    "measurement": "measured from claude-code-action execution_file total_cost_usd"
+  }
+}


### PR DESCRIPTION
Sweeps the 7 standalone `ops/budget-*` fallback branches (orchestrator fail-mode path — budget JSON committed to an orphan branch with no PR, "human merges directly") into one PR: 3× 2026-07-12 + 4× 2026-07-13 records under `dev/budget/`. Verified each file is absent on main. After merge, the 7 source branches get deleted along with the merged-PR branch cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)